### PR TITLE
Changed TNS styling for Card component

### DIFF
--- a/src/kirby/components/card/card.component.tns.scss
+++ b/src/kirby/components/card/card.component.tns.scss
@@ -5,7 +5,6 @@ $color-card-border: rgb(133, 133, 133);
 .background, .container {
     flex-direction: column;
     width: 100%;
-    height: 100%;
 }
 
 .container {
@@ -14,4 +13,5 @@ $color-card-border: rgb(133, 133, 133);
     border: 1;
     border-color: $color-card-border;
     margin: 8;
+    padding-bottom: 16;
 }


### PR DESCRIPTION
## Why

It should not display as "height 100%".

## Screenshot of new style

![screenshot 2019-01-23 at 14 07 22](https://user-images.githubusercontent.com/46480050/51608681-77237780-1f18-11e9-8ba1-b26b790f7cd8.png)
