### PR TITLE
Reverting change from 25a94bdda235a40f76590dc200740401edee6c45

### DIFF
--- a/src/kirby/package.json
+++ b/src/kirby/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/kirbydesign/designsystem#readme",
   "types": "index.d.ts",
-  "peerDependencies": {
+  "dependencies": {
     "highcharts": "^6.2.0",
     "nativescript-webview-interface": "^1.4.2"
   }


### PR DESCRIPTION
When dependencies are defined as "peerDependencies" they won't get downloaded in the project you are using kirby. Then it fails with this error:

<img width="1083" alt="screenshot 2019-01-23 at 15 12 58" src="https://user-images.githubusercontent.com/46480050/51612345-8bb83d80-1f21-11e9-883a-94a2bf89453f.png">
