### PR TITLE
Bugfix: App crashes when navigating away from kirby list without section headers.

### DIFF
--- a/src/kirby/components/list/list.component.tns.html
+++ b/src/kirby/components/list/list.component.tns.html
@@ -11,7 +11,7 @@
         </ng-container>
       </FlexboxLayout>
     </ng-template>
-    <ng-template let-section="category" tkGroupTemplate>
+    <ng-template let-section="category" tkGroupTemplate *ngIf="getSectionName">
       <FlexboxLayout alignItems="center" class="list-section-header-container" ios:height="50">
         <ng-container *ngTemplateOutlet="sectionHeaderTemplate; context: {$implicit: section}"></ng-container>
       </FlexboxLayout>

--- a/src/kirby/components/list/list.component.tns.html
+++ b/src/kirby/components/list/list.component.tns.html
@@ -11,7 +11,7 @@
         </ng-container>
       </FlexboxLayout>
     </ng-template>
-    <ng-template let-section="category" tkGroupTemplate *ngIf="getSectionName">
+    <ng-template let-section="category" tkGroupTemplate *ngIf="isSectionsEnabled">
       <FlexboxLayout alignItems="center" class="list-section-header-container" ios:height="50">
         <ng-container *ngTemplateOutlet="sectionHeaderTemplate; context: {$implicit: section}"></ng-container>
       </FlexboxLayout>


### PR DESCRIPTION
If there is a kirby list without sections headers the app would crash on iOS. This was do to, that the section header template was still rendered but just empty. This would lead to an error, in the radlistview code on the OnDestroy lifecycle hook.

I fix this with a simple ngIf.

Fixes #90 