### PR TITLE
Fix/list warnings

### DIFF
--- a/src/app/examples/list-example/base-list.component.ts
+++ b/src/app/examples/list-example/base-list.component.ts
@@ -2,13 +2,13 @@ export class BaseListComponent {
   myItems = [
     {
       title: 'Vestas Wind Systems has a very long name',
-      subTitle: '2000 stk',
+      subTitle: '2000 pcs',
       amount: '5.587.218.309 DKK',
       detail: 225,
     },
-    { title: 'A.P. Møller-Mærsk', subTitle: '2 stk', amount: '14.019 DKK', detail: 0 },
-    { title: 'Novo Nordisk A/S B', subTitle: '18 stk', amount: '7560 DKK', detail: 171 },
-    { title: 'Danske Bank A/S', subTitle: '10 stk', amount: '1560 DKK', detail: -171 },
+    { title: 'A.P. Møller-Mærsk', subTitle: '2 pcs', amount: '14.019 DKK', detail: 0 },
+    { title: 'Novo Nordisk A/S B', subTitle: '18 pcs', amount: '7560 DKK', detail: 171 },
+    { title: 'Danske Bank A/S', subTitle: '10 pcs', amount: '1560 DKK', detail: -171 },
   ];
 
   onItemSelect(item: any) {

--- a/src/app/examples/progress-bar-example/progress-bar-example.component.tns.html
+++ b/src/app/examples/progress-bar-example/progress-bar-example.component.tns.html
@@ -1,12 +1,12 @@
 <ScrollView>
   <StackLayout>
     <kirby-card>
-      <kirby-card-header title="Progress bar" subtitle="Default Example" />
-      <kirby-progress-bar progress="33" />
+      <kirby-card-header title="Progress bar" subtitle="Default Example"></kirby-card-header>
+      <kirby-progress-bar progress="33"></kirby-progress-bar>
     </kirby-card>
     <kirby-card>
-      <kirby-card-header title="Progress bar" subtitle="Custom color example" />
-      <kirby-progress-bar progress="54" progressColor="#FFC163" backgroundColor="#00A775" />
+      <kirby-card-header title="Progress bar" subtitle="Custom color example"></kirby-card-header>
+      <kirby-progress-bar progress="54" progressColor="#FFC163" backgroundColor="#00A775"></kirby-progress-bar>
     </kirby-card>
   </StackLayout>
 </ScrollView>;

--- a/src/kirby/components/list/list-cell/list-cell.component.spec.ts
+++ b/src/kirby/components/list/list-cell/list-cell.component.spec.ts
@@ -85,7 +85,7 @@ describe('ListCellComponent', () => {
       expect(component.getHorisontalAlignment()).toBe(expected);
     });
 
-    it('right should be transformed flex-end', () => {
+    it('right should be transformed to flex-end', () => {
       component.horisontalAlignment = 'right';
       const expected = 'flex-end';
 

--- a/src/kirby/components/list/list-cell/list-cell.component.tns.html
+++ b/src/kirby/components/list/list-cell/list-cell.component.tns.html
@@ -1,7 +1,7 @@
 <FlexboxLayout
   class="cell"
-  [justifyContent]="getJustifyContent()"
-  [alignItems]="getAlignItems()"
+  [justifyContent]="getVerticalAlignment()"
+  [alignItems]="getHorisontalAlignment()"
   [width]="getWidth()"
 >
   <ng-content></ng-content>

--- a/src/kirby/components/list/list-cell/list-cell.component.ts
+++ b/src/kirby/components/list/list-cell/list-cell.component.ts
@@ -15,19 +15,19 @@ enum horisontalAlignmentEnum {
 type horisontalAlignment = 'left' | 'center' | 'right' | 'space-between' | 'space-around';
 type verticalAlignment = 'top' | 'center' | 'bottom' | 'stretch' | 'baseline';
 
+const defaultHorisontalAlignment: horisontalAlignment = 'left';
+const defaultVerticalAlignment: verticalAlignment = 'center';
+const defaultWidth = 1;
+
 @Component({
   selector: 'kirby-list-cell',
   templateUrl: './list-cell.component.html',
   styleUrls: ['./list-cell.component.scss'],
 })
 export class ListCellComponent implements OnInit {
-  @Input() horisontalAlignment: horisontalAlignment;
-  @Input() verticalAlignment: verticalAlignment;
-  @Input() width: number;
-
-  private readonly defaultHorisontalAlignment: horisontalAlignment = 'left';
-  private readonly defaultVerticalAlignment: verticalAlignment = 'center';
-  private readonly defaultWidth = 1;
+  @Input() horisontalAlignment: horisontalAlignment = defaultHorisontalAlignment;
+  @Input() verticalAlignment: verticalAlignment = defaultVerticalAlignment;
+  @Input() width: number = defaultWidth;
 
   @HostBinding('style.flex-basis')
   private _flexBasisHost: string;
@@ -47,11 +47,11 @@ export class ListCellComponent implements OnInit {
       return `${this.width * 100}%`;
     }
     console.warn(
-      `Invalid value ${this.width} for width. Valid values numbers > 0. Defaulting to '${
-        this.defaultWidth
-      }'`
+      `Invalid value ${
+        this.width
+      } for width. Valid values numbers > 0. Defaulting to '${defaultWidth}'`
     );
-    return `${this.defaultWidth * 100}%`;
+    return `${defaultWidth * 100}%`;
   }
 
   getHorisontalAlignment(): string {
@@ -69,11 +69,9 @@ export class ListCellComponent implements OnInit {
     console.warn(
       `Invalid value ${
         this.horisontalAlignment
-      } for horisontalAlignment. Valid values are 'left', 'center', 'right', 'space-between', 'space-around'. Defaulting to '${
-        this.defaultHorisontalAlignment
-      }'`
+      } for horisontalAlignment. Valid values are 'left', 'center', 'right', 'space-between', 'space-around'. Defaulting to '${defaultHorisontalAlignment}'`
     );
-    return horisontalAlignmentEnum[this.defaultHorisontalAlignment];
+    return horisontalAlignmentEnum[defaultHorisontalAlignment];
   }
 
   getVerticalAlignment(): string {
@@ -83,11 +81,9 @@ export class ListCellComponent implements OnInit {
     console.warn(
       `Invalid value ${
         this.verticalAlignment
-      } for verticalAlignment. Valid values are 'top', 'center', 'bottom', 'stretch', 'baseline'. Defaulting to '${
-        this.defaultVerticalAlignment
-      }'`
+      } for verticalAlignment. Valid values are 'top', 'center', 'bottom', 'stretch', 'baseline'. Defaulting to '${defaultVerticalAlignment}'`
     );
-    return verticalAlignmentEnum[this.defaultVerticalAlignment];
+    return verticalAlignmentEnum[defaultVerticalAlignment];
   }
 
   private setStyle() {


### PR DESCRIPTION
- Fixed warnings in list when no input has been set, by adding default value
- stk => pcs in example data
- A couple of elements in progress-bar-example.tns.html was "self closed". That is not supported.
- Wrong methods calls in list-cell.component.tns.html fixed