### PR TITLE
Enhancement/fix for 239

### DIFF
--- a/src/app/showcase/list-showcase/list-showcase.component.html
+++ b/src/app/showcase/list-showcase/list-showcase.component.html
@@ -1,4 +1,10 @@
 <div class="example">
   <kirby-list-example></kirby-list-example>
   <kirby-html-viewer [html]="exampleHtml"></kirby-html-viewer>
+  <br />
+  <br />
+  <span>When <b><em>not</em></b> using the built-in <code>kirby-list-section-header</code> component you will need to natively to define a height for iOS</span>
+  <kirby-html-viewer [html]="sectionHeaderExampleHtml"></kirby-html-viewer>
+    
+
 </div>

--- a/src/app/showcase/list-showcase/list-showcase.component.html
+++ b/src/app/showcase/list-showcase/list-showcase.component.html
@@ -3,7 +3,7 @@
   <kirby-html-viewer [html]="exampleHtml"></kirby-html-viewer>
   <br />
   <br />
-  <span>When <b><em>not</em></b> using the built-in <code>kirby-list-section-header</code> component you will need to natively to define a height for iOS</span>
+  <span>When <b><em>not</em></b> using the built-in <code>kirby-list-section-header</code> component you will need to natively define a height for iOS</span>
   <kirby-html-viewer [html]="sectionHeaderExampleHtml"></kirby-html-viewer>
     
 

--- a/src/app/showcase/list-showcase/list-showcase.component.ts
+++ b/src/app/showcase/list-showcase/list-showcase.component.ts
@@ -9,6 +9,8 @@ declare var require: any;
 export class ListShowcaseComponent implements OnInit {
   exampleHtml: string = require('../../examples/list/list-example.component.html');
 
+  sectionHeaderExampleHtml: string =
+    '<GridLayout *kirbyListSectionHeader="let section" ios:height="50">...</GridLayout>';
   constructor() {}
 
   ngOnInit() {}

--- a/src/kirby/components/list/list-section-header/list-section-header.component.tns.html
+++ b/src/kirby/components/list/list-section-header/list-section-header.component.tns.html
@@ -1,3 +1,3 @@
-<FlexboxLayout class="header">
+<GridLayout class="header" ios:height="50">
   <Label text="{{ title }}" class="section-header kirby-text-medium"></Label>
-</FlexboxLayout>
+</GridLayout>

--- a/src/kirby/components/list/list.component.tns.html
+++ b/src/kirby/components/list/list.component.tns.html
@@ -23,14 +23,14 @@
 
     <!-- SECTION HEADER-->
     <ng-template let-section="category" tkGroupTemplate *ngIf="isSectionsEnabled">
-      <FlexboxLayout alignItems="center" ios:height="50">
+      <GridLayout rows="*" columns="*">
         <ng-container
           *ngTemplateOutlet="
             sectionHeaderTemplate;
             context: { $implicit: section }
           ">
         </ng-container>
-      </FlexboxLayout>
+      </GridLayout>
     </ng-template> 
 
     <!-- HEADER -->


### PR DESCRIPTION
Fixes #239 

I have removed the hardcode height on the wrapper for the section header in a list. I moved this height to the built-in `kirby-list-section-header` component.

I also updated the documentation for the kirby list to explain the user of kirby, that if they don't use the built-in component for sections they will have to set the height for iOS explicit.