### PR TITLE
Added ng-content to nativescript button view.

### DIFF
--- a/src/kirby/components/button/button.component.tns.html
+++ b/src/kirby/components/button/button.component.tns.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>


### PR DESCRIPTION
in {N} it is possible to have a `FormattedString` inside a `Button` tag like:

```html
<Button>
   <FormattedString>
      <Span text="foo" fontSize="60"></Span>
      <Span text="bar" fontSize="10"></Span>
   </FormattedString>
</Button>
```

But right now the tns view for `kirby-button` is not rendering any containing elements for a `Button`.
I have fixed this by adding a `ng-content` tag.