### PR TITLE
Fix/absolute imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "designsystem",
-  "version": "0.0.151",
+  "version": "0.0.152",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "version": "5.2.0"
     }
   },
-  "version": "0.0.151",
+  "version": "0.0.152",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
 import { BrowserModule } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
-import { IonicModule } from '@ionic/angular';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -10,7 +9,7 @@ import { HomeComponent } from './home/home.component';
 import { SideNavComponent } from './page/side-nav/side-nav.component';
 import { HeaderComponent } from './page/header/header.component';
 import { IntroComponent } from './intro/intro.component';
-import { KirbyModule } from '../kirby/kirby.module';
+import { KirbyModule } from '@kirbydesign/designsystem';
 
 @NgModule({
   declarations: [AppComponent, HomeComponent, SideNavComponent, HeaderComponent, IntroComponent],

--- a/src/app/component-status/component-status.module.ts
+++ b/src/app/component-status/component-status.module.ts
@@ -3,7 +3,7 @@ import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { IonicModule } from '@ionic/angular';
 
-import { KirbyModule } from '~/kirby/kirby.module';
+import { KirbyModule } from '@kirbydesign/designsystem';
 import { ComponentStatusComponent } from './component-status.component';
 
 @NgModule({

--- a/src/app/examples/action-sheet-example/action-sheet-example.component.ts
+++ b/src/app/examples/action-sheet-example/action-sheet-example.component.ts
@@ -1,8 +1,8 @@
 import { Component, ViewContainerRef } from '@angular/core';
 
-import { ModalController } from '~/kirby/components/modal/services/modal.controller';
-import { ActionSheetConfig } from '~/kirby/components/modal/action-sheet/config/action-sheet-config';
-import { ActionSheetItem } from '~/kirby/components/modal/action-sheet/config/action-sheet-item';
+import { ModalController } from '@kirbydesign/designsystem/modal';
+import { ActionSheetConfig } from '@kirbydesign/designsystem/modal';
+import { ActionSheetItem } from '@kirbydesign/designsystem/modal';
 
 @Component({
   selector: 'kirby-action-sheet-example',

--- a/src/app/examples/alert-example/alert-example.component.ts
+++ b/src/app/examples/alert-example/alert-example.component.ts
@@ -1,7 +1,7 @@
 import { Component, ViewContainerRef } from '@angular/core';
 
-import { ModalController } from '~/kirby/components/modal/services/modal.controller';
-import { AlertConfig } from '~/kirby/components/modal/alert/config/alert-config';
+import { ModalController } from '@kirbydesign/designsystem/modal';
+import { AlertConfig } from '@kirbydesign/designsystem/modal';
 
 @Component({
   selector: 'kirby-alert-example',

--- a/src/app/examples/checkbox-example/checkbox-example.component.spec.ts
+++ b/src/app/examples/checkbox-example/checkbox-example.component.spec.ts
@@ -1,7 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CheckboxExampleComponent } from './checkbox-example.component';
-import { KirbyModule } from '~/kirby';
+import { KirbyModule } from '@kirbydesign/designsystem';
 
 describe('CheckboxExampleComponent', () => {
   let component: CheckboxExampleComponent;

--- a/src/app/examples/examples.common.ts
+++ b/src/app/examples/examples.common.ts
@@ -1,3 +1,5 @@
+import { CustomIconSettings, CUSTOM_FONT_SETTINGS } from '@kirbydesign/designsystem';
+
 import { AvatarExampleComponent } from './avatar-example/avatar-example.component';
 import { ButtonExampleComponent } from './button-example/button-example.component';
 import { FloatingActionButtonExampleComponent } from './floating-action-button-example/floating-action-button-example.component';
@@ -18,10 +20,6 @@ import { IconExampleComponent } from './icon-example/icon-example.component';
 import { CheckboxExampleComponent } from './checkbox-example/checkbox-example.component';
 import { SegmentedChipControlExampleComponent } from './segmented-chip-control-example/segmented-chip-control-example.component';
 import { ActionSheetExampleComponent } from './action-sheet-example/action-sheet-example.component';
-import {
-  CUSTOM_FONT_SETTINGS,
-  CustomIconSettings,
-} from '~/kirby/components/icon/custom-icon-settings';
 import { AlertExampleComponent } from './alert-example/alert-example.component';
 
 export const customIconSettings: CustomIconSettings = {

--- a/src/app/examples/examples.module.ts
+++ b/src/app/examples/examples.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { KirbyModule } from '../../kirby/kirby.module';
+import { KirbyModule } from '@kirbydesign/designsystem';
 import { COMPONENT_DECLARATIONS, PROVIDER_DECLARATIONS } from './examples.common';
 import { CardExampleComponent } from './card-example/card-example.component';
 import { FirstEmbeddedModalExampleComponent } from './modal-example/first-embedded-modal-example/first-embedded-modal-example.component';

--- a/src/app/examples/icon-example/icon-example.component.spec.ts
+++ b/src/app/examples/icon-example/icon-example.component.spec.ts
@@ -3,7 +3,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { KirbyModule } from '../../../kirby/kirby.module';
 import { IconExampleComponent } from './icon-example.component';
-import { CUSTOM_FONT_SETTINGS } from '~/kirby/components/icon/custom-icon-settings';
+import { CUSTOM_FONT_SETTINGS } from '@kirbydesign/designsystem';
 import { customIconSettings } from '../examples.common';
 
 describe('IconExampleComponent', () => {

--- a/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.spec.ts
+++ b/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.spec.ts
@@ -1,9 +1,10 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { KirbyModule } from '../../../../kirby/kirby.module';
+import { KirbyModule } from '@kirbydesign/designsystem';
+import { COMPONENT_PROPS } from '@kirbydesign/designsystem/modal';
+
 import { FirstEmbeddedModalExampleComponent } from './first-embedded-modal-example.component';
-import { COMPONENT_PROPS } from '~/kirby/components/modal/modal-wrapper/config/modal-config.helper';
 
 describe('FirstEmbeddedModalExampleComponent', () => {
   let component: FirstEmbeddedModalExampleComponent;

--- a/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.ts
+++ b/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.ts
@@ -1,9 +1,9 @@
 import { Component, Inject, ViewContainerRef } from '@angular/core';
 
-import { ModalController } from '~/kirby/modal';
-import { ModalConfig } from '~/kirby/modal';
+import { ModalController } from '@kirbydesign/designsystem/modal';
+import { ModalConfig } from '@kirbydesign/designsystem/modal';
 import { SecondEmbeddedModalExampleComponent } from '../second-embedded-modal-example/second-embedded-modal-example.component';
-import { COMPONENT_PROPS } from '~/kirby';
+import { COMPONENT_PROPS } from '@kirbydesign/designsystem/modal';
 
 @Component({
   templateUrl: './first-embedded-modal-example.component.html',

--- a/src/app/examples/modal-example/modal-example.component.ts
+++ b/src/app/examples/modal-example/modal-example.component.ts
@@ -1,7 +1,7 @@
 import { Component, ViewContainerRef } from '@angular/core';
 
-import { ModalConfig } from '~/kirby/modal';
-import { ModalController } from '~/kirby/modal';
+import { ModalConfig } from '@kirbydesign/designsystem/modal';
+import { ModalController } from '@kirbydesign/designsystem/modal';
 import { FirstEmbeddedModalExampleComponent } from './first-embedded-modal-example/first-embedded-modal-example.component';
 
 @Component({

--- a/src/app/examples/modal-example/second-embedded-modal-example/second-embedded-modal-example.component.ts
+++ b/src/app/examples/modal-example/second-embedded-modal-example/second-embedded-modal-example.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 
-import { ModalController } from '~/kirby/components/modal/services/modal.controller';
+import { ModalController } from '@kirbydesign/designsystem/modal';
 
 @Component({
   templateUrl: './second-embedded-modal-example.component.html',

--- a/src/app/examples/segmented-control-example/segmented-control-example.component.ts
+++ b/src/app/examples/segmented-control-example/segmented-control-example.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 
-import { SegmentItem } from '~/kirby/components/segmented-control/segment-item';
+import { SegmentItem } from '@kirbydesign/designsystem';
 
 @Component({
   selector: 'kirby-segmented-control-example',

--- a/src/app/showcase/checkbox-showcase/checkbox-showcase.component.spec.ts
+++ b/src/app/showcase/checkbox-showcase/checkbox-showcase.component.spec.ts
@@ -3,7 +3,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { CheckboxShowcaseComponent } from './checkbox-showcase.component';
 import { ExamplesModule } from '~/app/examples/examples.module';
-import { KirbyModule } from '~/kirby';
+import { KirbyModule } from '@kirbydesign/designsystem';
 
 describe('CheckboxShowcaseComponent', () => {
   let component: CheckboxShowcaseComponent;

--- a/src/app/showcase/icon-showcase/icon-showcase.component.ts
+++ b/src/app/showcase/icon-showcase/icon-showcase.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 
+import { iconsCharCodeMap } from '@kirbydesign/designsystem/components/icon/icon.component';
+
 import { ShowcaseProperty } from '~/app/shared/showcase-properties/showcase-property';
-import { iconsCharCodeMap } from '~/kirby/components/icon/icon.component';
 
 declare var require: any;
 

--- a/src/kirby/components/list/helpers/list-helper.spec.ts
+++ b/src/kirby/components/list/helpers/list-helper.spec.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from '@angular/core';
 
-import { ListComponent } from '~/kirby';
+import { ListComponent } from '../list.component';
 import { ListHelper } from './list-helper';
 import { LoadOnDemandEvent } from '../list.event';
 

--- a/src/kirby/components/list/list.component.spec.ts
+++ b/src/kirby/components/list/list.component.spec.ts
@@ -3,9 +3,9 @@ import { createTestComponentFactory, Spectator } from '@netbasal/spectator';
 import { LoadOnDemandEvent } from './list.event';
 import { GroupByPipe } from './pipes/group-by.pipe';
 import { ListComponent } from './list.component';
-import { SpinnerComponent } from '~/kirby';
+import { SpinnerComponent } from '../spinner/spinner.component';
 import { InfiniteScrollDirective } from './directives/infinite-scroll.directive';
-import { ListHelper } from '~/kirby/components/list/helpers/list-helper';
+import { ListHelper } from './helpers/list-helper';
 
 /**
  * We need an actual model item, since WeakMap can't use primitives for keys.

--- a/src/kirby/components/list/list.component.ts
+++ b/src/kirby/components/list/list.component.ts
@@ -20,7 +20,7 @@ import {
 } from './list.directive';
 import { LoadOnDemandEvent, LoadOnDemandEventData } from './list.event';
 import { ListHelper } from './helpers/list-helper';
-import { GroupByPipe } from '~/kirby/components/list/pipes/group-by.pipe';
+import { GroupByPipe } from './pipes/group-by.pipe';
 
 export type ListShape = 'square' | 'rounded';
 

--- a/src/kirby/components/modal/action-sheet/action-sheet.component.spec.ts
+++ b/src/kirby/components/modal/action-sheet/action-sheet.component.spec.ts
@@ -10,7 +10,7 @@ import { ListComponent } from '../../list/list.component';
 import { ListCellLineComponent } from '../../list/list-cell-line/list-cell-line.component';
 import { CardComponent } from '../../card/card.component';
 import { GroupByPipe } from '../../list/pipes/group-by.pipe';
-import { SpinnerComponent } from '~/kirby';
+import { SpinnerComponent } from '../../spinner/spinner.component';
 import { InfiniteScrollDirective } from '../../list/directives/infinite-scroll.directive';
 import { CardHeaderComponent } from '../../card/card-header/card-header.component';
 

--- a/src/kirby/modal.ts
+++ b/src/kirby/modal.ts
@@ -1,2 +1,6 @@
 export { ModalController } from './components/modal/services/modal.controller';
 export { ModalConfig } from './components/modal/modal-wrapper/config/modal-config';
+export { COMPONENT_PROPS } from './components/modal/modal-wrapper/config/modal-config.helper';
+export { ActionSheetConfig } from './components/modal/action-sheet/config/action-sheet-config';
+export { ActionSheetItem } from './components/modal/action-sheet/config/action-sheet-item';
+export { AlertConfig } from './components/modal/alert/config/alert-config';

--- a/src/test.ts
+++ b/src/test.ts
@@ -19,7 +19,7 @@ getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDyn
 
 // Then we find all the files which needs test.
 const appContext = require.context('./app', true, /^((?!\.tns).)*\.ts/);
-const kirbyContext = require.context('./kirby', true, /^((?!(\.tns|index\.d\.ts)).)*\.ts/);
+const kirbyContext = require.context('./kirby', true, /^((?!(\.tns|\.d\.ts)).)*\.ts/);
 
 // And load the modules.
 appContext.keys().map(appContext);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,9 +18,10 @@
         ],
         "baseUrl": ".",
         "paths": {
-            "~/*": [
-                "src/*"
-            ]
+            "~/app/*": ["src/app/*"],
+            "~/environments/*": ["src/environments/*"],
+            "@kirbydesign/designsystem": ["src/kirby/index.ts"],
+            "@kirbydesign/designsystem/*": ["src/kirby/*"],
         }
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
             "~/app/*": ["src/app/*"],
             "~/environments/*": ["src/environments/*"],
             "@kirbydesign/designsystem": ["src/kirby/index.ts"],
-            "@kirbydesign/designsystem/*": ["src/kirby/*"],
+            "@kirbydesign/designsystem/*": ["src/kirby/*"]
         }
     }
 }

--- a/tsconfig.tns.json
+++ b/tsconfig.tns.json
@@ -3,11 +3,6 @@
     "compilerOptions": {
         "module": "es2015",
         "moduleResolution": "node",
-        "paths": {
-            "~/*": [
-                "src/*"
-            ],
-        }
     },
     "exclude": [
         "**/*.tns.ts",


### PR DESCRIPTION
This change prevents us from importing from `~/kirby` in Kirby source code
It also ensures classes are exported through `index.ts` by importing from `@kirbydesign/designsystem` in the cookbook itself.