### PR TITLE
:bug: Fix tsconfig app path

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,9 @@
             ],
             "@kirbydesign/designsystem/*": [
                 "src/kirby/*"
+            ],
+            "~/*": [
+                "tilde-imports-are-not-allowed-as-it-breaks-compilation-in-target-project"
             ]
         }
     }


### PR DESCRIPTION
(as {N} re-adds `"~/*"` on clean npm install)