### PR TITLE
Added color for unselected segment

### DIFF
--- a/src/kirby/components/segmented-control/segmented-control.component.tns.scss
+++ b/src/kirby/components/segmented-control/segmented-control.component.tns.scss
@@ -19,6 +19,7 @@ $border-radius: 20;
   padding-right: size("m");
   border-radius: $border-radius;
   height: 100%;
+  color: get-color('contrast-dark');
 
   &.is-checked {
     color: get-color('contrast-light');


### PR DESCRIPTION
Added a color for the un-selected segment. 

Reason: 
In DRB we will be setting every elements font color to get-color('contrast-dark') in order to fix the android grey fonts. So without a set font on the segment, it will get a wrong color.