### PR TITLE
update to {N} 5.4

### DIFF
--- a/nsconfig.json
+++ b/nsconfig.json
@@ -3,5 +3,6 @@
   "appPath": "src",
   "nsext": ".tns",
   "webext": "",
-  "shared": true
+  "shared": true,
+  "useLegacyWorkflow": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8163,9 +8163,9 @@
       }
     },
     "nativescript": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/nativescript/-/nativescript-5.3.4.tgz",
-      "integrity": "sha512-JIdvJV1OIuhOWqRO+CCMCKTZOAjzazR4vgn6W8UofHPSe1RbxE3295p9ScQMFJqA8p4hHglEDMdyQxcgfeGWEg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/nativescript/-/nativescript-5.4.0.tgz",
+      "integrity": "sha512-wrdpofXkHN/wVpIwyBuCgDLsOWBaSeYRp3q8z/sDPHeVqRGATaVp0DDtvXhOsucq1+F2H4tgIBNpOk4XhDNdBw==",
       "dev": true,
       "requires": {
         "@nativescript/schematics-executor": "0.0.2",
@@ -8186,13 +8186,13 @@
         "istextorbinary": "2.2.1",
         "jimp": "0.2.28",
         "lodash": "4.17.11",
-        "log4js": "1.0.1",
+        "log4js": "4.1.0",
         "marked": "0.5.1",
         "marked-terminal": "3.1.1",
         "minimatch": "3.0.2",
         "mkdirp": "0.5.1",
         "mute-stream": "0.0.5",
-        "nativescript-dev-xcode": "0.1.0",
+        "nativescript-dev-xcode": "0.2.0",
         "nativescript-doctor": "1.9.2",
         "nativescript-preview-sdk": "0.3.4",
         "open": "0.0.5",
@@ -8200,7 +8200,7 @@
         "osenv": "0.1.3",
         "pacote": "8.1.6",
         "pako": "1.0.6",
-        "pbxproj-dom": "1.1.0",
+        "pbxproj-dom": "1.2.0",
         "plist": "1.1.0",
         "plist-merge-patch": "0.1.1",
         "proper-lockfile": "3.2.0",
@@ -8354,7 +8354,7 @@
         },
         "@types/ora": {
           "version": "1.3.3",
-          "resolved": "http://registry.npmjs.org/@types/ora/-/ora-1.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/@types/ora/-/ora-1.3.3.tgz",
           "integrity": "sha512-XaSVRyCfnGq1xGlb6iuoxnomMXPIlZnvIIkKiGNMTCeVOg7G1Si+FA9N1lPrykPEfiRHwbuZXuTCSoYcHyjcdg==",
           "requires": {
             "@types/node": "*"
@@ -8395,7 +8395,7 @@
         },
         "@types/rx": {
           "version": "4.1.1",
-          "resolved": "http://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
           "integrity": "sha1-WY/JSla67ZdfGUV04PVy/Y5iekg=",
           "requires": {
             "@types/rx-core": "*",
@@ -8739,9 +8739,13 @@
           "dev": true
         },
         "async": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
-          "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA="
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.11"
+          }
         },
         "async-each": {
           "version": "1.0.2",
@@ -8779,7 +8783,7 @@
         },
         "axios": {
           "version": "0.18.0",
-          "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
           "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
           "dev": true,
           "requires": {
@@ -8948,7 +8952,7 @@
             },
             "http-errors": {
               "version": "1.3.1",
-              "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
               "requires": {
                 "inherits": "~2.0.1",
@@ -9660,9 +9664,9 @@
           }
         },
         "date-format": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/date-format/-/date-format-0.0.0.tgz",
-          "integrity": "sha1-CSBoY6sHDrRZrOpVQsvYVrEZZrM=",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.0.0.tgz",
+          "integrity": "sha512-M6UqVvZVgFYqZL1SfHsRGIQSz3ZL+qgbsV5Lp1Vj61LZVYuEwcMXYay7DRDtYs2HQQBK5hQtQ0fD9aEJ89V0LA==",
           "dev": true
         },
         "dateformat": {
@@ -10137,7 +10141,7 @@
           "dependencies": {
             "ansi-escapes": {
               "version": "1.4.0",
-              "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
               "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
             },
             "chalk": {
@@ -10199,7 +10203,7 @@
             },
             "onetime": {
               "version": "1.1.0",
-              "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
               "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
             },
             "restore-cursor": {
@@ -10598,6 +10602,12 @@
             }
           }
         },
+        "flatted": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+          "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+          "dev": true
+        },
         "flush-write-stream": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -10694,6 +10704,17 @@
           "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "fs-minipass": {
@@ -11202,7 +11223,7 @@
             },
             "readable-stream": {
               "version": "1.1.14",
-              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "dev": true,
               "requires": {
@@ -11214,7 +11235,7 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
               "dev": true
             }
@@ -11854,7 +11875,7 @@
         },
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
@@ -12580,6 +12601,11 @@
               "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
               "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
             },
+            "async": {
+              "version": "1.5.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+            },
             "escodegen": {
               "version": "1.8.1",
               "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
@@ -12628,7 +12654,7 @@
             },
             "source-map": {
               "version": "0.2.0",
-              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
               "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
               "optional": true,
               "requires": {
@@ -12768,6 +12794,15 @@
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
           "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
         },
         "jsonify": {
           "version": "0.0.0",
@@ -13007,14 +13042,33 @@
           }
         },
         "log4js": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/log4js/-/log4js-1.0.1.tgz",
-          "integrity": "sha1-+vZMEFa2NSpfu/CpO2Gpl5qEIsw=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/log4js/-/log4js-4.1.0.tgz",
+          "integrity": "sha512-eDa+zZPeVEeK6QGJAePyXM6pg4P3n3TO5rX9iZMVY48JshsTyLJZLIL5HipI1kQ2qLsSyOpUqNND/C5H4WhhiA==",
           "dev": true,
           "requires": {
-            "debug": "^2.2.0",
-            "semver": "^5.3.0",
-            "streamroller": "^0.2.1"
+            "date-format": "^2.0.0",
+            "debug": "^4.1.1",
+            "flatted": "^2.0.0",
+            "rfdc": "^1.1.2",
+            "streamroller": "^1.0.4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+              "dev": true
+            }
           }
         },
         "lolex": {
@@ -13375,7 +13429,7 @@
           "dependencies": {
             "commander": {
               "version": "2.9.0",
-              "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
               "requires": {
                 "graceful-readlink": ">= 1.0.0"
@@ -13493,9 +13547,9 @@
           }
         },
         "nativescript-dev-xcode": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/nativescript-dev-xcode/-/nativescript-dev-xcode-0.1.0.tgz",
-          "integrity": "sha512-auQd2/qVdOwD/8v+rHKLflYE8jpT4o1wMwtEFkFGp7sewLkBQz7y9pH79oNM7ztyw0gnL/cFAhLT/ViGLWdw6w==",
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/nativescript-dev-xcode/-/nativescript-dev-xcode-0.2.0.tgz",
+          "integrity": "sha512-UKX+AS3rF/HNQ7777GunT9SaVQJXmcYnol9yKxVXWM1uRNXiQUgLaUmhjYUkHw7voqNN+FCqqRZQlB8mHUPA9g==",
           "dev": true,
           "requires": {
             "simple-plist": "^1.0.0",
@@ -14269,9 +14323,9 @@
           "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
         },
         "pbxproj-dom": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/pbxproj-dom/-/pbxproj-dom-1.1.0.tgz",
-          "integrity": "sha512-ti2ZuXEptfYbkkUweP6sBtLBlRjTcWkxWG450lbJ+PwNMk8nvhhAtV7lIuQPHR29h7hPUHOIvUBAIljIx8ygxg==",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/pbxproj-dom/-/pbxproj-dom-1.2.0.tgz",
+          "integrity": "sha512-K2czrWqA68AR0q1UXz5EBi/zoxcljrkO4RSJX0jPnVn3iyE0HYnYOzaEEDYMpueczkT/Vtdm3SCc3NM+12kMaQ==",
           "dev": true
         },
         "pend": {
@@ -14483,7 +14537,7 @@
         },
         "proxy-agent": {
           "version": "2.3.1",
-          "resolved": "http://registry.npmjs.org/proxy-agent/-/proxy-agent-2.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-2.3.1.tgz",
           "integrity": "sha512-CNKuhC1jVtm8KJYFTS2ZRO71VCBx3QSA92So/e6NrY6GoJonkx3Irnk4047EsCcswczwqAekRj3s8qLRGahSKg==",
           "dev": true,
           "requires": {
@@ -14923,6 +14977,12 @@
           "version": "0.10.1",
           "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
           "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
+          "dev": true
+        },
+        "rfdc": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.2.tgz",
+          "integrity": "sha512-92ktAgvZhBzYTIK0Mja9uen5q5J3NRVMoDkJL2VMwq6SXjVCgqvQeVP2XAaUY6HT+XpQYeLSjb3UoitBryKmdA==",
           "dev": true
         },
         "rimraf": {
@@ -15471,44 +15531,31 @@
           }
         },
         "streamroller": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-0.2.2.tgz",
-          "integrity": "sha1-oTQg4EFp5XPbBo9ZIO4j2IGr/jM=",
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-1.0.4.tgz",
+          "integrity": "sha512-Wc2Gm5ygjSX8ZpW9J7Y9FwiSzTlKSvcl0FTTMd3rn7RoxDXpBW+xD9TY5sWL2n0UR61COB0LG1BQvN6nTUQbLQ==",
           "dev": true,
           "requires": {
-            "date-format": "^0.0.0",
-            "debug": "^0.7.2",
-            "readable-stream": "^1.1.7"
+            "async": "^2.6.1",
+            "date-format": "^2.0.0",
+            "debug": "^3.1.0",
+            "fs-extra": "^7.0.0",
+            "lodash": "^4.17.10"
           },
           "dependencies": {
             "debug": {
-              "version": "0.7.4",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-              "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk=",
-              "dev": true
-            },
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "1.1.14",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+              "version": "3.2.6",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "ms": "^2.1.1"
               }
             },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+            "ms": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
               "dev": true
             }
           }
@@ -15639,7 +15686,7 @@
         },
         "superagent-proxy": {
           "version": "1.0.3",
-          "resolved": "http://registry.npmjs.org/superagent-proxy/-/superagent-proxy-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/superagent-proxy/-/superagent-proxy-1.0.3.tgz",
           "integrity": "sha512-79Ujg1lRL2ICfuHUdX+H2MjIw73kB7bXsIkxLwHURz3j0XUmEEEoJ+u/wq+mKwna21Uejsm2cGR3OESA00TIjA==",
           "dev": true,
           "requires": {
@@ -16109,7 +16156,21 @@
             "request": "2.x",
             "underscore": "1.x",
             "uuid": "^3.0.0"
+          },
+          "dependencies": {
+            "async": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
+              "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA=",
+              "dev": true
+            }
           }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
         },
         "unpipe": {
           "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "1.2.0"
+            "minimist": "^1.2.0"
           }
         },
         "loader-utils": {
@@ -111,9 +111,9 @@
           "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
           "dev": true,
           "requires": {
-            "big.js": "5.2.2",
-            "emojis-list": "2.1.0",
-            "json5": "1.0.1"
+            "big.js": "^5.2.2",
+            "emojis-list": "^2.0.0",
+            "json5": "^1.0.1"
           }
         },
         "minimist": {
@@ -140,8 +140,8 @@
           "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
           "dev": true,
           "requires": {
-            "buffer-from": "1.1.1",
-            "source-map": "0.6.1"
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
           },
           "dependencies": {
             "source-map": {
@@ -178,7 +178,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "1.2.0"
+            "minimist": "^1.2.0"
           }
         },
         "loader-utils": {
@@ -187,9 +187,9 @@
           "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
           "dev": true,
           "requires": {
-            "big.js": "5.2.2",
-            "emojis-list": "2.1.0",
-            "json5": "1.0.1"
+            "big.js": "^5.2.2",
+            "emojis-list": "^2.0.0",
+            "json5": "^1.0.1"
           }
         },
         "minimist": {
@@ -290,7 +290,7 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-7.2.4.tgz",
       "integrity": "sha512-Wx6cqU6koFOASlyl4aCygtbtROoehU6OKwV2EZTkfzHx6Eu/QyTiSa5kyoApVM5LMmCNeb8SxJMSAnKXztNl0A==",
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.9.0"
       }
     },
     "@angular/cli": {
@@ -327,7 +327,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-7.2.4.tgz",
       "integrity": "sha512-3/i8RtnLTx/90gJHk5maE8zwsSiHgHvLItaa0qVfNlWiU0eCId/PL6TgDkut5vN9SQYL0oxhxFaVd35HmwsmuQ==",
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.9.0"
       }
     },
     "@angular/compiler": {
@@ -335,7 +335,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-7.2.4.tgz",
       "integrity": "sha512-+zyMzPCL45ePEV9nrnYJvhAVgp2Y19bDaq0f0YdZAqAjgDqHzXGGR6wX8GueyJWmUYWx5vwK6Apla4HwDrYA1w==",
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.9.0"
       }
     },
     "@angular/compiler-cli": {
@@ -345,15 +345,15 @@
       "dev": true,
       "requires": {
         "canonical-path": "1.0.0",
-        "chokidar": "2.1.5",
-        "convert-source-map": "1.6.0",
-        "dependency-graph": "0.7.2",
-        "magic-string": "0.25.2",
-        "minimist": "1.2.0",
-        "reflect-metadata": "0.1.12",
-        "shelljs": "0.8.3",
-        "source-map": "0.6.1",
-        "tslib": "1.9.3",
+        "chokidar": "^2.1.1",
+        "convert-source-map": "^1.5.1",
+        "dependency-graph": "^0.7.2",
+        "magic-string": "^0.25.0",
+        "minimist": "^1.2.0",
+        "reflect-metadata": "^0.1.2",
+        "shelljs": "^0.8.1",
+        "source-map": "^0.6.1",
+        "tslib": "^1.9.0",
         "yargs": "9.0.1"
       },
       "dependencies": {
@@ -375,18 +375,18 @@
           "integrity": "sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==",
           "dev": true,
           "requires": {
-            "anymatch": "2.0.0",
-            "async-each": "1.0.1",
-            "braces": "2.3.2",
-            "fsevents": "1.2.9",
-            "glob-parent": "3.1.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "4.0.1",
-            "normalize-path": "3.0.0",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.2.1",
-            "upath": "1.1.2"
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
           }
         },
         "cross-spawn": {
@@ -395,9 +395,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.5",
-            "shebang-command": "1.2.0",
-            "which": "1.3.1"
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "execa": {
@@ -406,13 +406,13 @@
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "fsevents": {
@@ -422,8 +422,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "nan": "2.13.2",
-            "node-pre-gyp": "0.12.0"
+            "nan": "^2.12.1",
+            "node-pre-gyp": "^0.12.0"
           },
           "dependencies": {
             "abbrev": {
@@ -449,8 +449,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.6"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
               }
             },
             "balanced-match": {
@@ -463,7 +463,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
               }
             },
@@ -500,7 +500,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "ms": "2.1.1"
+                "ms": "^2.1.1"
               }
             },
             "deep-extend": {
@@ -527,7 +527,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "minipass": "2.3.5"
+                "minipass": "^2.2.1"
               }
             },
             "fs.realpath": {
@@ -542,14 +542,14 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.3"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
               }
             },
             "glob": {
@@ -558,12 +558,12 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "has-unicode": {
@@ -578,7 +578,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
               }
             },
             "ignore-walk": {
@@ -587,7 +587,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "minimatch": "3.0.4"
+                "minimatch": "^3.0.4"
               }
             },
             "inflight": {
@@ -596,8 +596,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
               }
             },
             "inherits": {
@@ -616,7 +616,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "isarray": {
@@ -630,7 +630,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
@@ -643,8 +643,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.2",
-                "yallist": "3.0.3"
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
               }
             },
             "minizlib": {
@@ -653,7 +653,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "minipass": "2.3.5"
+                "minipass": "^2.2.1"
               }
             },
             "mkdirp": {
@@ -676,9 +676,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "debug": "4.1.1",
-                "iconv-lite": "0.4.24",
-                "sax": "1.2.4"
+                "debug": "^4.1.0",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
               }
             },
             "node-pre-gyp": {
@@ -687,16 +687,16 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "detect-libc": "1.0.3",
-                "mkdirp": "0.5.1",
-                "needle": "2.3.0",
-                "nopt": "4.0.1",
-                "npm-packlist": "1.4.1",
-                "npmlog": "4.1.2",
-                "rc": "1.2.8",
-                "rimraf": "2.6.3",
-                "semver": "5.7.0",
-                "tar": "4.4.8"
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
               }
             },
             "nopt": {
@@ -705,8 +705,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "abbrev": "1.1.1",
-                "osenv": "0.1.5"
+                "abbrev": "1",
+                "osenv": "^0.1.4"
               }
             },
             "npm-bundled": {
@@ -721,8 +721,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "ignore-walk": "3.0.1",
-                "npm-bundled": "1.0.6"
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
               }
             },
             "npmlog": {
@@ -731,10 +731,10 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "are-we-there-yet": "1.1.5",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
               }
             },
             "number-is-nan": {
@@ -753,7 +753,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               }
             },
             "os-homedir": {
@@ -774,8 +774,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
               }
             },
             "path-is-absolute": {
@@ -796,10 +796,10 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "deep-extend": "0.6.0",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
               },
               "dependencies": {
                 "minimist": {
@@ -816,13 +816,13 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             },
             "rimraf": {
@@ -831,7 +831,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "glob": "7.1.3"
+                "glob": "^7.1.3"
               }
             },
             "safe-buffer": {
@@ -874,9 +874,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             },
             "string_decoder": {
@@ -885,7 +885,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             },
             "strip-ansi": {
@@ -893,7 +893,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             },
             "strip-json-comments": {
@@ -908,13 +908,13 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "chownr": "1.1.1",
-                "fs-minipass": "1.2.5",
-                "minipass": "2.3.5",
-                "minizlib": "1.2.1",
-                "mkdirp": "0.5.1",
-                "safe-buffer": "5.1.2",
-                "yallist": "3.0.3"
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.3.4",
+                "minizlib": "^1.1.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.2"
               }
             },
             "util-deprecate": {
@@ -929,7 +929,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "string-width": "1.0.2"
+                "string-width": "^1.0.2 || 2"
               }
             },
             "wrappy": {
@@ -956,10 +956,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "mem": {
@@ -968,7 +968,7 @@
           "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.2.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "mimic-fn": {
@@ -1002,9 +1002,9 @@
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
           }
         },
         "path-type": {
@@ -1013,7 +1013,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "2.3.0"
+            "pify": "^2.0.0"
           }
         },
         "pify": {
@@ -1028,9 +1028,9 @@
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.5.0",
-            "path-type": "2.0.0"
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
           }
         },
         "read-pkg-up": {
@@ -1039,8 +1039,8 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         },
         "readdirp": {
@@ -1049,9 +1049,9 @@
           "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "micromatch": "3.1.10",
-            "readable-stream": "2.3.6"
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
           }
         },
         "source-map": {
@@ -1066,8 +1066,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -1076,7 +1076,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "strip-bom": {
@@ -1103,19 +1103,19 @@
           "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.3",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
           }
         },
         "yargs-parser": {
@@ -1124,7 +1124,7 @@
           "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -1134,7 +1134,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-7.2.4.tgz",
       "integrity": "sha512-kfAxhIxl89PmB7y81FR/RAv0yWRFcEYxEnTwV+o8jKGfemAXtQ0g/Vh+lJR0SD/TBgFilMxotN1mhwH4A8GShw==",
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.9.0"
       }
     },
     "@angular/forms": {
@@ -1142,7 +1142,7 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-7.2.4.tgz",
       "integrity": "sha512-DAtOrdlTRsgvmZrsvczCAkY8dhTwZb5DXBmPuSXh0UR9lvEiCgNHGbwEiIiIkAHpw1wSeXZrq0qyy/oJRvf18g==",
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.9.0"
       }
     },
     "@angular/http": {
@@ -1150,7 +1150,7 @@
       "resolved": "https://registry.npmjs.org/@angular/http/-/http-7.2.4.tgz",
       "integrity": "sha512-kazJREm7MtSCYbE+9zU/CcUXI5Csu53PooeQlAp80/TOHqry6fVKIMHCI892Db9ScY2ds0SzbyTmrxEQo7PP1A==",
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.9.0"
       }
     },
     "@angular/platform-browser": {
@@ -1158,7 +1158,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-7.2.4.tgz",
       "integrity": "sha512-Klt8aKR5SP9bqfMfpSY5vQOY7AQEs8JGuZOk5Bfc2dUtYT2IEIvK2IqO8v2rcFRVO13HOPUxl328efyHqLgI7g==",
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.9.0"
       }
     },
     "@angular/platform-browser-dynamic": {
@@ -1166,7 +1166,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-7.2.4.tgz",
       "integrity": "sha512-J/xWlmaYOPUoCHZ5TiIRiyYa4uRMtCz3aGdBfY8k/NWtNo8SCYaS3aut7Sk4RS5rK8aAVi+aYFlY5YOrlW+Hbg==",
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.9.0"
       }
     },
     "@angular/router": {
@@ -1174,7 +1174,7 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-7.2.4.tgz",
       "integrity": "sha512-T8Uqf2H1SV1MQI38WwYJ4aa+4NNnvlp2Tp/rkfg6tKcp/cLkKqE6OOfiy9lmW+i/624v8tMgYoBMOUNBjAG23g==",
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.9.0"
       }
     },
     "@babel/code-frame": {
@@ -1183,7 +1183,7 @@
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0"
+        "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/helper-function-name": {
@@ -1192,9 +1192,9 @@
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "7.0.0",
-        "@babel/template": "7.1.2",
-        "@babel/types": "7.1.3"
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -1203,7 +1203,7 @@
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.1.3"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/highlight": {
@@ -1212,9 +1212,9 @@
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "esutils": "2.0.2",
-        "js-tokens": "4.0.0"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
       },
       "dependencies": {
         "js-tokens": {
@@ -1237,7 +1237,7 @@
       "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
       "dev": true,
       "requires": {
-        "regenerator-runtime": "0.13.2"
+        "regenerator-runtime": "^0.13.2"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -1254,9 +1254,9 @@
       "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0",
-        "@babel/parser": "7.1.3",
-        "@babel/types": "7.1.3"
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.1.2",
+        "@babel/types": "^7.1.2"
       }
     },
     "@babel/traverse": {
@@ -1265,15 +1265,15 @@
       "integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0",
-        "@babel/generator": "7.4.4",
-        "@babel/helper-function-name": "7.1.0",
-        "@babel/helper-split-export-declaration": "7.4.4",
-        "@babel/parser": "7.4.4",
-        "@babel/types": "7.4.4",
-        "debug": "4.1.1",
-        "globals": "11.12.0",
-        "lodash": "4.17.11"
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.4.4",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "@babel/generator": {
@@ -1282,11 +1282,11 @@
           "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
           "dev": true,
           "requires": {
-            "@babel/types": "7.4.4",
-            "jsesc": "2.5.2",
-            "lodash": "4.17.11",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
+            "@babel/types": "^7.4.4",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
           }
         },
         "@babel/helper-split-export-declaration": {
@@ -1295,7 +1295,7 @@
           "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
           "dev": true,
           "requires": {
-            "@babel/types": "7.4.4"
+            "@babel/types": "^7.4.4"
           }
         },
         "@babel/parser": {
@@ -1310,9 +1310,9 @@
           "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.11",
-            "to-fast-properties": "2.0.0"
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
           }
         },
         "debug": {
@@ -1321,7 +1321,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "globals": {
@@ -1362,9 +1362,9 @@
       "integrity": "sha512-RpPOVfK+yatXyn8n4PB1NW6k9qjinrXrRR8ugBN8fD6hCy5RXI6PSbVqpOJBO9oSaY7Nom4ohj35feb0UR9hSA==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "lodash": "4.17.11",
-        "to-fast-properties": "2.0.0"
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.10",
+        "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
         "to-fast-properties": {
@@ -1381,7 +1381,7 @@
       "integrity": "sha512-5Z7/52vCzP+wcJoUfqOWBHcjeajXWGoz6AW/sOeF/RtXqkFDc7rqrpfxZCuL6FanFm/Aayh5F7O8t5/ZgeZGqA==",
       "requires": {
         "@ionic/core": "4.1.1",
-        "tslib": "1.9.3"
+        "tslib": "^1.9.3"
       }
     },
     "@ionic/core": {
@@ -1398,9 +1398,9 @@
       "integrity": "sha512-tUn4uveKVdspL6xbb+KKCsfhBnfe2cfCu6I0bFOeCEPh2HrueWQgFHulVM7v+5NKoxKdFl+Hrc22+thAKSWJDQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "7.1.4",
-        "@angular-devkit/schematics": "7.1.4",
-        "@schematics/angular": "7.1.4"
+        "@angular-devkit/core": "~7.1.3",
+        "@angular-devkit/schematics": "~7.1.3",
+        "@schematics/angular": "~7.1.3"
       },
       "dependencies": {
         "@angular-devkit/core": {
@@ -1443,10 +1443,10 @@
           "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "2.0.1",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.4.1",
-            "uri-js": "4.2.2"
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
         },
         "fast-deep-equal": {
@@ -1477,8 +1477,8 @@
       "requires": {
         "dom-testing-library": "3.16.0",
         "jquery": "3.4.1",
-        "schematics-utilities": "1.1.2",
-        "tslib": "1.9.3"
+        "schematics-utilities": "^1.1.1",
+        "tslib": "^1.9.0"
       }
     },
     "@ngtools/webpack": {
@@ -1576,7 +1576,7 @@
       "integrity": "sha512-1awkm/O4pQCR9hI2F80HmIOda/L+ogkSL8Arj1k00eue5VLY5ooewhSOyF/cUJE0S+/34uD5EYY3zmd6fu2OCA==",
       "dev": true,
       "requires": {
-        "@types/jasmine": "2.8.9"
+        "@types/jasmine": "*"
       }
     },
     "@types/node": {
@@ -1614,9 +1614,9 @@
       "integrity": "sha512-zfvjpp7jiafSmrzJ2/i3LqOyTYTuJ7u1KOXlKgDlvsj9Rr0x7ZiYu5lZbXwobL7lmsRNtPXlBfmaUD8eU2Hu8w==",
       "dev": true,
       "requires": {
-        "@types/node": "8.9.5",
-        "@types/source-list-map": "0.1.2",
-        "source-map": "0.6.1"
+        "@types/node": "*",
+        "@types/source-list-map": "*",
+        "source-map": "^0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -1701,7 +1701,7 @@
       "integrity": "sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==",
       "dev": true,
       "requires": {
-        "@xtuc/ieee754": "1.2.0"
+        "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
@@ -1823,8 +1823,8 @@
       "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "dev": true,
       "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "abbrev": {
@@ -1839,7 +1839,7 @@
       "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.24",
+        "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
       },
       "dependencies": {
@@ -1903,7 +1903,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "1.2.0"
+            "minimist": "^1.2.0"
           }
         },
         "loader-utils": {
@@ -1912,9 +1912,9 @@
           "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
           "dev": true,
           "requires": {
-            "big.js": "5.2.2",
-            "emojis-list": "2.1.0",
-            "json5": "1.0.1"
+            "big.js": "^5.2.2",
+            "emojis-list": "^2.0.0",
+            "json5": "^1.0.1"
           }
         },
         "minimist": {
@@ -1943,7 +1943,7 @@
       "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "dev": true,
       "requires": {
-        "es6-promisify": "5.0.0"
+        "es6-promisify": "^5.0.0"
       }
     },
     "agentkeepalive": {
@@ -1952,7 +1952,7 @@
       "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
       "dev": true,
       "requires": {
-        "humanize-ms": "1.2.1"
+        "humanize-ms": "^1.2.1"
       }
     },
     "ajv": {
@@ -1961,10 +1961,10 @@
       "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "2.0.1",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       },
       "dependencies": {
         "fast-deep-equal": {
@@ -2029,7 +2029,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "anymatch": {
@@ -2038,8 +2038,8 @@
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
       "requires": {
-        "micromatch": "3.1.10",
-        "normalize-path": "2.1.1"
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
       }
     },
     "app-root-path": {
@@ -2054,7 +2054,7 @@
       "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
       "dev": true,
       "requires": {
-        "default-require-extensions": "2.0.0"
+        "default-require-extensions": "^2.0.0"
       }
     },
     "aproba": {
@@ -2069,8 +2069,8 @@
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.6"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -2079,7 +2079,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arity-n": {
@@ -2142,7 +2142,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -2182,7 +2182,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": "~2.1.0"
       }
     },
     "asn1.js": {
@@ -2191,9 +2191,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -2240,7 +2240,7 @@
       "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "lodash": {
@@ -2287,12 +2287,12 @@
       "integrity": "sha512-Yp51mevbOEdxDUy5WjiKtpQaecqYq9OqZSL04rSoCiry7Tc5I9FEyo3bfxiTJc1DfHeKwSFCUYbBAiOQ2VGfiw==",
       "dev": true,
       "requires": {
-        "browserslist": "4.5.6",
-        "caniuse-lite": "1.0.30000967",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "7.0.14",
-        "postcss-value-parser": "3.3.1"
+        "browserslist": "^4.4.1",
+        "caniuse-lite": "^1.0.30000929",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^7.0.13",
+        "postcss-value-parser": "^3.3.1"
       }
     },
     "aws-sign2": {
@@ -2313,9 +2313,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2330,11 +2330,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "supports-color": {
@@ -2351,14 +2351,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.11",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
       }
     },
     "babel-messages": {
@@ -2367,7 +2367,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-runtime": {
@@ -2376,8 +2376,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.7",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -2386,11 +2386,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.11"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -2399,15 +2399,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.11"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -2416,10 +2416,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.11",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -2446,13 +2446,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.3.0",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -2461,7 +2461,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -2470,7 +2470,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -2479,7 +2479,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -2488,9 +2488,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -2526,7 +2526,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "better-assert": {
@@ -2544,10 +2544,10 @@
       "integrity": "sha512-+GUNvzHR4nRyGybQc2WpNJL4MJazMuvf92ueIyA0bIkPRwhhQu3IfZQ2PSoVPpCBJfmoSdOxu5rnotfFLlvYRQ==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.2",
-        "check-types": "7.4.0",
-        "hoopy": "0.1.4",
-        "tryer": "1.0.1"
+        "bluebird": "^3.5.1",
+        "check-types": "^7.3.0",
+        "hoopy": "^0.1.2",
+        "tryer": "^1.0.0"
       }
     },
     "big.js": {
@@ -2574,7 +2574,7 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "blocking-proxy": {
@@ -2583,7 +2583,7 @@
       "integrity": "sha512-KE8NFMZr3mN2E0HcvCgRtX7DjhiIQrwle+nSVJVC/yqFb9+xznHl2ZcoBp2L9qzkI4t4cBFJ1efXF8Dwi132RA==",
       "dev": true,
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
@@ -2613,15 +2613,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
         "iconv-lite": "0.4.23",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.2",
         "raw-body": "2.3.3",
-        "type-is": "1.6.18"
+        "type-is": "~1.6.16"
       }
     },
     "bonjour": {
@@ -2630,12 +2630,12 @@
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "dev": true,
       "requires": {
-        "array-flatten": "2.1.2",
-        "deep-equal": "1.0.1",
-        "dns-equal": "1.0.0",
-        "dns-txt": "2.0.2",
-        "multicast-dns": "6.2.3",
-        "multicast-dns-service-types": "1.1.0"
+        "array-flatten": "^2.1.0",
+        "deep-equal": "^1.0.1",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
       }
     },
     "brace-expansion": {
@@ -2644,7 +2644,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -2654,16 +2654,16 @@
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0",
-        "array-unique": "0.3.2",
-        "extend-shallow": "2.0.1",
-        "fill-range": "4.0.0",
-        "isobject": "3.0.1",
-        "repeat-element": "1.1.3",
-        "snapdragon": "0.8.2",
-        "snapdragon-node": "2.1.1",
-        "split-string": "3.1.0",
-        "to-regex": "3.0.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2672,7 +2672,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -2689,12 +2689,12 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -2703,9 +2703,9 @@
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.2.0",
-        "browserify-des": "1.0.2",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -2714,10 +2714,10 @@
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "browserify-rsa": {
@@ -2726,8 +2726,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.1.0"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -2736,13 +2736,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "elliptic": "6.4.1",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.4"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -2751,7 +2751,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "1.0.6"
+        "pako": "~1.0.5"
       }
     },
     "browserslist": {
@@ -2760,9 +2760,9 @@
       "integrity": "sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000967",
-        "electron-to-chromium": "1.3.132",
-        "node-releases": "1.1.18"
+        "caniuse-lite": "^1.0.30000963",
+        "electron-to-chromium": "^1.3.127",
+        "node-releases": "^1.1.17"
       }
     },
     "buffer": {
@@ -2771,9 +2771,9 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.13",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-alloc": {
@@ -2782,8 +2782,8 @@
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dev": true,
       "requires": {
-        "buffer-alloc-unsafe": "1.1.0",
-        "buffer-fill": "1.0.0"
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -2846,19 +2846,19 @@
       "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.2",
-        "chownr": "1.1.1",
-        "glob": "7.1.3",
-        "graceful-fs": "4.1.11",
-        "lru-cache": "4.1.5",
-        "mississippi": "2.0.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "promise-inflight": "1.0.1",
-        "rimraf": "2.6.2",
-        "ssri": "5.3.0",
-        "unique-filename": "1.1.1",
-        "y18n": "4.0.0"
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^2.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^5.2.4",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
       }
     },
     "cache-base": {
@@ -2867,15 +2867,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.3.0",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "callsite": {
@@ -2896,8 +2896,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       }
     },
     "caniuse-lite": {
@@ -2924,9 +2924,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chardet": {
@@ -2947,19 +2947,19 @@
       "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
       "dev": true,
       "requires": {
-        "anymatch": "2.0.0",
-        "async-each": "1.0.1",
-        "braces": "2.3.2",
-        "fsevents": "1.2.4",
-        "glob-parent": "3.1.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "4.0.1",
-        "lodash.debounce": "4.0.8",
-        "normalize-path": "2.1.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0",
-        "upath": "1.1.2"
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.0",
+        "braces": "^2.3.0",
+        "fsevents": "^1.2.2",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "lodash.debounce": "^4.0.8",
+        "normalize-path": "^2.1.1",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0",
+        "upath": "^1.0.5"
       }
     },
     "chownr": {
@@ -2974,7 +2974,7 @@
       "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
       "dev": true,
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.9.0"
       }
     },
     "cipher-base": {
@@ -2983,8 +2983,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "circular-dependency-plugin": {
@@ -2999,10 +2999,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -3011,7 +3011,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -3022,7 +3022,7 @@
       "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
       "dev": true,
       "requires": {
-        "source-map": "0.6.1"
+        "source-map": "~0.6.0"
       },
       "dependencies": {
         "source-map": {
@@ -3039,7 +3039,7 @@
       "integrity": "sha512-gvwfMsqu3HBgTVvaBa1H3AZKO03CHpr5uP92SPIktP3827EovAitwW+1xoqXyTxCuXnLYpMHG5ytS4AoukHDWA==",
       "dev": true,
       "requires": {
-        "rimraf": "2.6.2"
+        "rimraf": "^2.6.1"
       }
     },
     "cli-cursor": {
@@ -3048,7 +3048,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-width": {
@@ -3063,9 +3063,9 @@
       "integrity": "sha512-7yhQBmtN+uYZmfRjjVjKa0dZdWuabzpSKGtyQZN+9C8xlC788SSJjOHWh7tzurfwTqTD5UDYAhIv5fRJg3sHjQ==",
       "optional": true,
       "requires": {
-        "good-listener": "1.2.2",
-        "select": "1.1.2",
-        "tiny-emitter": "2.0.2"
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
       }
     },
     "cliui": {
@@ -3074,9 +3074,9 @@
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
       }
     },
     "clone": {
@@ -3091,10 +3091,10 @@
       "integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
       "dev": true,
       "requires": {
-        "for-own": "1.0.0",
-        "is-plain-object": "2.0.4",
-        "kind-of": "6.0.2",
-        "shallow-clone": "1.0.0"
+        "for-own": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.0",
+        "shallow-clone": "^1.0.0"
       }
     },
     "co": {
@@ -3115,12 +3115,12 @@
       "integrity": "sha512-oO6vCkjqsVrEsmh58oNlnJkRXuA30hF8cdNAQV9DytEalDwyOFRvHMnlKFzmOStNerOmPGZU9GAHnBo4tGvtiQ==",
       "dev": true,
       "requires": {
-        "app-root-path": "2.1.0",
-        "css-selector-tokenizer": "0.7.0",
-        "cssauron": "1.4.0",
-        "semver-dsl": "1.0.1",
-        "source-map": "0.5.7",
-        "sprintf-js": "1.1.2"
+        "app-root-path": "^2.1.0",
+        "css-selector-tokenizer": "^0.7.0",
+        "cssauron": "^1.4.0",
+        "semver-dsl": "^1.0.1",
+        "source-map": "^0.5.7",
+        "sprintf-js": "^1.1.1"
       },
       "dependencies": {
         "sprintf-js": {
@@ -3137,8 +3137,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
       }
     },
     "color-convert": {
@@ -3168,7 +3168,7 @@
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -3213,7 +3213,7 @@
       "integrity": "sha1-ntZ18TzFRQHTCVCkhv9qe6OrGF8=",
       "dev": true,
       "requires": {
-        "arity-n": "1.0.4"
+        "arity-n": "^1.0.4"
       }
     },
     "compressible": {
@@ -3222,7 +3222,7 @@
       "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
       "dev": true,
       "requires": {
-        "mime-db": "1.40.0"
+        "mime-db": ">= 1.40.0 < 2"
       },
       "dependencies": {
         "mime-db": {
@@ -3239,13 +3239,13 @@
       "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
       "dev": true,
       "requires": {
-        "accepts": "1.3.7",
+        "accepts": "~1.3.5",
         "bytes": "3.0.0",
-        "compressible": "2.0.17",
+        "compressible": "~2.0.16",
         "debug": "2.6.9",
-        "on-headers": "1.0.2",
+        "on-headers": "~1.0.2",
         "safe-buffer": "5.1.2",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       }
     },
     "concat-map": {
@@ -3260,10 +3260,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "connect": {
@@ -3274,7 +3274,7 @@
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
-        "parseurl": "1.3.3",
+        "parseurl": "~1.3.2",
         "utils-merge": "1.0.1"
       },
       "dependencies": {
@@ -3285,12 +3285,12 @@
           "dev": true,
           "requires": {
             "debug": "2.6.9",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.3",
-            "statuses": "1.3.1",
-            "unpipe": "1.0.0"
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "statuses": "~1.3.1",
+            "unpipe": "~1.0.0"
           }
         },
         "statuses": {
@@ -3313,7 +3313,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "console-control-strings": {
@@ -3346,7 +3346,7 @@
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.1"
       }
     },
     "cookie": {
@@ -3367,12 +3367,12 @@
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "fs-write-stream-atomic": "1.0.10",
-        "iferr": "0.1.5",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
       }
     },
     "copy-descriptor": {
@@ -3387,14 +3387,14 @@
       "integrity": "sha512-Y+SQCF+0NoWQryez2zXn5J5knmr9z/9qSQt7fbL78u83rxmigOy8X5+BFn8CFSuX+nKT8gpYwJX68ekqtQt6ZA==",
       "dev": true,
       "requires": {
-        "cacache": "10.0.4",
-        "find-cache-dir": "1.0.0",
-        "globby": "7.1.1",
-        "is-glob": "4.0.1",
-        "loader-utils": "1.1.0",
-        "minimatch": "3.0.4",
-        "p-limit": "1.3.0",
-        "serialize-javascript": "1.7.0"
+        "cacache": "^10.0.4",
+        "find-cache-dir": "^1.0.0",
+        "globby": "^7.1.1",
+        "is-glob": "^4.0.0",
+        "loader-utils": "^1.1.0",
+        "minimatch": "^3.0.4",
+        "p-limit": "^1.0.0",
+        "serialize-javascript": "^1.4.0"
       }
     },
     "core-js": {
@@ -3414,10 +3414,10 @@
       "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
       "dev": true,
       "requires": {
-        "is-directory": "0.3.1",
-        "js-yaml": "3.13.1",
-        "parse-json": "4.0.0",
-        "require-from-string": "2.0.2"
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.9.0",
+        "parse-json": "^4.0.0",
+        "require-from-string": "^2.0.1"
       },
       "dependencies": {
         "parse-json": {
@@ -3426,8 +3426,8 @@
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.2",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         }
       }
@@ -3438,12 +3438,12 @@
       "integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
       "dev": true,
       "requires": {
-        "growl": "1.10.5",
-        "js-yaml": "3.13.1",
-        "lcov-parse": "0.0.10",
-        "log-driver": "1.2.7",
-        "minimist": "1.2.0",
-        "request": "2.88.0"
+        "growl": "~> 1.10.0",
+        "js-yaml": "^3.11.0",
+        "lcov-parse": "^0.0.10",
+        "log-driver": "^1.2.7",
+        "minimist": "^1.2.0",
+        "request": "^2.85.0"
       },
       "dependencies": {
         "minimist": {
@@ -3460,17 +3460,17 @@
       "integrity": "sha1-GFvgGFEdhycN7czCkxceN2VauI8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "chokidar": "1.7.0",
-        "duplexer": "0.1.1",
-        "glob": "7.1.3",
-        "glob2base": "0.0.12",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "resolve": "1.1.7",
-        "safe-buffer": "5.1.2",
-        "shell-quote": "1.6.1",
-        "subarg": "1.0.0"
+        "babel-runtime": "^6.9.2",
+        "chokidar": "^1.6.0",
+        "duplexer": "^0.1.1",
+        "glob": "^7.0.5",
+        "glob2base": "^0.0.12",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "resolve": "^1.1.7",
+        "safe-buffer": "^5.0.1",
+        "shell-quote": "^1.6.1",
+        "subarg": "^1.0.0"
       },
       "dependencies": {
         "anymatch": {
@@ -3479,8 +3479,8 @@
           "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
           "dev": true,
           "requires": {
-            "micromatch": "2.3.11",
-            "normalize-path": "2.1.1"
+            "micromatch": "^2.1.5",
+            "normalize-path": "^2.0.0"
           }
         },
         "arr-diff": {
@@ -3489,7 +3489,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "array-unique": {
@@ -3504,9 +3504,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.3"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "chokidar": {
@@ -3515,15 +3515,15 @@
           "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
           "dev": true,
           "requires": {
-            "anymatch": "1.3.2",
-            "async-each": "1.0.1",
-            "fsevents": "1.2.4",
-            "glob-parent": "2.0.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "2.0.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.1.0"
+            "anymatch": "^1.3.0",
+            "async-each": "^1.0.0",
+            "fsevents": "^1.0.0",
+            "glob-parent": "^2.0.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^2.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0"
           }
         },
         "expand-brackets": {
@@ -3532,7 +3532,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "extglob": {
@@ -3541,7 +3541,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "glob-parent": {
@@ -3550,7 +3550,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "is-extglob": {
@@ -3565,7 +3565,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         },
         "kind-of": {
@@ -3574,7 +3574,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         },
         "micromatch": {
@@ -3583,19 +3583,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           }
         }
       }
@@ -3606,8 +3606,8 @@
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.1"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-hash": {
@@ -3616,11 +3616,11 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "md5.js": "1.3.5",
-        "ripemd160": "2.0.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -3629,12 +3629,12 @@
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cross-spawn": {
@@ -3643,8 +3643,8 @@
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.5",
-        "which": "1.3.1"
+        "lru-cache": "^4.0.1",
+        "which": "^1.2.9"
       }
     },
     "crypto-browserify": {
@@ -3653,17 +3653,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.1",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.3",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "diffie-hellman": "5.0.3",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.17",
-        "public-encrypt": "4.0.3",
-        "randombytes": "2.1.0",
-        "randomfill": "1.0.4"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "css": {
@@ -3672,10 +3672,10 @@
       "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "source-map": "0.6.1",
-        "source-map-resolve": "0.5.2",
-        "urix": "0.1.0"
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
+        "urix": "^0.1.0"
       },
       "dependencies": {
         "source-map": {
@@ -3687,46 +3687,66 @@
       }
     },
     "css-loader": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-1.0.1.tgz",
-      "integrity": "sha512-+ZHAZm/yqvJ2kDtPne3uX0C+Vr3Zn5jFn2N4HywtS5ujwvsVkyg0VArEXpl3BgczDA8anieki1FIzhchX4yrDw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-2.1.1.tgz",
+      "integrity": "sha512-OcKJU/lt232vl1P9EEDamhoO9iKY3tIjY5GU+XDLblAykTdgs6Ux9P1hTHve8nFKy5KPpOXOsVI/hIwi3841+w==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "css-selector-tokenizer": "0.7.0",
-        "icss-utils": "2.1.0",
-        "loader-utils": "1.1.0",
-        "lodash": "4.17.11",
-        "postcss": "6.0.23",
-        "postcss-modules-extract-imports": "1.2.1",
-        "postcss-modules-local-by-default": "1.2.0",
-        "postcss-modules-scope": "1.1.0",
-        "postcss-modules-values": "1.3.0",
-        "postcss-value-parser": "3.3.1",
-        "source-list-map": "2.0.1"
+        "camelcase": "^5.2.0",
+        "icss-utils": "^4.1.0",
+        "loader-utils": "^1.2.3",
+        "normalize-path": "^3.0.0",
+        "postcss": "^7.0.14",
+        "postcss-modules-extract-imports": "^2.0.0",
+        "postcss-modules-local-by-default": "^2.0.6",
+        "postcss-modules-scope": "^2.1.0",
+        "postcss-modules-values": "^2.0.0",
+        "postcss-value-parser": "^3.3.0",
+        "schema-utils": "^1.0.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+        "big.js": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
           "dev": true
         },
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "chalk": "2.4.1",
-            "source-map": "0.6.1",
-            "supports-color": "5.5.0"
+            "minimist": "^1.2.0"
           }
         },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+        "loader-utils": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+          "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^2.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
           "dev": true
         }
       }
@@ -3743,9 +3763,9 @@
       "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
       "dev": true,
       "requires": {
-        "cssesc": "0.1.0",
-        "fastparse": "1.1.1",
-        "regexpu-core": "1.0.0"
+        "cssesc": "^0.1.0",
+        "fastparse": "^1.1.1",
+        "regexpu-core": "^1.0.0"
       }
     },
     "cssauron": {
@@ -3754,7 +3774,7 @@
       "integrity": "sha1-pmAt/34EqDBtwNuaVR6S6LVmKtg=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "X.X.X"
       }
     },
     "cssesc": {
@@ -3769,7 +3789,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "custom-event": {
@@ -3786,11 +3806,11 @@
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.50"
+        "es5-ext": "^0.10.9"
       }
     },
     "dashdash": {
@@ -3799,7 +3819,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-format": {
@@ -3847,8 +3867,8 @@
       "integrity": "sha512-lAc4i9QJR0YHSDFdzeBQKfZ1SRDG3hsJNEkrpcZa8QhBfidLAilT60BDEIVUUGqosFp425KOgB3uYqcnQrWafQ==",
       "dev": true,
       "requires": {
-        "execa": "0.10.0",
-        "ip-regex": "2.1.0"
+        "execa": "^0.10.0",
+        "ip-regex": "^2.1.0"
       }
     },
     "default-require-extensions": {
@@ -3857,7 +3877,7 @@
       "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
       "dev": true,
       "requires": {
-        "strip-bom": "3.0.0"
+        "strip-bom": "^3.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -3874,8 +3894,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "1.0.2",
-        "isobject": "3.0.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -3884,7 +3904,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -3893,7 +3913,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -3902,9 +3922,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -3915,12 +3935,12 @@
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "dev": true,
       "requires": {
-        "globby": "6.1.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "p-map": "1.2.0",
-        "pify": "3.0.0",
-        "rimraf": "2.6.2"
+        "globby": "^6.1.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "p-map": "^1.1.1",
+        "pify": "^3.0.0",
+        "rimraf": "^2.2.8"
       },
       "dependencies": {
         "globby": {
@@ -3929,11 +3949,11 @@
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.3",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           },
           "dependencies": {
             "pify": {
@@ -3982,8 +4002,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "destroy": {
@@ -3998,7 +4018,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "detect-node": {
@@ -4025,9 +4045,9 @@
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.1.0"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "dir-glob": {
@@ -4036,7 +4056,7 @@
       "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
       "dev": true,
       "requires": {
-        "path-type": "3.0.0"
+        "path-type": "^3.0.0"
       }
     },
     "dns-equal": {
@@ -4051,8 +4071,8 @@
       "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "dev": true,
       "requires": {
-        "ip": "1.1.5",
-        "safe-buffer": "5.1.2"
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "dns-txt": {
@@ -4061,7 +4081,7 @@
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "dev": true,
       "requires": {
-        "buffer-indexof": "1.1.1"
+        "buffer-indexof": "^1.0.0"
       }
     },
     "dom-serialize": {
@@ -4070,10 +4090,10 @@
       "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
       "dev": true,
       "requires": {
-        "custom-event": "1.0.1",
-        "ent": "2.2.0",
-        "extend": "3.0.2",
-        "void-elements": "2.0.1"
+        "custom-event": "~1.0.0",
+        "ent": "~2.2.0",
+        "extend": "^3.0.0",
+        "void-elements": "^2.0.0"
       }
     },
     "dom-testing-library": {
@@ -4082,10 +4102,10 @@
       "integrity": "sha512-KfhmOHA0R78V37rcFvfWYfgCXu3FaOgrUVci1Zmu7JwlPBBifgbHF/Epdifay4mYQLTCpN9tCzdGgZAHOuL4QA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "7.4.4",
-        "@sheerun/mutationobserver-shim": "0.3.2",
-        "pretty-format": "23.6.0",
-        "wait-for-expect": "1.2.0"
+        "@babel/runtime": "^7.1.5",
+        "@sheerun/mutationobserver-shim": "^0.3.2",
+        "pretty-format": "^23.6.0",
+        "wait-for-expect": "^1.1.0"
       }
     },
     "domain-browser": {
@@ -4106,10 +4126,10 @@
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -4119,8 +4139,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ee-first": {
@@ -4147,13 +4167,13 @@
       "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.7",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "emojis-list": {
@@ -4174,7 +4194,7 @@
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.23"
+        "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
@@ -4183,7 +4203,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "engine.io": {
@@ -4192,12 +4212,12 @@
       "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
       "dev": true,
       "requires": {
-        "accepts": "1.3.7",
+        "accepts": "~1.3.4",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "3.1.0",
-        "engine.io-parser": "2.1.3",
-        "ws": "3.3.3"
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.0",
+        "ws": "~3.3.1"
       },
       "dependencies": {
         "debug": {
@@ -4221,9 +4241,9 @@
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "dev": true,
           "requires": {
-            "async-limiter": "1.0.0",
-            "safe-buffer": "5.1.2",
-            "ultron": "1.1.1"
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
           }
         }
       }
@@ -4236,14 +4256,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "3.1.0",
-        "engine.io-parser": "2.1.3",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.1",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "3.3.3",
-        "xmlhttprequest-ssl": "1.5.5",
+        "ws": "~3.3.1",
+        "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -4274,9 +4294,9 @@
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "dev": true,
           "requires": {
-            "async-limiter": "1.0.0",
-            "safe-buffer": "5.1.2",
-            "ultron": "1.1.1"
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
           }
         }
       }
@@ -4288,10 +4308,10 @@
       "dev": true,
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "0.0.7",
+        "arraybuffer.slice": "~0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.5",
-        "has-binary2": "1.0.3"
+        "has-binary2": "~1.0.2"
       }
     },
     "enhanced-resolve": {
@@ -4300,9 +4320,9 @@
       "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "tapable": "1.1.3"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "tapable": "^1.0.0"
       }
     },
     "ent": {
@@ -4323,7 +4343,7 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -4332,7 +4352,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es5-ext": {
@@ -4341,9 +4361,9 @@
       "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "next-tick": "1.0.0"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "^1.0.0"
       }
     },
     "es6-iterator": {
@@ -4352,9 +4372,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.50",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-promise": {
@@ -4369,7 +4389,7 @@
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.2.4"
+        "es6-promise": "^4.0.3"
       }
     },
     "es6-symbol": {
@@ -4378,8 +4398,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.50"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "escape-html": {
@@ -4400,8 +4420,8 @@
       "integrity": "sha512-CStQYJgALoQBw3FsBzH0VOVDRnJ/ZimUlpLm226U8qgqYJfPOY/CPK6wyRInMxh73HSKg5wyRwdS4BVYYHwokA==",
       "dev": true,
       "requires": {
-        "fast-diff": "1.2.0",
-        "jest-docblock": "21.2.0"
+        "fast-diff": "^1.1.1",
+        "jest-docblock": "^21.0.0"
       }
     },
     "eslint-scope": {
@@ -4410,8 +4430,8 @@
       "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "esprima": {
@@ -4426,7 +4446,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -4465,7 +4485,7 @@
       "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
       "dev": true,
       "requires": {
-        "original": "1.0.2"
+        "original": "^1.0.0"
       }
     },
     "evp_bytestokey": {
@@ -4474,8 +4494,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.5",
-        "safe-buffer": "5.1.2"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "execa": {
@@ -4484,13 +4504,13 @@
       "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
       "dev": true,
       "requires": {
-        "cross-spawn": "6.0.5",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -4499,11 +4519,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "1.0.5",
-            "path-key": "2.0.1",
-            "semver": "5.5.1",
-            "shebang-command": "1.2.0",
-            "which": "1.3.1"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         }
       }
@@ -4520,13 +4540,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "posix-character-classes": "0.1.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -4535,7 +4555,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -4544,7 +4564,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -4555,7 +4575,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.4"
+        "fill-range": "^2.1.0"
       },
       "dependencies": {
         "fill-range": {
@@ -4564,11 +4584,11 @@
           "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "3.1.0",
-            "repeat-element": "1.1.3",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "is-number": {
@@ -4577,7 +4597,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "isobject": {
@@ -4595,7 +4615,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4606,36 +4626,36 @@
       "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
       "dev": true,
       "requires": {
-        "accepts": "1.3.7",
+        "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.3",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.5",
+        "proxy-addr": "~2.0.4",
         "qs": "6.5.2",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.2",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0",
-        "type-is": "1.6.18",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "array-flatten": {
@@ -4658,8 +4678,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "1.0.0",
-        "is-extendable": "1.0.1"
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -4668,7 +4688,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -4679,9 +4699,9 @@
       "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "dev": true,
       "requires": {
-        "chardet": "0.7.0",
-        "iconv-lite": "0.4.24",
-        "tmp": "0.0.33"
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
       },
       "dependencies": {
         "iconv-lite": {
@@ -4690,7 +4710,7 @@
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         }
       }
@@ -4701,14 +4721,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "expand-brackets": "2.1.4",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -4717,7 +4737,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "extend-shallow": {
@@ -4726,7 +4746,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "is-accessor-descriptor": {
@@ -4735,7 +4755,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -4744,7 +4764,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -4753,9 +4773,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -4796,7 +4816,7 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
-        "websocket-driver": "0.7.0"
+        "websocket-driver": ">=0.5.1"
       }
     },
     "figgy-pudding": {
@@ -4811,7 +4831,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-loader": {
@@ -4820,8 +4840,8 @@
       "integrity": "sha512-4sNIOXgtH/9WZq4NvlfU3Opn5ynUsqBwSLyM+I7UOwdGigTBYfVVQEwe/msZNX/j4pCJTIM14Fsw66Svo1oVrw==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "schema-utils": "1.0.0"
+        "loader-utils": "^1.0.2",
+        "schema-utils": "^1.0.0"
       }
     },
     "filename-regex": {
@@ -4836,8 +4856,8 @@
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
       "dev": true,
       "requires": {
-        "glob": "7.1.3",
-        "minimatch": "3.0.4"
+        "glob": "^7.0.3",
+        "minimatch": "^3.0.3"
       }
     },
     "filesize": {
@@ -4852,10 +4872,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1",
-        "to-regex-range": "2.1.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -4864,7 +4884,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -4876,12 +4896,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.3",
-        "statuses": "1.4.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
       }
     },
     "find-cache-dir": {
@@ -4890,9 +4910,9 @@
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "dev": true,
       "requires": {
-        "commondir": "1.0.1",
-        "make-dir": "1.3.0",
-        "pkg-dir": "2.0.0"
+        "commondir": "^1.0.1",
+        "make-dir": "^1.0.0",
+        "pkg-dir": "^2.0.0"
       }
     },
     "find-index": {
@@ -4907,7 +4927,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flatted": {
@@ -4922,8 +4942,8 @@
       "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
       }
     },
     "follow-redirects": {
@@ -4932,7 +4952,7 @@
       "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
       "dev": true,
       "requires": {
-        "debug": "3.2.6"
+        "debug": "^3.2.6"
       },
       "dependencies": {
         "debug": {
@@ -4941,7 +4961,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -4964,7 +4984,7 @@
       "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "forever-agent": {
@@ -4973,15 +4993,39 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
+    "fork-ts-checker-webpack-plugin": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.3.0.tgz",
+      "integrity": "sha512-38nL1h4nRLrU/0oCAvjQY7ZJw0JpcsOOwSMZQSaMdVi2d+vXNcyvVg/n6q4mRcvGmVW2z2EIlj5ufaITk0M5bA==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.4.1",
+        "chokidar": "^2.0.4",
+        "micromatch": "^3.1.10",
+        "minimatch": "^3.0.4",
+        "semver": "^5.6.0",
+        "tapable": "^1.0.0",
+        "worker-rpc": "^0.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
+      }
+    },
     "form-data": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.20"
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -4996,7 +5040,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "0.2.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fresh": {
@@ -5011,8 +5055,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs-access": {
@@ -5021,7 +5065,7 @@
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
-        "null-check": "1.0.0"
+        "null-check": "^1.0.0"
       }
     },
     "fs-extra": {
@@ -5030,9 +5074,9 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs-minipass": {
@@ -5041,7 +5085,7 @@
       "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
       "dev": true,
       "requires": {
-        "minipass": "2.3.5"
+        "minipass": "^2.2.1"
       }
     },
     "fs-write-stream-atomic": {
@@ -5050,10 +5094,10 @@
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "2.3.6"
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
       }
     },
     "fs.realpath": {
@@ -5069,8 +5113,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.11.0",
-        "node-pre-gyp": "0.10.0"
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -5084,8 +5128,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5109,15 +5152,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5127,22 +5168,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5263,8 +5301,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5278,7 +5315,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5295,7 +5331,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5343,16 +5378,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.8"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -5401,8 +5436,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5416,7 +5450,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5512,8 +5545,7 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5555,7 +5587,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5577,7 +5608,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5610,8 +5640,7 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5621,10 +5650,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "gauge": {
@@ -5633,14 +5662,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.3"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "gaze": {
@@ -5649,7 +5678,7 @@
       "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
       "dev": true,
       "requires": {
-        "globule": "1.2.1"
+        "globule": "^1.0.0"
       }
     },
     "genfun": {
@@ -5688,7 +5717,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -5697,12 +5726,12 @@
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -5711,8 +5740,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "glob-parent": {
@@ -5721,7 +5750,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           }
         },
         "is-extglob": {
@@ -5736,7 +5765,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -5747,8 +5776,8 @@
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
-        "is-glob": "3.1.0",
-        "path-dirname": "1.0.2"
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
       },
       "dependencies": {
         "is-glob": {
@@ -5757,7 +5786,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         }
       }
@@ -5768,7 +5797,7 @@
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
       "dev": true,
       "requires": {
-        "find-index": "0.1.1"
+        "find-index": "^0.1.1"
       }
     },
     "global-modules-path": {
@@ -5789,12 +5818,12 @@
       "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "dir-glob": "2.2.2",
-        "glob": "7.1.3",
-        "ignore": "3.3.10",
-        "pify": "3.0.0",
-        "slash": "1.0.0"
+        "array-union": "^1.0.1",
+        "dir-glob": "^2.0.0",
+        "glob": "^7.1.2",
+        "ignore": "^3.3.5",
+        "pify": "^3.0.0",
+        "slash": "^1.0.0"
       }
     },
     "globule": {
@@ -5803,9 +5832,9 @@
       "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
       "dev": true,
       "requires": {
-        "glob": "7.1.3",
-        "lodash": "4.17.11",
-        "minimatch": "3.0.4"
+        "glob": "~7.1.1",
+        "lodash": "~4.17.10",
+        "minimatch": "~3.0.2"
       }
     },
     "gonzales-pe": {
@@ -5814,7 +5843,7 @@
       "integrity": "sha512-Kjhohco0esHQnOiqqdJeNz/5fyPkOMD/d6XVjwTAoPGUFh0mCollPUTUTa2OZy4dYNAqlPIQdTiNzJTWdd9Htw==",
       "dev": true,
       "requires": {
-        "minimist": "1.1.3"
+        "minimist": "1.1.x"
       },
       "dependencies": {
         "minimist": {
@@ -5831,7 +5860,7 @@
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "optional": true,
       "requires": {
-        "delegate": "3.2.0"
+        "delegate": "^3.1.2"
       }
     },
     "graceful-fs": {
@@ -5847,13 +5876,13 @@
       "dev": true
     },
     "gzip-size": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.0.tgz",
-      "integrity": "sha512-wfSnvypBDRW94v5W3ckvvz/zFUNdJ81VgOP6tE4bPpRUcc0wGqU+y0eZjJEvKxwubJFix6P84sE8M51YWLT7rQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
+      "integrity": "sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==",
       "dev": true,
       "requires": {
-        "duplexer": "0.1.1",
-        "pify": "4.0.1"
+        "duplexer": "^0.1.1",
+        "pify": "^4.0.1"
       },
       "dependencies": {
         "pify": {
@@ -5882,8 +5911,8 @@
       "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.3.0",
+        "har-schema": "^2.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -5892,10 +5921,10 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         }
       }
@@ -5906,7 +5935,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-binary2": {
@@ -5950,9 +5979,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
       }
     },
     "has-values": {
@@ -5961,8 +5990,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -5971,7 +6000,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -5982,8 +6011,8 @@
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "hash.js": {
@@ -5992,8 +6021,8 @@
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
       }
     },
     "highcharts": {
@@ -6007,9 +6036,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.7",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoopy": {
@@ -6030,10 +6059,10 @@
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "obuf": "1.1.2",
-        "readable-stream": "2.3.6",
-        "wbuf": "1.7.3"
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
       }
     },
     "html-entities": {
@@ -6060,10 +6089,10 @@
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-parser-js": {
@@ -6078,9 +6107,9 @@
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "dev": true,
       "requires": {
-        "eventemitter3": "3.1.2",
-        "follow-redirects": "1.7.0",
-        "requires-port": "1.0.0"
+        "eventemitter3": "^3.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
       }
     },
     "http-proxy-agent": {
@@ -6089,7 +6118,7 @@
       "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.1",
+        "agent-base": "4",
         "debug": "3.1.0"
       },
       "dependencies": {
@@ -6110,10 +6139,10 @@
       "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
       "dev": true,
       "requires": {
-        "http-proxy": "1.17.0",
-        "is-glob": "4.0.1",
-        "lodash": "4.17.11",
-        "micromatch": "3.1.10"
+        "http-proxy": "^1.16.2",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.5",
+        "micromatch": "^3.1.9"
       }
     },
     "http-signature": {
@@ -6122,9 +6151,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -6139,8 +6168,8 @@
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.1",
-        "debug": "3.1.0"
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -6160,7 +6189,7 @@
       "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.0.0"
       }
     },
     "iconv-lite": {
@@ -6169,7 +6198,7 @@
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "icss-replace-symbols": {
@@ -6179,31 +6208,12 @@
       "dev": true
     },
     "icss-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
-      "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
+      "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.23"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.4.1",
-            "source-map": "0.6.1",
-            "supports-color": "5.5.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
+        "postcss": "^7.0.14"
       }
     },
     "ieee754": {
@@ -6230,7 +6240,7 @@
       "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "dev": true,
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.4"
       }
     },
     "image-size": {
@@ -6252,7 +6262,7 @@
       "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
       "dev": true,
       "requires": {
-        "import-from": "2.1.0"
+        "import-from": "^2.1.0"
       }
     },
     "import-from": {
@@ -6261,7 +6271,7 @@
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       }
     },
     "import-local": {
@@ -6270,8 +6280,8 @@
       "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "3.0.0",
-        "resolve-cwd": "2.0.0"
+        "pkg-dir": "^3.0.0",
+        "resolve-cwd": "^2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -6280,7 +6290,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "3.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "locate-path": {
@@ -6289,8 +6299,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "3.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "p-limit": {
@@ -6299,7 +6309,7 @@
           "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "dev": true,
           "requires": {
-            "p-try": "2.2.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
@@ -6308,7 +6318,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "2.2.0"
+            "p-limit": "^2.0.0"
           }
         },
         "p-try": {
@@ -6323,7 +6333,7 @@
           "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "dev": true,
           "requires": {
-            "find-up": "3.0.0"
+            "find-up": "^3.0.0"
           }
         }
       }
@@ -6346,8 +6356,14 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
     },
     "indexof": {
       "version": "0.0.1",
@@ -6361,8 +6377,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -6383,19 +6399,19 @@
       "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.2.0",
-        "chalk": "2.4.1",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "3.0.3",
-        "figures": "2.0.0",
-        "lodash": "4.17.11",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.0",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.10",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rxjs": "6.3.3",
-        "string-width": "2.1.1",
-        "strip-ansi": "5.2.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rxjs": "^6.1.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6416,8 +6432,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "strip-ansi": {
@@ -6426,7 +6442,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -6437,7 +6453,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "4.1.0"
+            "ansi-regex": "^4.1.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -6456,8 +6472,8 @@
       "integrity": "sha512-NXXgESC2nNVtU+pqmC9e6R8B1GpKxzsAQhffvh5AL79qKnodd+L7tnEQmTiUAVngqLalPbSqRA7XGIEL5nCd0Q==",
       "dev": true,
       "requires": {
-        "default-gateway": "2.7.2",
-        "ipaddr.js": "1.9.0"
+        "default-gateway": "^2.6.0",
+        "ipaddr.js": "^1.5.2"
       }
     },
     "interpret": {
@@ -6472,7 +6488,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.4.0"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -6510,7 +6526,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6519,7 +6535,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6536,7 +6552,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -6551,7 +6567,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6560,7 +6576,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6571,9 +6587,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "0.1.6",
-        "is-data-descriptor": "0.1.4",
-        "kind-of": "5.1.0"
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -6608,7 +6624,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -6629,7 +6645,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -6638,7 +6654,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-glob": {
@@ -6647,7 +6663,7 @@
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
       "requires": {
-        "is-extglob": "2.1.1"
+        "is-extglob": "^2.1.1"
       }
     },
     "is-number": {
@@ -6656,7 +6672,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -6665,7 +6681,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -6682,7 +6698,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -6691,7 +6707,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-object": {
@@ -6700,7 +6716,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-posix-bracket": {
@@ -6763,7 +6779,7 @@
       "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
       "dev": true,
       "requires": {
-        "buffer-alloc": "1.2.0"
+        "buffer-alloc": "^1.2.0"
       }
     },
     "isexe": {
@@ -6790,19 +6806,19 @@
       "integrity": "sha512-LYTOa2UrYFyJ/aSczZi/6lBykVMjCCvUmT64gOe+jPZFy4w6FYfPGqFT2IiQ2BxVHHDOvCD7qrIXb0EOh4uGWw==",
       "dev": true,
       "requires": {
-        "async": "2.6.2",
-        "compare-versions": "3.4.0",
-        "fileset": "2.0.3",
-        "istanbul-lib-coverage": "2.0.5",
-        "istanbul-lib-hook": "2.0.7",
-        "istanbul-lib-instrument": "3.3.0",
-        "istanbul-lib-report": "2.0.8",
-        "istanbul-lib-source-maps": "3.0.6",
-        "istanbul-reports": "2.2.5",
-        "js-yaml": "3.13.1",
-        "make-dir": "2.1.0",
-        "minimatch": "3.0.4",
-        "once": "1.4.0"
+        "async": "^2.6.2",
+        "compare-versions": "^3.4.0",
+        "fileset": "^2.0.3",
+        "istanbul-lib-coverage": "^2.0.5",
+        "istanbul-lib-hook": "^2.0.7",
+        "istanbul-lib-instrument": "^3.3.0",
+        "istanbul-lib-report": "^2.0.8",
+        "istanbul-lib-source-maps": "^3.0.6",
+        "istanbul-reports": "^2.2.5",
+        "js-yaml": "^3.13.1",
+        "make-dir": "^2.1.0",
+        "minimatch": "^3.0.4",
+        "once": "^1.4.0"
       },
       "dependencies": {
         "@babel/generator": {
@@ -6811,11 +6827,11 @@
           "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
           "dev": true,
           "requires": {
-            "@babel/types": "7.4.4",
-            "jsesc": "2.5.2",
-            "lodash": "4.17.11",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
+            "@babel/types": "^7.4.4",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
           }
         },
         "@babel/parser": {
@@ -6830,9 +6846,9 @@
           "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "7.0.0",
-            "@babel/parser": "7.4.4",
-            "@babel/types": "7.4.4"
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.4.4",
+            "@babel/types": "^7.4.4"
           }
         },
         "@babel/types": {
@@ -6841,9 +6857,9 @@
           "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "lodash": "4.17.11",
-            "to-fast-properties": "2.0.0"
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
           }
         },
         "debug": {
@@ -6852,7 +6868,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "handlebars": {
@@ -6861,10 +6877,10 @@
           "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
           "dev": true,
           "requires": {
-            "neo-async": "2.6.0",
-            "optimist": "0.6.1",
-            "source-map": "0.6.1",
-            "uglify-js": "3.4.9"
+            "neo-async": "^2.6.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
           },
           "dependencies": {
             "source-map": {
@@ -6887,7 +6903,7 @@
           "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
           "dev": true,
           "requires": {
-            "append-transform": "1.0.0"
+            "append-transform": "^1.0.0"
           }
         },
         "istanbul-lib-instrument": {
@@ -6896,13 +6912,13 @@
           "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
           "dev": true,
           "requires": {
-            "@babel/generator": "7.4.4",
-            "@babel/parser": "7.4.4",
-            "@babel/template": "7.4.4",
-            "@babel/traverse": "7.4.4",
-            "@babel/types": "7.4.4",
-            "istanbul-lib-coverage": "2.0.5",
-            "semver": "6.0.0"
+            "@babel/generator": "^7.4.0",
+            "@babel/parser": "^7.4.3",
+            "@babel/template": "^7.4.0",
+            "@babel/traverse": "^7.4.3",
+            "@babel/types": "^7.4.0",
+            "istanbul-lib-coverage": "^2.0.5",
+            "semver": "^6.0.0"
           }
         },
         "istanbul-lib-report": {
@@ -6911,9 +6927,9 @@
           "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "2.0.5",
-            "make-dir": "2.1.0",
-            "supports-color": "6.1.0"
+            "istanbul-lib-coverage": "^2.0.5",
+            "make-dir": "^2.1.0",
+            "supports-color": "^6.1.0"
           }
         },
         "istanbul-lib-source-maps": {
@@ -6922,11 +6938,11 @@
           "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
           "dev": true,
           "requires": {
-            "debug": "4.1.1",
-            "istanbul-lib-coverage": "2.0.5",
-            "make-dir": "2.1.0",
-            "rimraf": "2.6.3",
-            "source-map": "0.6.1"
+            "debug": "^4.1.1",
+            "istanbul-lib-coverage": "^2.0.5",
+            "make-dir": "^2.1.0",
+            "rimraf": "^2.6.3",
+            "source-map": "^0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -6943,7 +6959,7 @@
           "integrity": "sha512-ilCSjE6f7elNIRxnSnIhnOpXdf3ryUT7Zkl+TaADItM638SWXjfNW40cujZCIjex4g4DTkzIy9kzwkaLruB50Q==",
           "dev": true,
           "requires": {
-            "handlebars": "4.1.2"
+            "handlebars": "^4.1.2"
           }
         },
         "jsesc": {
@@ -6964,8 +6980,8 @@
           "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
           "dev": true,
           "requires": {
-            "pify": "4.0.1",
-            "semver": "5.7.0"
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
           },
           "dependencies": {
             "semver": {
@@ -6994,7 +7010,7 @@
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
-            "glob": "7.1.3"
+            "glob": "^7.1.3"
           }
         },
         "semver": {
@@ -7009,7 +7025,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "to-fast-properties": {
@@ -7026,10 +7042,10 @@
       "integrity": "sha512-a5SPObZgS0jB/ixaKSMdn6n/gXSrK2S6q/UfRJBT3e6gQmVjwZROTODQsYW5ZNwOu78hG62Y3fWlebaVOL0C+w==",
       "dev": true,
       "requires": {
-        "convert-source-map": "1.6.0",
-        "istanbul-lib-instrument": "1.10.2",
-        "loader-utils": "1.1.0",
-        "schema-utils": "0.3.0"
+        "convert-source-map": "^1.5.0",
+        "istanbul-lib-instrument": "^1.7.3",
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^0.3.0"
       },
       "dependencies": {
         "ajv": {
@@ -7038,10 +7054,10 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         },
         "schema-utils": {
@@ -7050,7 +7066,7 @@
           "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
           "dev": true,
           "requires": {
-            "ajv": "5.5.2"
+            "ajv": "^5.0.0"
           }
         }
       }
@@ -7067,13 +7083,13 @@
       "integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
       "dev": true,
       "requires": {
-        "babel-generator": "6.26.1",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.2.1",
-        "semver": "5.5.1"
+        "babel-generator": "^6.18.0",
+        "babel-template": "^6.16.0",
+        "babel-traverse": "^6.18.0",
+        "babel-types": "^6.18.0",
+        "babylon": "^6.18.0",
+        "istanbul-lib-coverage": "^1.2.1",
+        "semver": "^5.3.0"
       }
     },
     "jasmine": {
@@ -7082,9 +7098,9 @@
       "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
       "dev": true,
       "requires": {
-        "exit": "0.1.2",
-        "glob": "7.1.3",
-        "jasmine-core": "2.8.0"
+        "exit": "^0.1.2",
+        "glob": "^7.0.6",
+        "jasmine-core": "~2.8.0"
       },
       "dependencies": {
         "jasmine-core": {
@@ -7146,8 +7162,8 @@
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -7205,7 +7221,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -7238,11 +7254,11 @@
       "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
       "dev": true,
       "requires": {
-        "core-js": "2.3.0",
-        "es6-promise": "3.0.2",
-        "lie": "3.1.1",
-        "pako": "1.0.6",
-        "readable-stream": "2.0.6"
+        "core-js": "~2.3.0",
+        "es6-promise": "~3.0.2",
+        "lie": "~3.1.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.0.6"
       },
       "dependencies": {
         "core-js": {
@@ -7269,12 +7285,12 @@
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -7291,31 +7307,31 @@
       "integrity": "sha512-xckiDqyNi512U4dXGOOSyLKPwek6X/vUizSy2f3geYevbLj+UIdvNwbn7IwfUIL2g1GXEPWt/87qFD1fBbl/Uw==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.2",
-        "body-parser": "1.18.3",
-        "braces": "2.3.2",
-        "chokidar": "2.0.4",
-        "colors": "1.1.2",
-        "connect": "3.6.6",
-        "core-js": "2.5.7",
-        "di": "0.0.1",
-        "dom-serialize": "2.2.1",
-        "flatted": "2.0.0",
-        "glob": "7.1.3",
-        "graceful-fs": "4.1.11",
-        "http-proxy": "1.17.0",
-        "isbinaryfile": "3.0.3",
-        "lodash": "4.17.11",
-        "log4js": "4.1.1",
-        "mime": "2.4.2",
-        "minimatch": "3.0.4",
-        "optimist": "0.6.1",
-        "qjobs": "1.2.0",
-        "range-parser": "1.2.0",
-        "rimraf": "2.6.2",
-        "safe-buffer": "5.1.2",
+        "bluebird": "^3.3.0",
+        "body-parser": "^1.16.1",
+        "braces": "^2.3.2",
+        "chokidar": "^2.0.3",
+        "colors": "^1.1.0",
+        "connect": "^3.6.0",
+        "core-js": "^2.2.0",
+        "di": "^0.0.1",
+        "dom-serialize": "^2.2.0",
+        "flatted": "^2.0.0",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.2",
+        "http-proxy": "^1.13.0",
+        "isbinaryfile": "^3.0.0",
+        "lodash": "^4.17.11",
+        "log4js": "^4.0.0",
+        "mime": "^2.3.1",
+        "minimatch": "^3.0.2",
+        "optimist": "^0.6.1",
+        "qjobs": "^1.1.4",
+        "range-parser": "^1.2.0",
+        "rimraf": "^2.6.0",
+        "safe-buffer": "^5.0.1",
         "socket.io": "2.1.1",
-        "source-map": "0.6.1",
+        "source-map": "^0.6.1",
         "tmp": "0.0.33",
         "useragent": "2.3.0"
       },
@@ -7346,8 +7362,8 @@
       "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
       "dev": true,
       "requires": {
-        "fs-access": "1.0.1",
-        "which": "1.3.1"
+        "fs-access": "^1.0.0",
+        "which": "^1.2.1"
       }
     },
     "karma-coverage-istanbul-reporter": {
@@ -7356,8 +7372,8 @@
       "integrity": "sha512-xJS7QSQIVU6VK9HuJ/ieE5yynxKhjCCkd96NLY/BX/HXsx0CskU9JJiMQbd4cHALiddMwI4OWh1IIzeWrsavJw==",
       "dev": true,
       "requires": {
-        "istanbul-api": "2.1.7",
-        "minimatch": "3.0.4"
+        "istanbul-api": "^2.0.5",
+        "minimatch": "^3.0.4"
       }
     },
     "karma-jasmine": {
@@ -7372,7 +7388,7 @@
       "integrity": "sha1-SKjl7xiAdhfuK14zwRlMNbQ5Ukw=",
       "dev": true,
       "requires": {
-        "karma-jasmine": "1.1.2"
+        "karma-jasmine": "^1.0.2"
       }
     },
     "karma-junit-reporter": {
@@ -7381,7 +7397,7 @@
       "integrity": "sha1-T5xAzt+xo5X4rvh2q/lhiZF8Y5Y=",
       "dev": true,
       "requires": {
-        "path-is-absolute": "1.0.1",
+        "path-is-absolute": "^1.0.0",
         "xmlbuilder": "8.2.2"
       },
       "dependencies": {
@@ -7399,7 +7415,7 @@
       "integrity": "sha512-HcPqdAusNez/ywa+biN4EphGz62MmQyPggUsDfsHqa7tSe4jdsxgvTKuDfIazjL+IOxpVWyT7Pr4dhAV+sxX5Q==",
       "dev": true,
       "requires": {
-        "source-map-support": "0.5.9"
+        "source-map-support": "^0.5.5"
       }
     },
     "karma-spec-reporter": {
@@ -7408,7 +7424,7 @@
       "integrity": "sha1-LpxyB+pyZ3EmAln4K+y1QyCeRAo=",
       "dev": true,
       "requires": {
-        "colors": "1.1.2"
+        "colors": "^1.1.2"
       }
     },
     "killable": {
@@ -7429,7 +7445,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "lcov-parse": {
@@ -7444,15 +7460,15 @@
       "integrity": "sha512-31CmtPEZraNUtuUREYjSqRkeETFdyEHSEPAGq4erDlUXtda7pzNmctdljdIagSb589d/qXGWiiP31R5JVf+v0w==",
       "dev": true,
       "requires": {
-        "clone": "2.1.2",
-        "errno": "0.1.7",
-        "graceful-fs": "4.1.11",
-        "image-size": "0.5.5",
-        "mime": "1.6.0",
-        "mkdirp": "0.5.1",
-        "promise": "7.3.1",
-        "request": "2.88.0",
-        "source-map": "0.6.1"
+        "clone": "^2.1.2",
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
+        "image-size": "~0.5.0",
+        "mime": "^1.4.1",
+        "mkdirp": "^0.5.0",
+        "promise": "^7.1.1",
+        "request": "^2.83.0",
+        "source-map": "~0.6.0"
       },
       "dependencies": {
         "source-map": {
@@ -7470,9 +7486,9 @@
       "integrity": "sha512-KNTsgCE9tMOM70+ddxp9yyt9iHqgmSs0yTZc5XH5Wo+g80RWRIYNqE58QJKm/yMud5wZEvz50ugRDuzVIkyahg==",
       "dev": true,
       "requires": {
-        "clone": "2.1.2",
-        "loader-utils": "1.1.0",
-        "pify": "3.0.0"
+        "clone": "^2.1.1",
+        "loader-utils": "^1.1.0",
+        "pify": "^3.0.0"
       }
     },
     "license-webpack-plugin": {
@@ -7481,8 +7497,8 @@
       "integrity": "sha512-vDiBeMWxjE9n6TabQ9J4FH8urFdsRK0Nvxn1cit9biCiR9aq1zBR0X2BlAkEiIG6qPamLeU0GzvIgLkrFc398A==",
       "dev": true,
       "requires": {
-        "@types/webpack-sources": "0.1.5",
-        "webpack-sources": "1.3.0"
+        "@types/webpack-sources": "^0.1.5",
+        "webpack-sources": "^1.2.0"
       }
     },
     "lie": {
@@ -7491,7 +7507,7 @@
       "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
       "dev": true,
       "requires": {
-        "immediate": "3.0.6"
+        "immediate": "~3.0.5"
       }
     },
     "lines-and-columns": {
@@ -7506,11 +7522,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -7533,9 +7549,9 @@
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "dev": true,
       "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1"
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
       }
     },
     "locate-path": {
@@ -7544,8 +7560,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -7584,11 +7600,11 @@
       "integrity": "sha512-tSQUF9bBMdcBtuLD6vD7hBM9Ci6Lng/NVHZEq4YbuRGo7ObmLiZuhxz33HKAmJItit74pAjvZgirqYX2LRaoGA==",
       "dev": true,
       "requires": {
-        "date-format": "2.0.0",
-        "debug": "4.1.1",
-        "flatted": "2.0.0",
-        "rfdc": "1.1.2",
-        "streamroller": "1.0.4"
+        "date-format": "^2.0.0",
+        "debug": "^4.1.1",
+        "flatted": "^2.0.0",
+        "rfdc": "^1.1.2",
+        "streamroller": "^1.0.4"
       },
       "dependencies": {
         "debug": {
@@ -7597,7 +7613,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -7620,7 +7636,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
     "loud-rejection": {
@@ -7629,8 +7645,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lru-cache": {
@@ -7639,8 +7655,8 @@
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       },
       "dependencies": {
         "yallist": {
@@ -7657,7 +7673,7 @@
       "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
       "dev": true,
       "requires": {
-        "sourcemap-codec": "1.4.4"
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
@@ -7666,7 +7682,7 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "make-error": {
@@ -7681,17 +7697,17 @@
       "integrity": "sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==",
       "dev": true,
       "requires": {
-        "agentkeepalive": "3.5.2",
-        "cacache": "11.3.2",
-        "http-cache-semantics": "3.8.1",
-        "http-proxy-agent": "2.1.0",
-        "https-proxy-agent": "2.2.1",
-        "lru-cache": "4.1.5",
-        "mississippi": "3.0.0",
-        "node-fetch-npm": "2.0.2",
-        "promise-retry": "1.1.1",
-        "socks-proxy-agent": "4.0.2",
-        "ssri": "6.0.1"
+        "agentkeepalive": "^3.4.1",
+        "cacache": "^11.0.1",
+        "http-cache-semantics": "^3.8.1",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1",
+        "lru-cache": "^4.1.2",
+        "mississippi": "^3.0.0",
+        "node-fetch-npm": "^2.0.2",
+        "promise-retry": "^1.1.1",
+        "socks-proxy-agent": "^4.0.0",
+        "ssri": "^6.0.0"
       },
       "dependencies": {
         "bluebird": {
@@ -7706,20 +7722,20 @@
           "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
           "dev": true,
           "requires": {
-            "bluebird": "3.5.4",
-            "chownr": "1.1.1",
-            "figgy-pudding": "3.5.1",
-            "glob": "7.1.3",
-            "graceful-fs": "4.1.15",
-            "lru-cache": "5.1.1",
-            "mississippi": "3.0.0",
-            "mkdirp": "0.5.1",
-            "move-concurrently": "1.0.1",
-            "promise-inflight": "1.0.1",
-            "rimraf": "2.6.2",
-            "ssri": "6.0.1",
-            "unique-filename": "1.1.1",
-            "y18n": "4.0.0"
+            "bluebird": "^3.5.3",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.1.15",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
+            "y18n": "^4.0.0"
           },
           "dependencies": {
             "lru-cache": {
@@ -7728,7 +7744,7 @@
               "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
               "dev": true,
               "requires": {
-                "yallist": "3.0.3"
+                "yallist": "^3.0.2"
               }
             }
           }
@@ -7745,16 +7761,16 @@
           "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
           "dev": true,
           "requires": {
-            "concat-stream": "1.6.2",
-            "duplexify": "3.7.1",
-            "end-of-stream": "1.4.1",
-            "flush-write-stream": "1.1.1",
-            "from2": "2.3.0",
-            "parallel-transform": "1.1.0",
-            "pump": "3.0.0",
-            "pumpify": "1.5.1",
-            "stream-each": "1.2.3",
-            "through2": "2.0.5"
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
           }
         },
         "pump": {
@@ -7763,8 +7779,8 @@
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "ssri": {
@@ -7773,7 +7789,7 @@
           "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "dev": true,
           "requires": {
-            "figgy-pudding": "3.5.1"
+            "figgy-pudding": "^3.5.1"
           }
         }
       }
@@ -7784,7 +7800,7 @@
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "dev": true,
       "requires": {
-        "p-defer": "1.0.0"
+        "p-defer": "^1.0.0"
       }
     },
     "map-cache": {
@@ -7805,7 +7821,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "1.0.1"
+        "object-visit": "^1.0.0"
       }
     },
     "math-random": {
@@ -7820,9 +7836,9 @@
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "media-typer": {
@@ -7837,9 +7853,9 @@
       "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
       "dev": true,
       "requires": {
-        "map-age-cleaner": "0.1.3",
-        "mimic-fn": "2.1.0",
-        "p-is-promise": "2.1.0"
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
       }
     },
     "memory-fs": {
@@ -7848,8 +7864,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.7",
-        "readable-stream": "2.3.6"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       }
     },
     "meow": {
@@ -7858,16 +7874,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.5.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -7890,25 +7906,31 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
+    "microevent.ts": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.1.1.tgz",
+      "integrity": "sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==",
+      "dev": true
+    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "braces": "2.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "extglob": "2.0.4",
-        "fragment-cache": "0.2.1",
-        "kind-of": "6.0.2",
-        "nanomatch": "1.2.13",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "miller-rabin": {
@@ -7917,8 +7939,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime": {
@@ -7940,7 +7962,7 @@
       "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
       "dev": true,
       "requires": {
-        "mime-db": "1.36.0"
+        "mime-db": "~1.36.0"
       }
     },
     "mimic-fn": {
@@ -7955,9 +7977,9 @@
       "integrity": "sha512-IuaLjruM0vMKhUUT51fQdQzBYTX49dLj8w68ALEAe2A4iYNpIC4eMac67mt3NzycvjOlf07/kYxJDc0RTl1Wqw==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "schema-utils": "1.0.0",
-        "webpack-sources": "1.3.0"
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^1.0.0",
+        "webpack-sources": "^1.1.0"
       }
     },
     "minimalistic-assert": {
@@ -7978,7 +8000,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -7993,8 +8015,8 @@
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2",
-        "yallist": "3.0.3"
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
       }
     },
     "minizlib": {
@@ -8003,7 +8025,7 @@
       "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
       "dev": true,
       "requires": {
-        "minipass": "2.3.5"
+        "minipass": "^2.2.1"
       }
     },
     "mississippi": {
@@ -8012,16 +8034,16 @@
       "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.2",
-        "duplexify": "3.7.1",
-        "end-of-stream": "1.4.1",
-        "flush-write-stream": "1.1.1",
-        "from2": "2.3.0",
-        "parallel-transform": "1.1.0",
-        "pump": "2.0.1",
-        "pumpify": "1.5.1",
-        "stream-each": "1.2.3",
-        "through2": "2.0.5"
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^2.0.1",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
       }
     },
     "mixin-deep": {
@@ -8030,8 +8052,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -8040,7 +8062,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "2.0.4"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -8051,8 +8073,8 @@
       "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
       "dev": true,
       "requires": {
-        "for-in": "0.1.8",
-        "is-extendable": "0.1.1"
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
       },
       "dependencies": {
         "for-in": {
@@ -8078,12 +8100,12 @@
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "copy-concurrently": "1.0.5",
-        "fs-write-stream-atomic": "1.0.10",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
       }
     },
     "ms": {
@@ -8098,8 +8120,8 @@
       "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
       "dev": true,
       "requires": {
-        "dns-packet": "1.3.1",
-        "thunky": "1.0.3"
+        "dns-packet": "^1.3.1",
+        "thunky": "^1.0.2"
       }
     },
     "multicast-dns-service-types": {
@@ -8127,17 +8149,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "fragment-cache": "0.2.1",
-        "is-windows": "1.0.2",
-        "kind-of": "6.0.2",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.2",
-        "snapdragon": "0.8.2",
-        "to-regex": "3.0.2"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       }
     },
     "nativescript": {
@@ -8228,8 +8250,8 @@
           "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
           "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
           "requires": {
-            "@sinonjs/commons": "1.4.0",
-            "@sinonjs/samsam": "3.3.1"
+            "@sinonjs/commons": "^1",
+            "@sinonjs/samsam": "^3.1.0"
           }
         },
         "@sinonjs/samsam": {
@@ -8237,9 +8259,9 @@
           "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
           "integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
           "requires": {
-            "@sinonjs/commons": "1.4.0",
-            "array-from": "2.1.1",
-            "lodash": "4.17.11"
+            "@sinonjs/commons": "^1.0.2",
+            "array-from": "^2.1.1",
+            "lodash": "^4.17.11"
           }
         },
         "@sinonjs/text-encoding": {
@@ -8253,7 +8275,7 @@
           "integrity": "sha1-7CMA++fX3d1+udOr+HmZlkyvzkY=",
           "dev": true,
           "requires": {
-            "axios": "0.18.0"
+            "axios": "*"
           }
         },
         "@types/chai": {
@@ -8266,7 +8288,7 @@
           "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-0.0.31.tgz",
           "integrity": "sha512-DWT96QeM5AeASIkChnFtEOy6O45WvKmaw27MPhAKLkx06TaFNqrzJuWVurKjCEo3PqVV89YLR2iVON8PhTRaLg==",
           "requires": {
-            "@types/chai": "4.0.1"
+            "@types/chai": "*"
           }
         },
         "@types/chokidar": {
@@ -8274,7 +8296,7 @@
           "resolved": "https://registry.npmjs.org/@types/chokidar/-/chokidar-1.6.0.tgz",
           "integrity": "sha1-2xhDNg1UjyZ+84o1+Tj+IkM8Uoc=",
           "requires": {
-            "@types/node": "8.10.30"
+            "@types/node": "*"
           }
         },
         "@types/color": {
@@ -8282,7 +8304,7 @@
           "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.0.tgz",
           "integrity": "sha512-5qqtNia+m2I0/85+pd2YzAXaTyKO8j+svirO5aN+XaQJ5+eZ8nx0jPtEWZLxCi50xwYsX10xUHetFzfb1WEs4Q==",
           "requires": {
-            "@types/color-convert": "1.9.0"
+            "@types/color-convert": "*"
           }
         },
         "@types/color-convert": {
@@ -8290,7 +8312,7 @@
           "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-1.9.0.tgz",
           "integrity": "sha512-OKGEfULrvSL2VRbkl/gnjjgbbF7ycIlpSsX7Nkab4MOWi5XxmgBYvuiQ7lcCFY5cPDz7MUNaKgxte2VRmtr4Fg==",
           "requires": {
-            "@types/color-name": "1.1.1"
+            "@types/color-name": "*"
           }
         },
         "@types/color-name": {
@@ -8308,7 +8330,7 @@
           "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
           "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
           "requires": {
-            "@types/node": "8.10.30"
+            "@types/node": "*"
           }
         },
         "@types/inquirer": {
@@ -8316,8 +8338,8 @@
           "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.43.tgz",
           "integrity": "sha512-xgyfKZVMFqE8aIKy1xfFVsX2MxyXUNgjgmbF6dRbR3sL+ZM5K4ka/9L4mmTwX8eTeVYtduyXu0gUVwVJa1HbNw==",
           "requires": {
-            "@types/rx": "4.1.1",
-            "@types/through": "0.0.29"
+            "@types/rx": "*",
+            "@types/through": "*"
           }
         },
         "@types/lodash": {
@@ -8335,7 +8357,7 @@
           "resolved": "http://registry.npmjs.org/@types/ora/-/ora-1.3.3.tgz",
           "integrity": "sha512-XaSVRyCfnGq1xGlb6iuoxnomMXPIlZnvIIkKiGNMTCeVOg7G1Si+FA9N1lPrykPEfiRHwbuZXuTCSoYcHyjcdg==",
           "requires": {
-            "@types/node": "8.10.30"
+            "@types/node": "*"
           }
         },
         "@types/proper-lockfile": {
@@ -8354,7 +8376,7 @@
           "resolved": "https://registry.npmjs.org/@types/qr-image/-/qr-image-3.2.0.tgz",
           "integrity": "sha1-09XkVzWSOnIpoHbH/JC6ufDcYgs=",
           "requires": {
-            "@types/node": "8.10.30"
+            "@types/node": "*"
           }
         },
         "@types/request": {
@@ -8362,8 +8384,8 @@
           "resolved": "https://registry.npmjs.org/@types/request/-/request-0.0.45.tgz",
           "integrity": "sha512-OIIREjT58pnpfJjEY5PeBEuRtRR2ED4DF1Ez3Dj9474kCqEKfE+iNAYyM/P3RxxDjNxBhipo+peNBW0S/7Wrzg==",
           "requires": {
-            "@types/form-data": "2.2.1",
-            "@types/node": "8.10.30"
+            "@types/form-data": "*",
+            "@types/node": "*"
           }
         },
         "@types/retry": {
@@ -8376,18 +8398,18 @@
           "resolved": "http://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
           "integrity": "sha1-WY/JSla67ZdfGUV04PVy/Y5iekg=",
           "requires": {
-            "@types/rx-core": "4.0.3",
-            "@types/rx-core-binding": "4.0.4",
-            "@types/rx-lite": "4.0.6",
-            "@types/rx-lite-aggregates": "4.0.3",
-            "@types/rx-lite-async": "4.0.2",
-            "@types/rx-lite-backpressure": "4.0.3",
-            "@types/rx-lite-coincidence": "4.0.3",
-            "@types/rx-lite-experimental": "4.0.1",
-            "@types/rx-lite-joinpatterns": "4.0.1",
-            "@types/rx-lite-testing": "4.0.1",
-            "@types/rx-lite-time": "4.0.3",
-            "@types/rx-lite-virtualtime": "4.0.3"
+            "@types/rx-core": "*",
+            "@types/rx-core-binding": "*",
+            "@types/rx-lite": "*",
+            "@types/rx-lite-aggregates": "*",
+            "@types/rx-lite-async": "*",
+            "@types/rx-lite-backpressure": "*",
+            "@types/rx-lite-coincidence": "*",
+            "@types/rx-lite-experimental": "*",
+            "@types/rx-lite-joinpatterns": "*",
+            "@types/rx-lite-testing": "*",
+            "@types/rx-lite-time": "*",
+            "@types/rx-lite-virtualtime": "*"
           }
         },
         "@types/rx-core": {
@@ -8400,7 +8422,7 @@
           "resolved": "https://registry.npmjs.org/@types/rx-core-binding/-/rx-core-binding-4.0.4.tgz",
           "integrity": "sha512-5pkfxnC4w810LqBPUwP5bg7SFR/USwhMSaAeZQQbEHeBp57pjKXRlXmqpMrLJB4y1oglR/c2502853uN0I+DAQ==",
           "requires": {
-            "@types/rx-core": "4.0.3"
+            "@types/rx-core": "*"
           }
         },
         "@types/rx-lite": {
@@ -8408,8 +8430,8 @@
           "resolved": "https://registry.npmjs.org/@types/rx-lite/-/rx-lite-4.0.6.tgz",
           "integrity": "sha512-oYiDrFIcor9zDm0VDUca1UbROiMYBxMLMaM6qzz4ADAfOmA9r1dYEcAFH+2fsPI5BCCjPvV9pWC3X3flbrvs7w==",
           "requires": {
-            "@types/rx-core": "4.0.3",
-            "@types/rx-core-binding": "4.0.4"
+            "@types/rx-core": "*",
+            "@types/rx-core-binding": "*"
           }
         },
         "@types/rx-lite-aggregates": {
@@ -8417,7 +8439,7 @@
           "resolved": "https://registry.npmjs.org/@types/rx-lite-aggregates/-/rx-lite-aggregates-4.0.3.tgz",
           "integrity": "sha512-MAGDAHy8cRatm94FDduhJF+iNS5//jrZ/PIfm+QYw9OCeDgbymFHChM8YVIvN2zArwsRftKgE33QfRWvQk4DPg==",
           "requires": {
-            "@types/rx-lite": "4.0.6"
+            "@types/rx-lite": "*"
           }
         },
         "@types/rx-lite-async": {
@@ -8425,7 +8447,7 @@
           "resolved": "https://registry.npmjs.org/@types/rx-lite-async/-/rx-lite-async-4.0.2.tgz",
           "integrity": "sha512-vTEv5o8l6702ZwfAM5aOeVDfUwBSDOs+ARoGmWAKQ6LOInQ8J4/zjM7ov12fuTpktUKdMQjkeCp07Vd73mPkxw==",
           "requires": {
-            "@types/rx-lite": "4.0.6"
+            "@types/rx-lite": "*"
           }
         },
         "@types/rx-lite-backpressure": {
@@ -8433,7 +8455,7 @@
           "resolved": "https://registry.npmjs.org/@types/rx-lite-backpressure/-/rx-lite-backpressure-4.0.3.tgz",
           "integrity": "sha512-Y6aIeQCtNban5XSAF4B8dffhIKu6aAy/TXFlScHzSxh6ivfQBQw6UjxyEJxIOt3IT49YkS+siuayM2H/Q0cmgA==",
           "requires": {
-            "@types/rx-lite": "4.0.6"
+            "@types/rx-lite": "*"
           }
         },
         "@types/rx-lite-coincidence": {
@@ -8441,7 +8463,7 @@
           "resolved": "https://registry.npmjs.org/@types/rx-lite-coincidence/-/rx-lite-coincidence-4.0.3.tgz",
           "integrity": "sha512-1VNJqzE9gALUyMGypDXZZXzR0Tt7LC9DdAZQ3Ou/Q0MubNU35agVUNXKGHKpNTba+fr8GdIdkC26bRDqtCQBeQ==",
           "requires": {
-            "@types/rx-lite": "4.0.6"
+            "@types/rx-lite": "*"
           }
         },
         "@types/rx-lite-experimental": {
@@ -8449,7 +8471,7 @@
           "resolved": "https://registry.npmjs.org/@types/rx-lite-experimental/-/rx-lite-experimental-4.0.1.tgz",
           "integrity": "sha1-xTL1y98/LBXaFt7Ykw0bKYQCPL0=",
           "requires": {
-            "@types/rx-lite": "4.0.6"
+            "@types/rx-lite": "*"
           }
         },
         "@types/rx-lite-joinpatterns": {
@@ -8457,7 +8479,7 @@
           "resolved": "https://registry.npmjs.org/@types/rx-lite-joinpatterns/-/rx-lite-joinpatterns-4.0.1.tgz",
           "integrity": "sha1-9w/jcFGKhDLykVjMkv+1a05K/D4=",
           "requires": {
-            "@types/rx-lite": "4.0.6"
+            "@types/rx-lite": "*"
           }
         },
         "@types/rx-lite-testing": {
@@ -8465,7 +8487,7 @@
           "resolved": "https://registry.npmjs.org/@types/rx-lite-testing/-/rx-lite-testing-4.0.1.tgz",
           "integrity": "sha1-IbGdEfTf1v/vWp0WSOnIh5v+Iek=",
           "requires": {
-            "@types/rx-lite-virtualtime": "4.0.3"
+            "@types/rx-lite-virtualtime": "*"
           }
         },
         "@types/rx-lite-time": {
@@ -8473,7 +8495,7 @@
           "resolved": "https://registry.npmjs.org/@types/rx-lite-time/-/rx-lite-time-4.0.3.tgz",
           "integrity": "sha512-ukO5sPKDRwCGWRZRqPlaAU0SKVxmWwSjiOrLhoQDoWxZWg6vyB9XLEZViKOzIO6LnTIQBlk4UylYV0rnhJLxQw==",
           "requires": {
-            "@types/rx-lite": "4.0.6"
+            "@types/rx-lite": "*"
           }
         },
         "@types/rx-lite-virtualtime": {
@@ -8481,7 +8503,7 @@
           "resolved": "https://registry.npmjs.org/@types/rx-lite-virtualtime/-/rx-lite-virtualtime-4.0.3.tgz",
           "integrity": "sha512-3uC6sGmjpOKatZSVHI2xB1+dedgml669ZRvqxy+WqmGJDVusOdyxcKfyzjW0P3/GrCiN4nmRkLVMhPwHCc5QLg==",
           "requires": {
-            "@types/rx-lite": "4.0.6"
+            "@types/rx-lite": "*"
           }
         },
         "@types/semver": {
@@ -8510,7 +8532,7 @@
           "resolved": "https://registry.npmjs.org/@types/tar/-/tar-4.0.0.tgz",
           "integrity": "sha512-YybbEHNngcHlIWVCYsoj7Oo1JU9JqONuAlt1LlTH/lmL8BMhbzdFUgReY87a05rY1j8mfK47Del+TCkaLAXwLw==",
           "requires": {
-            "@types/node": "8.10.30"
+            "@types/node": "*"
           }
         },
         "@types/through": {
@@ -8518,7 +8540,7 @@
           "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.29.tgz",
           "integrity": "sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==",
           "requires": {
-            "@types/node": "8.10.30"
+            "@types/node": "*"
           }
         },
         "@types/universal-analytics": {
@@ -8531,8 +8553,8 @@
           "resolved": "https://registry.npmjs.org/@types/ws/-/ws-4.0.1.tgz",
           "integrity": "sha512-J56Wn8j7ovzmlrkUSPXnVRH+YXUCGoVokiB49QIjz+yq0234guOrBvF/HHrqrJjnY4p5oq+q6xAxT/7An6SeWQ==",
           "requires": {
-            "@types/events": "3.0.0",
-            "@types/node": "8.10.30"
+            "@types/events": "*",
+            "@types/node": "*"
           }
         },
         "@types/xml2js": {
@@ -8540,8 +8562,8 @@
           "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.3.tgz",
           "integrity": "sha512-Pv2HGRE4gWLs31In7nsyXEH4uVVsd0HNV9i2dyASvtDIlOtSTr1eczPLDpdEuyv5LWH5LT20GIXwPjkshKWI1g==",
           "requires": {
-            "@types/events": "3.0.0",
-            "@types/node": "8.10.30"
+            "@types/events": "*",
+            "@types/node": "*"
           }
         },
         "abbrev": {
@@ -8559,7 +8581,7 @@
           "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
           "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
           "requires": {
-            "acorn": "3.3.0"
+            "acorn": "^3.0.4"
           },
           "dependencies": {
             "acorn": {
@@ -8575,7 +8597,7 @@
           "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
           "dev": true,
           "requires": {
-            "es6-promisify": "5.0.0"
+            "es6-promisify": "^5.0.0"
           }
         },
         "agentkeepalive": {
@@ -8584,7 +8606,7 @@
           "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
           "dev": true,
           "requires": {
-            "humanize-ms": "1.2.1"
+            "humanize-ms": "^1.2.1"
           }
         },
         "ajv": {
@@ -8593,10 +8615,10 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         },
         "ajv-keywords": {
@@ -8637,8 +8659,8 @@
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "requires": {
-            "micromatch": "3.1.10",
-            "normalize-path": "2.1.1"
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
           }
         },
         "aproba": {
@@ -8652,7 +8674,7 @@
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
           "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
           "requires": {
-            "sprintf-js": "1.0.3"
+            "sprintf-js": "~1.0.2"
           }
         },
         "arr-diff": {
@@ -8691,7 +8713,7 @@
           "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
           "dev": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "~2.1.0"
           }
         },
         "assert-plus": {
@@ -8761,8 +8783,8 @@
           "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
           "dev": true,
           "requires": {
-            "follow-redirects": "1.7.0",
-            "is-buffer": "1.1.6"
+            "follow-redirects": "^1.3.0",
+            "is-buffer": "^1.1.5"
           }
         },
         "babel-code-frame": {
@@ -8770,9 +8792,9 @@
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           },
           "dependencies": {
             "chalk": {
@@ -8780,11 +8802,11 @@
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               }
             }
           }
@@ -8799,13 +8821,13 @@
           "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
           "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
           "requires": {
-            "cache-base": "1.0.1",
-            "class-utils": "0.3.6",
-            "component-emitter": "1.2.1",
-            "define-property": "1.0.0",
-            "isobject": "3.0.1",
-            "mixin-deep": "1.3.1",
-            "pascalcase": "0.1.1"
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
           },
           "dependencies": {
             "define-property": {
@@ -8813,7 +8835,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "is-accessor-descriptor": {
@@ -8821,7 +8843,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
@@ -8829,7 +8851,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
@@ -8837,9 +8859,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             }
           }
@@ -8856,7 +8878,7 @@
           "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
           "dev": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "big-integer": {
@@ -8900,15 +8922,15 @@
           "integrity": "sha1-EBXLH+LEQ4WCWVgdtTMy+NDPUPk=",
           "requires": {
             "bytes": "2.2.0",
-            "content-type": "1.0.4",
-            "debug": "2.2.0",
-            "depd": "1.1.2",
-            "http-errors": "1.3.1",
+            "content-type": "~1.0.1",
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "http-errors": "~1.3.1",
             "iconv-lite": "0.4.13",
-            "on-finished": "2.3.0",
+            "on-finished": "~2.3.0",
             "qs": "5.2.0",
-            "raw-body": "2.1.7",
-            "type-is": "1.6.16"
+            "raw-body": "~2.1.5",
+            "type-is": "~1.6.10"
           },
           "dependencies": {
             "bytes": {
@@ -8929,8 +8951,8 @@
               "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
               "requires": {
-                "inherits": "2.0.3",
-                "statuses": "1.5.0"
+                "inherits": "~2.0.1",
+                "statuses": "1"
               }
             },
             "iconv-lite": {
@@ -8973,7 +8995,7 @@
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "dev": true,
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           }
         },
         "bplist-creator": {
@@ -8982,7 +9004,7 @@
           "integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
           "dev": true,
           "requires": {
-            "stream-buffers": "2.2.0"
+            "stream-buffers": "~2.2.0"
           }
         },
         "bplist-parser": {
@@ -8990,7 +9012,7 @@
           "integrity": "sha512-B7Agq6ELA8hOERzvUhhgQPFe1Hcx6HCAtdaxHv/YS/PAUdxhxtCYzWFJ3zDfGIWXT1X2Nt2Q8lqeEASKoY3Wfw==",
           "dev": true,
           "requires": {
-            "big-integer": "1.6.43"
+            "big-integer": "^1.6.7"
           }
         },
         "brace-expansion": {
@@ -8998,7 +9020,7 @@
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -9007,16 +9029,16 @@
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.3",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -9024,7 +9046,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -9092,20 +9114,20 @@
           "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
           "dev": true,
           "requires": {
-            "bluebird": "3.5.3",
-            "chownr": "1.1.1",
-            "figgy-pudding": "3.5.1",
-            "glob": "7.1.3",
-            "graceful-fs": "4.1.15",
-            "lru-cache": "5.1.1",
-            "mississippi": "3.0.0",
-            "mkdirp": "0.5.1",
-            "move-concurrently": "1.0.1",
-            "promise-inflight": "1.0.1",
-            "rimraf": "2.6.3",
-            "ssri": "6.0.1",
-            "unique-filename": "1.1.1",
-            "y18n": "4.0.0"
+            "bluebird": "^3.5.3",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.1.15",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
+            "y18n": "^4.0.0"
           },
           "dependencies": {
             "lru-cache": {
@@ -9114,7 +9136,7 @@
               "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
               "dev": true,
               "requires": {
-                "yallist": "3.0.3"
+                "yallist": "^3.0.2"
               }
             },
             "rimraf": {
@@ -9123,7 +9145,7 @@
               "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "dev": true,
               "requires": {
-                "glob": "7.1.3"
+                "glob": "^7.1.3"
               }
             },
             "y18n": {
@@ -9145,15 +9167,15 @@
           "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
           "requires": {
-            "collection-visit": "1.0.0",
-            "component-emitter": "1.2.1",
-            "get-value": "2.0.6",
-            "has-value": "1.0.0",
-            "isobject": "3.0.1",
-            "set-value": "2.0.0",
-            "to-object-path": "0.3.0",
-            "union-value": "1.0.0",
-            "unset-value": "1.0.0"
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
           }
         },
         "cacheable-request": {
@@ -9182,7 +9204,7 @@
           "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
           "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
           "requires": {
-            "callsites": "0.2.0"
+            "callsites": "^0.2.0"
           }
         },
         "callsites": {
@@ -9201,8 +9223,8 @@
           "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "requires": {
-            "camelcase": "2.1.1",
-            "map-obj": "1.0.1"
+            "camelcase": "^2.0.0",
+            "map-obj": "^1.0.0"
           },
           "dependencies": {
             "camelcase": {
@@ -9218,8 +9240,8 @@
           "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
           "dev": true,
           "requires": {
-            "ansicolors": "0.3.2",
-            "redeyed": "2.1.1"
+            "ansicolors": "~0.3.2",
+            "redeyed": "~2.1.0"
           }
         },
         "caseless": {
@@ -9233,12 +9255,12 @@
           "resolved": "https://registry.npmjs.org/chai/-/chai-4.0.2.tgz",
           "integrity": "sha1-L3MnxN5vOF3XeHmZ4qsCaXoyuDs=",
           "requires": {
-            "assertion-error": "1.1.0",
-            "check-error": "1.0.2",
-            "deep-eql": "2.0.2",
-            "get-func-name": "2.0.0",
-            "pathval": "1.1.0",
-            "type-detect": "4.0.8"
+            "assertion-error": "^1.0.1",
+            "check-error": "^1.0.1",
+            "deep-eql": "^2.0.1",
+            "get-func-name": "^2.0.0",
+            "pathval": "^1.0.0",
+            "type-detect": "^4.0.0"
           }
         },
         "chai-as-promised": {
@@ -9246,8 +9268,8 @@
           "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.0.0.tgz",
           "integrity": "sha512-7YYdnXPq2pV9nvRBb36Wi/MXfT8j2iL/H76GtenlOMatXbMoQLb+PonuVHGFsw5wE2M6R/VFciq8AnSSAix0GA==",
           "requires": {
-            "check-error": "1.0.2",
-            "eslint": "3.19.0"
+            "check-error": "^1.0.2",
+            "eslint": "^3.19.0"
           }
         },
         "chalk": {
@@ -9255,11 +9277,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.0.tgz",
           "integrity": "sha1-CbRTzsSXp1Ug5KYK5IIUqHAOCSE=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.1.0",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "chardet": {
@@ -9278,19 +9300,19 @@
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
           "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
           "requires": {
-            "anymatch": "2.0.0",
-            "async-each": "1.0.2",
-            "braces": "2.3.2",
-            "fsevents": "1.2.7",
-            "glob-parent": "3.1.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "4.0.1",
-            "lodash.debounce": "4.0.8",
-            "normalize-path": "2.1.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.2.1",
-            "upath": "1.1.2"
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.0",
+            "braces": "^2.3.0",
+            "fsevents": "^1.2.2",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "lodash.debounce": "^4.0.8",
+            "normalize-path": "^2.1.1",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0",
+            "upath": "^1.0.5"
           }
         },
         "chownr": {
@@ -9309,10 +9331,10 @@
           "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
           "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
           "requires": {
-            "arr-union": "3.1.0",
-            "define-property": "0.2.5",
-            "isobject": "3.0.1",
-            "static-extend": "0.1.2"
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
           },
           "dependencies": {
             "define-property": {
@@ -9320,7 +9342,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             }
           }
@@ -9331,7 +9353,7 @@
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
-            "restore-cursor": "2.0.0"
+            "restore-cursor": "^2.0.0"
           }
         },
         "cli-spinners": {
@@ -9347,7 +9369,7 @@
           "requires": {
             "colors": "1.0.3",
             "lodash": "3.6.0",
-            "wcwidth": "1.0.1"
+            "wcwidth": "*"
           },
           "dependencies": {
             "colors": {
@@ -9375,9 +9397,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -9386,7 +9408,7 @@
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "string-width": {
@@ -9395,9 +9417,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -9413,7 +9435,7 @@
           "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
           "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
           "requires": {
-            "mimic-response": "1.0.1"
+            "mimic-response": "^1.0.0"
           }
         },
         "co": {
@@ -9436,8 +9458,8 @@
           "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
           "requires": {
-            "map-visit": "1.0.0",
-            "object-visit": "1.0.1"
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
           }
         },
         "color": {
@@ -9446,8 +9468,8 @@
           "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.3",
-            "color-string": "1.5.3"
+            "color-convert": "^1.9.1",
+            "color-string": "^1.5.2"
           }
         },
         "color-convert": {
@@ -9469,8 +9491,8 @@
           "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
           "dev": true,
           "requires": {
-            "color-name": "1.1.3",
-            "simple-swizzle": "0.2.2"
+            "color-name": "^1.0.0",
+            "simple-swizzle": "^0.2.2"
           }
         },
         "colors": {
@@ -9484,7 +9506,7 @@
           "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "commander": {
@@ -9507,10 +9529,10 @@
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "requires": {
-            "buffer-from": "1.1.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "content-type": {
@@ -9530,12 +9552,12 @@
           "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
           "dev": true,
           "requires": {
-            "aproba": "1.2.0",
-            "fs-write-stream-atomic": "1.0.10",
-            "iferr": "0.1.5",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.3",
-            "run-queue": "1.0.3"
+            "aproba": "^1.1.1",
+            "fs-write-stream-atomic": "^1.0.8",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.0"
           },
           "dependencies": {
             "rimraf": {
@@ -9544,7 +9566,7 @@
               "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "dev": true,
               "requires": {
-                "glob": "7.1.3"
+                "glob": "^7.1.3"
               }
             }
           }
@@ -9565,7 +9587,7 @@
           "integrity": "sha512-8I1sgZHfVwcSOY6mSGpVU3lw/GSIZvusg8dD2+OGehCJpOhQRLNcH0qb9upQnOH4XhgxxFJSg6E2kx95deb1Tw==",
           "dev": true,
           "requires": {
-            "boom": "5.2.0"
+            "boom": "5.x.x"
           },
           "dependencies": {
             "boom": {
@@ -9574,7 +9596,7 @@
               "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
               "dev": true,
               "requires": {
-                "hoek": "4.2.1"
+                "hoek": "4.x.x"
               }
             }
           }
@@ -9584,10 +9606,10 @@
           "resolved": "https://registry.npmjs.org/csproj2ts/-/csproj2ts-1.1.0.tgz",
           "integrity": "sha512-sk0RTT51t4lUNQ7UfZrqjQx7q4g0m3iwNA6mvyh7gLsgQYvwKzfdyoAgicC9GqJvkoIkU0UmndV9c7VZ8pJ45Q==",
           "requires": {
-            "es6-promise": "4.2.6",
-            "lodash": "4.17.11",
-            "semver": "5.5.0",
-            "xml2js": "0.4.19"
+            "es6-promise": "^4.1.1",
+            "lodash": "^4.17.4",
+            "semver": "^5.4.1",
+            "xml2js": "^0.4.19"
           },
           "dependencies": {
             "es6-promise": {
@@ -9602,7 +9624,7 @@
           "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
           "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
           "requires": {
-            "array-find-index": "1.0.2"
+            "array-find-index": "^1.0.1"
           }
         },
         "cyclist": {
@@ -9616,7 +9638,7 @@
           "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "requires": {
-            "es5-ext": "0.10.49"
+            "es5-ext": "^0.10.9"
           }
         },
         "dashdash": {
@@ -9625,7 +9647,7 @@
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "data-uri-to-buffer": {
@@ -9634,7 +9656,7 @@
           "integrity": "sha512-YbKCNLPPP4inc0E5If4OaalBc7gpaM2MRv77Pv2VThVComLKfbGYtJcdDCViDyp1Wd4SebhHLz94vp91zbK6bw==",
           "dev": true,
           "requires": {
-            "@types/node": "8.10.30"
+            "@types/node": "^8.0.7"
           }
         },
         "date-format": {
@@ -9648,8 +9670,8 @@
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
           "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
+            "get-stdin": "^4.0.1",
+            "meow": "^3.3.0"
           }
         },
         "debug": {
@@ -9675,7 +9697,7 @@
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
           "requires": {
-            "mimic-response": "1.0.1"
+            "mimic-response": "^1.0.0"
           }
         },
         "deep-eql": {
@@ -9683,7 +9705,7 @@
           "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
           "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
           "requires": {
-            "type-detect": "3.0.0"
+            "type-detect": "^3.0.0"
           },
           "dependencies": {
             "type-detect": {
@@ -9709,7 +9731,7 @@
           "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
           "dev": true,
           "requires": {
-            "clone": "1.0.4"
+            "clone": "^1.0.2"
           }
         },
         "define-properties": {
@@ -9718,7 +9740,7 @@
           "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
           "dev": true,
           "requires": {
-            "object-keys": "1.1.0"
+            "object-keys": "^1.0.12"
           }
         },
         "define-property": {
@@ -9726,8 +9748,8 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
           "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "requires": {
-            "is-descriptor": "1.0.2",
-            "isobject": "3.0.1"
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
           },
           "dependencies": {
             "is-accessor-descriptor": {
@@ -9735,7 +9757,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
@@ -9743,7 +9765,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
@@ -9751,9 +9773,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             }
           }
@@ -9764,9 +9786,9 @@
           "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
           "dev": true,
           "requires": {
-            "ast-types": "0.12.3",
-            "escodegen": "1.11.1",
-            "esprima": "3.1.3"
+            "ast-types": "0.x.x",
+            "escodegen": "1.x.x",
+            "esprima": "3.x.x"
           },
           "dependencies": {
             "esprima": {
@@ -9793,7 +9815,7 @@
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
           "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "detect-newline": {
@@ -9811,7 +9833,7 @@
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
           "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "requires": {
-            "esutils": "2.0.2"
+            "esutils": "^2.0.2"
           }
         },
         "dom-walk": {
@@ -9831,10 +9853,10 @@
           "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "stream-shift": "1.0.0"
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
           }
         },
         "ecc-jsbn": {
@@ -9843,8 +9865,8 @@
           "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
           "dev": true,
           "requires": {
-            "jsbn": "0.1.1",
-            "safer-buffer": "2.1.2"
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
           }
         },
         "editions": {
@@ -9870,7 +9892,7 @@
           "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
           "dev": true,
           "requires": {
-            "iconv-lite": "0.4.24"
+            "iconv-lite": "~0.4.13"
           },
           "dependencies": {
             "iconv-lite": {
@@ -9879,7 +9901,7 @@
               "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "dev": true,
               "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
               }
             }
           }
@@ -9890,7 +9912,7 @@
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.4.0"
           }
         },
         "err-code": {
@@ -9904,7 +9926,7 @@
           "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
           "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
           "requires": {
-            "is-arrayish": "0.2.1"
+            "is-arrayish": "^0.2.1"
           },
           "dependencies": {
             "is-arrayish": {
@@ -9920,12 +9942,12 @@
           "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
           "dev": true,
           "requires": {
-            "es-to-primitive": "1.2.0",
-            "function-bind": "1.1.1",
-            "has": "1.0.3",
-            "is-callable": "1.1.4",
-            "is-regex": "1.0.4",
-            "object-keys": "1.1.0"
+            "es-to-primitive": "^1.2.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-keys": "^1.0.12"
           }
         },
         "es-to-primitive": {
@@ -9934,9 +9956,9 @@
           "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
           "dev": true,
           "requires": {
-            "is-callable": "1.1.4",
-            "is-date-object": "1.0.1",
-            "is-symbol": "1.0.2"
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
           }
         },
         "es5-ext": {
@@ -9944,9 +9966,9 @@
           "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.49.tgz",
           "integrity": "sha512-3NMEhi57E31qdzmYp2jwRArIUsj1HI/RxbQ4bgnSB+AIKIxsAmTiK83bYMifIcpWvEc3P1X30DhUKOqEtF/kvg==",
           "requires": {
-            "es6-iterator": "2.0.3",
-            "es6-symbol": "3.1.1",
-            "next-tick": "1.0.0"
+            "es6-iterator": "~2.0.3",
+            "es6-symbol": "~3.1.1",
+            "next-tick": "^1.0.0"
           }
         },
         "es6-iterator": {
@@ -9954,9 +9976,9 @@
           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
           "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.49",
-            "es6-symbol": "3.1.1"
+            "d": "1",
+            "es5-ext": "^0.10.35",
+            "es6-symbol": "^3.1.1"
           }
         },
         "es6-map": {
@@ -9964,12 +9986,12 @@
           "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
           "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.49",
-            "es6-iterator": "2.0.3",
-            "es6-set": "0.1.5",
-            "es6-symbol": "3.1.1",
-            "event-emitter": "0.3.5"
+            "d": "1",
+            "es5-ext": "~0.10.14",
+            "es6-iterator": "~2.0.1",
+            "es6-set": "~0.1.5",
+            "es6-symbol": "~3.1.1",
+            "event-emitter": "~0.3.5"
           }
         },
         "es6-promise": {
@@ -9984,7 +10006,7 @@
           "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
           "dev": true,
           "requires": {
-            "es6-promise": "4.2.6"
+            "es6-promise": "^4.0.3"
           },
           "dependencies": {
             "es6-promise": {
@@ -10000,11 +10022,11 @@
           "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
           "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.49",
-            "es6-iterator": "2.0.3",
+            "d": "1",
+            "es5-ext": "~0.10.14",
+            "es6-iterator": "~2.0.1",
             "es6-symbol": "3.1.1",
-            "event-emitter": "0.3.5"
+            "event-emitter": "~0.3.5"
           }
         },
         "es6-symbol": {
@@ -10012,8 +10034,8 @@
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
           "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.49"
+            "d": "1",
+            "es5-ext": "~0.10.14"
           }
         },
         "es6-weak-map": {
@@ -10021,10 +10043,10 @@
           "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
           "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.49",
-            "es6-iterator": "2.0.3",
-            "es6-symbol": "3.1.1"
+            "d": "1",
+            "es5-ext": "^0.10.14",
+            "es6-iterator": "^2.0.1",
+            "es6-symbol": "^3.1.1"
           }
         },
         "escape-string-regexp": {
@@ -10038,11 +10060,11 @@
           "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
           "dev": true,
           "requires": {
-            "esprima": "3.1.3",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.6.1"
+            "esprima": "^3.1.3",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
           },
           "dependencies": {
             "esprima": {
@@ -10065,10 +10087,10 @@
           "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
           "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
           "requires": {
-            "es6-map": "0.1.5",
-            "es6-weak-map": "2.0.2",
-            "esrecurse": "4.2.1",
-            "estraverse": "4.2.0"
+            "es6-map": "^0.1.3",
+            "es6-weak-map": "^2.0.1",
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
           }
         },
         "eslint": {
@@ -10076,41 +10098,41 @@
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
           "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "chalk": "1.1.3",
-            "concat-stream": "1.6.2",
-            "debug": "2.6.9",
-            "doctrine": "2.1.0",
-            "escope": "3.6.0",
-            "espree": "3.5.4",
-            "esquery": "1.0.1",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "file-entry-cache": "2.0.0",
-            "glob": "7.1.3",
-            "globals": "9.18.0",
-            "ignore": "3.3.10",
-            "imurmurhash": "0.1.4",
-            "inquirer": "0.12.0",
-            "is-my-json-valid": "2.19.0",
-            "is-resolvable": "1.1.0",
-            "js-yaml": "3.13.0",
-            "json-stable-stringify": "1.0.1",
-            "levn": "0.3.0",
-            "lodash": "4.17.11",
-            "mkdirp": "0.5.1",
-            "natural-compare": "1.4.0",
-            "optionator": "0.8.2",
-            "path-is-inside": "1.0.2",
-            "pluralize": "1.2.1",
-            "progress": "1.1.8",
-            "require-uncached": "1.0.3",
-            "shelljs": "0.7.6",
-            "strip-bom": "3.0.0",
-            "strip-json-comments": "2.0.1",
-            "table": "3.8.3",
-            "text-table": "0.2.0",
-            "user-home": "2.0.0"
+            "babel-code-frame": "^6.16.0",
+            "chalk": "^1.1.3",
+            "concat-stream": "^1.5.2",
+            "debug": "^2.1.1",
+            "doctrine": "^2.0.0",
+            "escope": "^3.6.0",
+            "espree": "^3.4.0",
+            "esquery": "^1.0.0",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "glob": "^7.0.3",
+            "globals": "^9.14.0",
+            "ignore": "^3.2.0",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^0.12.0",
+            "is-my-json-valid": "^2.10.0",
+            "is-resolvable": "^1.0.0",
+            "js-yaml": "^3.5.1",
+            "json-stable-stringify": "^1.0.0",
+            "levn": "^0.3.0",
+            "lodash": "^4.0.0",
+            "mkdirp": "^0.5.0",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.1",
+            "pluralize": "^1.2.1",
+            "progress": "^1.1.8",
+            "require-uncached": "^1.0.2",
+            "shelljs": "^0.7.5",
+            "strip-bom": "^3.0.0",
+            "strip-json-comments": "~2.0.1",
+            "table": "^3.7.8",
+            "text-table": "~0.2.0",
+            "user-home": "^2.0.0"
           },
           "dependencies": {
             "ansi-escapes": {
@@ -10123,11 +10145,11 @@
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               }
             },
             "cli-cursor": {
@@ -10135,7 +10157,7 @@
               "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
               "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
               "requires": {
-                "restore-cursor": "1.0.1"
+                "restore-cursor": "^1.0.1"
               }
             },
             "figures": {
@@ -10143,8 +10165,8 @@
               "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
               "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
               "requires": {
-                "escape-string-regexp": "1.0.5",
-                "object-assign": "4.1.1"
+                "escape-string-regexp": "^1.0.5",
+                "object-assign": "^4.1.0"
               }
             },
             "inquirer": {
@@ -10152,19 +10174,19 @@
               "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
               "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
               "requires": {
-                "ansi-escapes": "1.4.0",
-                "ansi-regex": "2.1.1",
-                "chalk": "1.1.3",
-                "cli-cursor": "1.0.2",
-                "cli-width": "2.2.0",
-                "figures": "1.7.0",
-                "lodash": "4.17.11",
-                "readline2": "1.0.1",
-                "run-async": "0.1.0",
-                "rx-lite": "3.1.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "through": "2.3.8"
+                "ansi-escapes": "^1.1.0",
+                "ansi-regex": "^2.0.0",
+                "chalk": "^1.0.0",
+                "cli-cursor": "^1.0.1",
+                "cli-width": "^2.0.0",
+                "figures": "^1.3.5",
+                "lodash": "^4.3.0",
+                "readline2": "^1.0.1",
+                "run-async": "^0.1.0",
+                "rx-lite": "^3.1.2",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.0",
+                "through": "^2.3.6"
               }
             },
             "is-fullwidth-code-point": {
@@ -10172,7 +10194,7 @@
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "onetime": {
@@ -10185,8 +10207,8 @@
               "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
               "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
               "requires": {
-                "exit-hook": "1.1.1",
-                "onetime": "1.1.0"
+                "exit-hook": "^1.0.0",
+                "onetime": "^1.0.0"
               }
             },
             "run-async": {
@@ -10194,7 +10216,7 @@
               "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
               "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
               "requires": {
-                "once": "1.4.0"
+                "once": "^1.3.0"
               }
             },
             "string-width": {
@@ -10202,9 +10224,9 @@
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             },
             "strip-bom": {
@@ -10219,8 +10241,8 @@
           "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
           "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
           "requires": {
-            "acorn": "5.7.3",
-            "acorn-jsx": "3.0.1"
+            "acorn": "^5.5.0",
+            "acorn-jsx": "^3.0.0"
           }
         },
         "esprima": {
@@ -10233,7 +10255,7 @@
           "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
           "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
           "requires": {
-            "estraverse": "4.2.0"
+            "estraverse": "^4.0.0"
           }
         },
         "esrecurse": {
@@ -10241,7 +10263,7 @@
           "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
           "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
           "requires": {
-            "estraverse": "4.2.0"
+            "estraverse": "^4.1.0"
           }
         },
         "estraverse": {
@@ -10259,8 +10281,8 @@
           "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
           "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.49"
+            "d": "1",
+            "es5-ext": "~0.10.14"
           }
         },
         "eventemitter2": {
@@ -10289,13 +10311,13 @@
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -10303,7 +10325,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -10311,7 +10333,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -10327,8 +10349,8 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -10336,7 +10358,7 @@
               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "requires": {
-                "is-plain-object": "2.0.4"
+                "is-plain-object": "^2.0.4"
               }
             }
           }
@@ -10347,9 +10369,9 @@
           "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
           "dev": true,
           "requires": {
-            "chardet": "0.7.0",
-            "iconv-lite": "0.4.24",
-            "tmp": "0.0.33"
+            "chardet": "^0.7.0",
+            "iconv-lite": "^0.4.24",
+            "tmp": "^0.0.33"
           },
           "dependencies": {
             "iconv-lite": {
@@ -10358,7 +10380,7 @@
               "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "dev": true,
               "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
               }
             }
           }
@@ -10368,14 +10390,14 @@
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -10383,7 +10405,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
@@ -10391,7 +10413,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
@@ -10399,7 +10421,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
@@ -10407,7 +10429,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
@@ -10415,9 +10437,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             }
           }
@@ -10450,7 +10472,7 @@
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
           "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
           "requires": {
-            "websocket-driver": "0.7.0"
+            "websocket-driver": ">=0.5.1"
           }
         },
         "fd-slicer": {
@@ -10459,7 +10481,7 @@
           "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
           "dev": true,
           "requires": {
-            "pend": "1.2.0"
+            "pend": "~1.2.0"
           }
         },
         "figgy-pudding": {
@@ -10474,7 +10496,7 @@
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5"
+            "escape-string-regexp": "^1.0.5"
           }
         },
         "file-entry-cache": {
@@ -10482,8 +10504,8 @@
           "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
           "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
           "requires": {
-            "flat-cache": "1.3.4",
-            "object-assign": "4.1.1"
+            "flat-cache": "^1.2.1",
+            "object-assign": "^4.0.1"
           }
         },
         "file-sync-cmp": {
@@ -10508,10 +10530,10 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -10519,7 +10541,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -10529,8 +10551,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "findup-sync": {
@@ -10538,7 +10560,7 @@
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
           "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
           "requires": {
-            "glob": "5.0.15"
+            "glob": "~5.0.0"
           },
           "dependencies": {
             "glob": {
@@ -10546,11 +10568,11 @@
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
               "requires": {
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.2",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             }
           }
@@ -10560,10 +10582,10 @@
           "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
           "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
           "requires": {
-            "circular-json": "0.3.3",
-            "graceful-fs": "4.1.15",
-            "rimraf": "2.6.3",
-            "write": "0.2.1"
+            "circular-json": "^0.3.1",
+            "graceful-fs": "^4.1.2",
+            "rimraf": "~2.6.2",
+            "write": "^0.2.1"
           },
           "dependencies": {
             "rimraf": {
@@ -10571,7 +10593,7 @@
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
               "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "requires": {
-                "glob": "7.1.3"
+                "glob": "^7.1.3"
               }
             }
           }
@@ -10582,8 +10604,8 @@
           "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.3.6"
           }
         },
         "follow-redirects": {
@@ -10592,7 +10614,7 @@
           "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
           "dev": true,
           "requires": {
-            "debug": "3.2.6"
+            "debug": "^3.2.6"
           },
           "dependencies": {
             "debug": {
@@ -10601,7 +10623,7 @@
               "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
               "dev": true,
               "requires": {
-                "ms": "2.1.1"
+                "ms": "^2.1.1"
               }
             },
             "ms": {
@@ -10618,7 +10640,7 @@
           "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
           "dev": true,
           "requires": {
-            "is-callable": "1.1.4"
+            "is-callable": "^1.1.3"
           }
         },
         "for-in": {
@@ -10638,9 +10660,9 @@
           "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.7",
-            "mime-types": "2.1.22"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
           }
         },
         "formatio": {
@@ -10648,7 +10670,7 @@
           "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
           "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
           "requires": {
-            "samsam": "1.3.0"
+            "samsam": "1.x"
           }
         },
         "formidable": {
@@ -10662,7 +10684,7 @@
           "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
           "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
           "requires": {
-            "map-cache": "0.2.2"
+            "map-cache": "^0.2.2"
           }
         },
         "from2": {
@@ -10670,8 +10692,8 @@
           "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
           "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0"
           }
         },
         "fs-minipass": {
@@ -10680,7 +10702,7 @@
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "requires": {
-            "minipass": "2.3.5"
+            "minipass": "^2.2.1"
           }
         },
         "fs-write-stream-atomic": {
@@ -10689,10 +10711,10 @@
           "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.15",
-            "iferr": "0.1.5",
-            "imurmurhash": "0.1.4",
-            "readable-stream": "2.3.6"
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
           }
         },
         "fs.realpath": {
@@ -10706,8 +10728,8 @@
           "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
           "optional": true,
           "requires": {
-            "nan": "2.13.2",
-            "node-pre-gyp": "0.10.3"
+            "nan": "^2.9.2",
+            "node-pre-gyp": "^0.10.0"
           },
           "dependencies": {
             "abbrev": {
@@ -10717,8 +10739,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -10730,19 +10751,17 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.6"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
               }
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -10755,18 +10774,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -10801,7 +10817,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "minipass": "2.3.5"
+                "minipass": "^2.2.1"
               }
             },
             "fs.realpath": {
@@ -10814,14 +10830,14 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.3"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
               }
             },
             "glob": {
@@ -10829,12 +10845,12 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "has-unicode": {
@@ -10847,7 +10863,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
               }
             },
             "ignore-walk": {
@@ -10855,7 +10871,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "minimatch": "3.0.4"
+                "minimatch": "^3.0.4"
               }
             },
             "inflight": {
@@ -10863,14 +10879,13 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
               }
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -10881,7 +10896,7 @@
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "isarray": {
@@ -10892,7 +10907,6 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -10905,8 +10919,8 @@
               "version": "2.3.5",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.2",
-                "yallist": "3.0.3"
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
               }
             },
             "minizlib": {
@@ -10914,7 +10928,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "minipass": "2.3.5"
+                "minipass": "^2.2.1"
               }
             },
             "mkdirp": {
@@ -10934,9 +10948,9 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "debug": "2.6.9",
-                "iconv-lite": "0.4.24",
-                "sax": "1.2.4"
+                "debug": "^2.1.2",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
               }
             },
             "node-pre-gyp": {
@@ -10944,16 +10958,16 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "detect-libc": "1.0.3",
-                "mkdirp": "0.5.1",
-                "needle": "2.2.4",
-                "nopt": "4.0.1",
-                "npm-packlist": "1.2.0",
-                "npmlog": "4.1.2",
-                "rc": "1.2.8",
-                "rimraf": "2.6.3",
-                "semver": "5.6.0",
-                "tar": "4.4.8"
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
               }
             },
             "nopt": {
@@ -10961,8 +10975,8 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "abbrev": "1.1.1",
-                "osenv": "0.1.5"
+                "abbrev": "1",
+                "osenv": "^0.1.4"
               }
             },
             "npm-bundled": {
@@ -10975,8 +10989,8 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "ignore-walk": "3.0.1",
-                "npm-bundled": "1.0.5"
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
               }
             },
             "npmlog": {
@@ -10984,10 +10998,10 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "are-we-there-yet": "1.1.5",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
               }
             },
             "number-is-nan": {
@@ -11003,7 +11017,7 @@
               "version": "1.4.0",
               "bundled": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               }
             },
             "os-homedir": {
@@ -11021,8 +11035,8 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
               }
             },
             "path-is-absolute": {
@@ -11040,10 +11054,10 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "deep-extend": "0.6.0",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
               },
               "dependencies": {
                 "minimist": {
@@ -11058,13 +11072,13 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             },
             "rimraf": {
@@ -11072,7 +11086,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "glob": "7.1.3"
+                "glob": "^7.1.3"
               }
             },
             "safe-buffer": {
@@ -11108,9 +11122,9 @@
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             },
             "string_decoder": {
@@ -11118,14 +11132,14 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             },
             "strip-json-comments": {
@@ -11138,13 +11152,13 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "chownr": "1.1.1",
-                "fs-minipass": "1.2.5",
-                "minipass": "2.3.5",
-                "minizlib": "1.2.1",
-                "mkdirp": "0.5.1",
-                "safe-buffer": "5.1.2",
-                "yallist": "3.0.3"
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.3.4",
+                "minizlib": "^1.1.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.2"
               }
             },
             "util-deprecate": {
@@ -11157,7 +11171,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "string-width": "1.0.2"
+                "string-width": "^1.0.2 || 2"
               }
             },
             "wrappy": {
@@ -11176,7 +11190,7 @@
           "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
           "dev": true,
           "requires": {
-            "readable-stream": "1.1.14",
+            "readable-stream": "1.1.x",
             "xregexp": "2.0.0"
           },
           "dependencies": {
@@ -11192,10 +11206,10 @@
               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               }
             },
             "string_decoder": {
@@ -11217,7 +11231,7 @@
           "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
           "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
           "requires": {
-            "globule": "1.2.1"
+            "globule": "^1.0.0"
           }
         },
         "generate-function": {
@@ -11225,7 +11239,7 @@
           "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
           "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
           "requires": {
-            "is-property": "1.0.2"
+            "is-property": "^1.0.2"
           }
         },
         "generate-object-property": {
@@ -11233,7 +11247,7 @@
           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
           "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
           "requires": {
-            "is-property": "1.0.2"
+            "is-property": "^1.0.0"
           }
         },
         "genfun": {
@@ -11269,12 +11283,12 @@
           "integrity": "sha512-x5j6Ks7FOgLD/GlvjKwgu7wdmMR55iuRHhn8hj/+gA+eSbxQvZ+AEomq+3MgVEZj1vpi738QahGbCCSIDtXtkw==",
           "dev": true,
           "requires": {
-            "data-uri-to-buffer": "2.0.0",
-            "debug": "4.1.1",
-            "extend": "3.0.2",
-            "file-uri-to-path": "1.0.0",
-            "ftp": "0.3.10",
-            "readable-stream": "3.3.0"
+            "data-uri-to-buffer": "2",
+            "debug": "4",
+            "extend": "~3.0.2",
+            "file-uri-to-path": "1",
+            "ftp": "~0.3.10",
+            "readable-stream": "3"
           },
           "dependencies": {
             "debug": {
@@ -11283,7 +11297,7 @@
               "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
               "dev": true,
               "requires": {
-                "ms": "2.1.1"
+                "ms": "^2.1.1"
               }
             },
             "ms": {
@@ -11298,9 +11312,9 @@
               "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
               "dev": true,
               "requires": {
-                "inherits": "2.0.3",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
               }
             }
           }
@@ -11321,7 +11335,7 @@
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "glob": {
@@ -11329,12 +11343,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           },
           "dependencies": {
             "minimatch": {
@@ -11342,7 +11356,7 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
               }
             }
           }
@@ -11352,8 +11366,8 @@
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
           },
           "dependencies": {
             "is-glob": {
@@ -11361,7 +11375,7 @@
               "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
               }
             }
           }
@@ -11372,8 +11386,8 @@
           "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
           "dev": true,
           "requires": {
-            "min-document": "2.19.0",
-            "process": "0.5.2"
+            "min-document": "^2.19.0",
+            "process": "~0.5.1"
           }
         },
         "globals": {
@@ -11386,9 +11400,9 @@
           "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
           "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
           "requires": {
-            "glob": "7.1.3",
-            "lodash": "4.17.11",
-            "minimatch": "3.0.2"
+            "glob": "~7.1.1",
+            "lodash": "~4.17.10",
+            "minimatch": "~3.0.2"
           }
         },
         "got": {
@@ -11396,23 +11410,23 @@
           "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
           "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
           "requires": {
-            "@sindresorhus/is": "0.7.0",
-            "cacheable-request": "2.1.4",
-            "decompress-response": "3.3.0",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "into-stream": "3.1.0",
-            "is-retry-allowed": "1.1.0",
-            "isurl": "1.0.0",
-            "lowercase-keys": "1.0.1",
-            "mimic-response": "1.0.1",
-            "p-cancelable": "0.4.1",
-            "p-timeout": "2.0.1",
-            "pify": "3.0.0",
-            "safe-buffer": "5.1.2",
-            "timed-out": "4.0.1",
-            "url-parse-lax": "3.0.0",
-            "url-to-options": "1.0.1"
+            "@sindresorhus/is": "^0.7.0",
+            "cacheable-request": "^2.1.1",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "into-stream": "^3.1.0",
+            "is-retry-allowed": "^1.1.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "mimic-response": "^1.0.0",
+            "p-cancelable": "^0.4.0",
+            "p-timeout": "^2.0.1",
+            "pify": "^3.0.0",
+            "safe-buffer": "^5.1.1",
+            "timed-out": "^4.0.1",
+            "url-parse-lax": "^3.0.0",
+            "url-to-options": "^1.0.1"
           },
           "dependencies": {
             "pify": {
@@ -11442,22 +11456,22 @@
           "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.1.tgz",
           "integrity": "sha1-6HeHZOlEsY8yuw8QuQeEdcnftWs=",
           "requires": {
-            "coffee-script": "1.10.0",
-            "dateformat": "1.0.12",
-            "eventemitter2": "0.4.14",
-            "exit": "0.1.2",
-            "findup-sync": "0.3.0",
-            "glob": "7.0.6",
-            "grunt-cli": "1.2.0",
-            "grunt-known-options": "1.1.1",
-            "grunt-legacy-log": "1.0.2",
-            "grunt-legacy-util": "1.0.0",
-            "iconv-lite": "0.4.24",
-            "js-yaml": "3.5.5",
-            "minimatch": "3.0.2",
-            "nopt": "3.0.6",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.2.8"
+            "coffee-script": "~1.10.0",
+            "dateformat": "~1.0.12",
+            "eventemitter2": "~0.4.13",
+            "exit": "~0.1.1",
+            "findup-sync": "~0.3.0",
+            "glob": "~7.0.0",
+            "grunt-cli": "~1.2.0",
+            "grunt-known-options": "~1.1.0",
+            "grunt-legacy-log": "~1.0.0",
+            "grunt-legacy-util": "~1.0.0",
+            "iconv-lite": "~0.4.13",
+            "js-yaml": "~3.5.2",
+            "minimatch": "~3.0.0",
+            "nopt": "~3.0.6",
+            "path-is-absolute": "~1.0.0",
+            "rimraf": "~2.2.8"
           },
           "dependencies": {
             "glob": {
@@ -11465,12 +11479,12 @@
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
               "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.2",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.2",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "grunt-cli": {
@@ -11478,10 +11492,10 @@
               "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
               "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
               "requires": {
-                "findup-sync": "0.3.0",
-                "grunt-known-options": "1.1.1",
-                "nopt": "3.0.6",
-                "resolve": "1.1.7"
+                "findup-sync": "~0.3.0",
+                "grunt-known-options": "~1.1.0",
+                "nopt": "~3.0.6",
+                "resolve": "~1.1.0"
               }
             },
             "iconv-lite": {
@@ -11489,7 +11503,7 @@
               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
               "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
               "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
               }
             },
             "js-yaml": {
@@ -11497,8 +11511,8 @@
               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
               "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
               "requires": {
-                "argparse": "1.0.10",
-                "esprima": "2.7.0"
+                "argparse": "^1.0.2",
+                "esprima": "^2.6.0"
               }
             },
             "resolve": {
@@ -11513,8 +11527,8 @@
           "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-1.0.0.tgz",
           "integrity": "sha1-ay7ZQRfix//jLuBFeMlv5GJam20=",
           "requires": {
-            "async": "1.5.2",
-            "rimraf": "2.6.3"
+            "async": "^1.5.2",
+            "rimraf": "^2.5.1"
           },
           "dependencies": {
             "async": {
@@ -11527,7 +11541,7 @@
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
               "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "requires": {
-                "glob": "7.1.3"
+                "glob": "^7.1.3"
               }
             }
           }
@@ -11537,8 +11551,8 @@
           "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
           "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
           "requires": {
-            "chalk": "1.1.3",
-            "file-sync-cmp": "0.1.1"
+            "chalk": "^1.1.1",
+            "file-sync-cmp": "^0.1.0"
           },
           "dependencies": {
             "chalk": {
@@ -11546,11 +11560,11 @@
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               }
             }
           }
@@ -11560,10 +11574,10 @@
           "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.0.0.tgz",
           "integrity": "sha1-hKGnodar0m7VaEE0lscxM+mQAY8=",
           "requires": {
-            "async": "1.5.2",
-            "gaze": "1.1.3",
-            "lodash": "3.10.1",
-            "tiny-lr": "0.2.1"
+            "async": "^1.5.0",
+            "gaze": "^1.0.0",
+            "lodash": "^3.10.1",
+            "tiny-lr": "^0.2.1"
           },
           "dependencies": {
             "async": {
@@ -11588,10 +11602,10 @@
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.2.tgz",
           "integrity": "sha512-WdedTJ/6zCXnI/coaouzqvkI19uwqbcPkdsXiDRKJyB5rOUlOxnCnTVbpeUdEckKVir2uHF3rDBYppj2p6N3+g==",
           "requires": {
-            "colors": "1.1.2",
-            "grunt-legacy-log-utils": "1.0.0",
-            "hooker": "0.2.3",
-            "lodash": "4.17.11"
+            "colors": "~1.1.2",
+            "grunt-legacy-log-utils": "~1.0.0",
+            "hooker": "~0.2.3",
+            "lodash": "~4.17.5"
           }
         },
         "grunt-legacy-log-utils": {
@@ -11599,8 +11613,8 @@
           "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
           "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
           "requires": {
-            "chalk": "1.1.3",
-            "lodash": "4.3.0"
+            "chalk": "~1.1.1",
+            "lodash": "~4.3.0"
           },
           "dependencies": {
             "chalk": {
@@ -11608,11 +11622,11 @@
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               }
             },
             "lodash": {
@@ -11627,13 +11641,13 @@
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
           "integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
           "requires": {
-            "async": "1.5.2",
-            "exit": "0.1.2",
-            "getobject": "0.1.0",
-            "hooker": "0.2.3",
-            "lodash": "4.3.0",
-            "underscore.string": "3.2.3",
-            "which": "1.2.14"
+            "async": "~1.5.2",
+            "exit": "~0.1.1",
+            "getobject": "~0.1.0",
+            "hooker": "~0.2.3",
+            "lodash": "~4.3.0",
+            "underscore.string": "~3.2.3",
+            "which": "~1.2.1"
           },
           "dependencies": {
             "async": {
@@ -11651,7 +11665,7 @@
               "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
               "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
               "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
               }
             }
           }
@@ -11661,9 +11675,9 @@
           "resolved": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-1.3.0.tgz",
           "integrity": "sha1-3lYGCpNN+OzuZAdLYcYwSQDXEVg=",
           "requires": {
-            "chalk": "1.1.0",
-            "npm-run-path": "1.0.0",
-            "object-assign": "4.1.1"
+            "chalk": "^1.0.0",
+            "npm-run-path": "^1.0.0",
+            "object-assign": "^4.0.0"
           }
         },
         "grunt-template": {
@@ -11676,17 +11690,17 @@
           "resolved": "https://registry.npmjs.org/grunt-ts/-/grunt-ts-6.0.0-beta.22.tgz",
           "integrity": "sha512-g9e+ZImQ7W38dfpwhp0+GUltXWidy3YGPfIA/IyGL5HMv6wmVmMMoSgscI5swhs2HSPf8yAvXAAJbwrouijoRg==",
           "requires": {
-            "chokidar": "2.0.4",
-            "csproj2ts": "1.1.0",
-            "detect-indent": "4.0.0",
-            "detect-newline": "2.1.0",
-            "es6-promise": "0.1.2",
-            "jsmin2": "1.2.1",
-            "lodash": "4.17.11",
+            "chokidar": "^2.0.4",
+            "csproj2ts": "^1.1.0",
+            "detect-indent": "^4.0.0",
+            "detect-newline": "^2.1.0",
+            "es6-promise": "~0.1.1",
+            "jsmin2": "^1.2.1",
+            "lodash": "~4.17.10",
             "ncp": "0.5.1",
             "rimraf": "2.2.6",
-            "semver": "5.5.0",
-            "strip-bom": "2.0.0"
+            "semver": "^5.3.0",
+            "strip-bom": "^2.0.0"
           },
           "dependencies": {
             "es6-promise": {
@@ -11706,10 +11720,10 @@
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
           "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
           "requires": {
-            "neo-async": "2.6.0",
-            "optimist": "0.6.1",
-            "source-map": "0.6.1",
-            "uglify-js": "3.5.3"
+            "neo-async": "^2.6.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
           },
           "dependencies": {
             "source-map": {
@@ -11731,8 +11745,8 @@
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "dev": true,
           "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
           }
         },
         "has": {
@@ -11741,7 +11755,7 @@
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
           "dev": true,
           "requires": {
-            "function-bind": "1.1.1"
+            "function-bind": "^1.1.1"
           }
         },
         "has-ansi": {
@@ -11749,7 +11763,7 @@
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "has-flag": {
@@ -11773,7 +11787,7 @@
           "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
           "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
           "requires": {
-            "has-symbol-support-x": "1.4.2"
+            "has-symbol-support-x": "^1.4.1"
           }
         },
         "has-value": {
@@ -11781,9 +11795,9 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "1.0.0",
-            "isobject": "3.0.1"
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
           }
         },
         "has-values": {
@@ -11791,8 +11805,8 @@
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
           "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
           "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -11800,7 +11814,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -11811,10 +11825,10 @@
           "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
           "dev": true,
           "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.4",
-            "hoek": "4.2.1",
-            "sntp": "2.1.0"
+            "boom": "4.x.x",
+            "cryptiles": "3.x.x",
+            "hoek": "4.x.x",
+            "sntp": "2.x.x"
           }
         },
         "hoek": {
@@ -11844,10 +11858,10 @@
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
-            "depd": "1.1.2",
+            "depd": "~1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": "1.5.0"
+            "statuses": ">= 1.4.0 < 2"
           }
         },
         "http-parser-js": {
@@ -11861,7 +11875,7 @@
           "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
           "dev": true,
           "requires": {
-            "agent-base": "4.2.1",
+            "agent-base": "4",
             "debug": "3.1.0"
           },
           "dependencies": {
@@ -11882,9 +11896,9 @@
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.16.1"
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "https-proxy-agent": {
@@ -11893,8 +11907,8 @@
           "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
           "dev": true,
           "requires": {
-            "agent-base": "4.2.1",
-            "debug": "3.2.6"
+            "agent-base": "^4.1.0",
+            "debug": "^3.1.0"
           },
           "dependencies": {
             "debug": {
@@ -11903,7 +11917,7 @@
               "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
               "dev": true,
               "requires": {
-                "ms": "2.1.1"
+                "ms": "^2.1.1"
               }
             },
             "ms": {
@@ -11920,7 +11934,7 @@
           "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.0.0"
           }
         },
         "iconv-lite": {
@@ -11946,7 +11960,7 @@
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           },
           "dependencies": {
             "minimatch": {
@@ -11955,7 +11969,7 @@
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
               }
             }
           }
@@ -11970,7 +11984,7 @@
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "inflight": {
@@ -11978,8 +11992,8 @@
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -11998,19 +12012,19 @@
           "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "3.2.0",
-            "chalk": "2.4.2",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "3.0.3",
-            "figures": "2.0.0",
-            "lodash": "4.17.11",
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.17.10",
             "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rxjs": "6.4.0",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rxjs": "^6.1.0",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
           },
           "dependencies": {
             "ansi-regex": {
@@ -12025,7 +12039,7 @@
               "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "dev": true,
               "requires": {
-                "color-convert": "1.9.3"
+                "color-convert": "^1.9.0"
               }
             },
             "chalk": {
@@ -12034,9 +12048,9 @@
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.5.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
               }
             },
             "mute-stream": {
@@ -12051,7 +12065,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             },
             "supports-color": {
@@ -12060,7 +12074,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
               }
             }
           }
@@ -12075,8 +12089,8 @@
           "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
           "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
           "requires": {
-            "from2": "2.3.0",
-            "p-is-promise": "1.1.0"
+            "from2": "^2.1.1",
+            "p-is-promise": "^1.1.0"
           }
         },
         "invert-kv": {
@@ -12109,9 +12123,9 @@
           "integrity": "sha1-UaXn+TzUCwN/fI8+JwXjSI11VgE=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "plist": "2.1.0",
-            "yargs": "6.6.0"
+            "chalk": "^1.1.3",
+            "plist": "^2.0.1",
+            "yargs": "^6.5.0"
           },
           "dependencies": {
             "chalk": {
@@ -12120,11 +12134,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               }
             },
             "is-fullwidth-code-point": {
@@ -12133,7 +12147,7 @@
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "plist": {
@@ -12144,7 +12158,7 @@
               "requires": {
                 "base64-js": "1.2.0",
                 "xmlbuilder": "8.2.2",
-                "xmldom": "0.1.21"
+                "xmldom": "0.1.x"
               }
             },
             "string-width": {
@@ -12153,9 +12167,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             },
             "yargs": {
@@ -12164,19 +12178,19 @@
               "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
               "dev": true,
               "requires": {
-                "camelcase": "3.0.0",
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.3",
-                "os-locale": "1.4.0",
-                "read-pkg-up": "1.0.1",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "1.0.2",
-                "which-module": "1.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "4.2.1"
+                "camelcase": "^3.0.0",
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.2",
+                "which-module": "^1.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^4.2.0"
               }
             }
           }
@@ -12208,7 +12222,7 @@
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "lodash": {
@@ -12229,9 +12243,9 @@
               "integrity": "sha1-P28uSWXOxWX2X/OGHWRPh5KBpXY=",
               "dev": true,
               "requires": {
-                "glob": "7.1.3",
-                "interpret": "1.2.0",
-                "rechoir": "0.6.2"
+                "glob": "^7.0.0",
+                "interpret": "^1.0.0",
+                "rechoir": "^0.6.2"
               }
             },
             "string-width": {
@@ -12240,9 +12254,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             },
             "yargs": {
@@ -12251,19 +12265,19 @@
               "integrity": "sha1-5gQyZYozh/8mnAKOrN5KUS5Djf8=",
               "dev": true,
               "requires": {
-                "camelcase": "3.0.0",
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "lodash.assign": "4.2.0",
-                "os-locale": "1.4.0",
-                "pkg-conf": "1.1.3",
-                "read-pkg-up": "1.0.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "1.0.0",
-                "string-width": "1.0.2",
-                "window-size": "0.2.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "2.4.1"
+                "camelcase": "^3.0.0",
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "lodash.assign": "^4.0.3",
+                "os-locale": "^1.4.0",
+                "pkg-conf": "^1.1.2",
+                "read-pkg-up": "^1.0.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^1.0.0",
+                "string-width": "^1.0.1",
+                "window-size": "^0.2.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^2.4.0"
               }
             },
             "yargs-parser": {
@@ -12272,8 +12286,8 @@
               "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
               "dev": true,
               "requires": {
-                "camelcase": "3.0.0",
-                "lodash.assign": "4.2.0"
+                "camelcase": "^3.0.0",
+                "lodash.assign": "^4.0.6"
               }
             }
           }
@@ -12295,7 +12309,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -12303,7 +12317,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -12319,7 +12333,7 @@
           "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
           "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
           "requires": {
-            "binary-extensions": "1.13.1"
+            "binary-extensions": "^1.0.0"
           }
         },
         "is-buffer": {
@@ -12338,7 +12352,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -12346,7 +12360,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -12362,9 +12376,9 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -12389,7 +12403,7 @@
           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
           "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -12408,7 +12422,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
           "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.1"
           }
         },
         "is-my-ip-valid": {
@@ -12421,11 +12435,11 @@
           "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
           "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
           "requires": {
-            "generate-function": "2.3.1",
-            "generate-object-property": "1.2.0",
-            "is-my-ip-valid": "1.0.0",
-            "jsonpointer": "4.0.1",
-            "xtend": "4.0.1"
+            "generate-function": "^2.0.0",
+            "generate-object-property": "^1.1.0",
+            "is-my-ip-valid": "^1.0.0",
+            "jsonpointer": "^4.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "is-number": {
@@ -12433,7 +12447,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -12441,7 +12455,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -12461,7 +12475,7 @@
           "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
           "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.1"
           }
         },
         "is-promise": {
@@ -12481,7 +12495,7 @@
           "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
           "dev": true,
           "requires": {
-            "has": "1.0.3"
+            "has": "^1.0.1"
           }
         },
         "is-resolvable": {
@@ -12500,7 +12514,7 @@
           "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
           "dev": true,
           "requires": {
-            "has-symbols": "1.0.0"
+            "has-symbols": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -12545,20 +12559,20 @@
           "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
           "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
           "requires": {
-            "abbrev": "1.0.9",
-            "async": "1.2.1",
-            "escodegen": "1.8.1",
-            "esprima": "2.7.0",
-            "glob": "5.0.15",
-            "handlebars": "4.1.1",
-            "js-yaml": "3.13.0",
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "once": "1.4.0",
-            "resolve": "1.1.7",
-            "supports-color": "3.2.3",
-            "which": "1.3.1",
-            "wordwrap": "1.0.0"
+            "abbrev": "1.0.x",
+            "async": "1.x",
+            "escodegen": "1.8.x",
+            "esprima": "2.7.x",
+            "glob": "^5.0.15",
+            "handlebars": "^4.0.1",
+            "js-yaml": "3.x",
+            "mkdirp": "0.5.x",
+            "nopt": "3.x",
+            "once": "1.x",
+            "resolve": "1.1.x",
+            "supports-color": "^3.1.0",
+            "which": "^1.1.1",
+            "wordwrap": "^1.0.0"
           },
           "dependencies": {
             "abbrev": {
@@ -12571,11 +12585,11 @@
               "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
               "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
               "requires": {
-                "esprima": "2.7.3",
-                "estraverse": "1.9.3",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.2.0"
+                "esprima": "^2.7.1",
+                "estraverse": "^1.9.1",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.2.0"
               },
               "dependencies": {
                 "esprima": {
@@ -12595,11 +12609,11 @@
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
               "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
               "requires": {
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.2",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "2 || 3",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "has-flag": {
@@ -12618,7 +12632,7 @@
               "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
               "optional": true,
               "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
               }
             },
             "supports-color": {
@@ -12626,7 +12640,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
               "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
               "requires": {
-                "has-flag": "1.0.0"
+                "has-flag": "^1.0.0"
               }
             }
           }
@@ -12637,9 +12651,9 @@
           "integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
           "dev": true,
           "requires": {
-            "binaryextensions": "2.1.2",
-            "editions": "1.3.4",
-            "textextensions": "2.4.0"
+            "binaryextensions": "2",
+            "editions": "^1.3.3",
+            "textextensions": "2"
           }
         },
         "isurl": {
@@ -12647,8 +12661,8 @@
           "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
           "requires": {
-            "has-to-string-tag-x": "1.4.1",
-            "is-object": "1.0.1"
+            "has-to-string-tag-x": "^1.2.0",
+            "is-object": "^1.0.1"
           }
         },
         "jimp": {
@@ -12657,22 +12671,22 @@
           "integrity": "sha1-3VKak3GQ9ClXp5N9Gsw6d2KZbqI=",
           "dev": true,
           "requires": {
-            "bignumber.js": "2.4.0",
+            "bignumber.js": "^2.1.0",
             "bmp-js": "0.0.3",
-            "es6-promise": "3.3.1",
-            "exif-parser": "0.1.12",
-            "file-type": "3.9.0",
-            "jpeg-js": "0.2.0",
-            "load-bmfont": "1.4.0",
-            "mime": "1.6.0",
+            "es6-promise": "^3.0.2",
+            "exif-parser": "^0.1.9",
+            "file-type": "^3.1.0",
+            "jpeg-js": "^0.2.0",
+            "load-bmfont": "^1.2.3",
+            "mime": "^1.3.4",
             "mkdirp": "0.5.1",
-            "pixelmatch": "4.0.2",
-            "pngjs": "3.4.0",
-            "read-chunk": "1.0.1",
-            "request": "2.85.0",
-            "stream-to-buffer": "0.1.0",
-            "tinycolor2": "1.4.1",
-            "url-regex": "3.2.0"
+            "pixelmatch": "^4.0.0",
+            "pngjs": "^3.0.0",
+            "read-chunk": "^1.0.1",
+            "request": "^2.65.0",
+            "stream-to-buffer": "^0.1.0",
+            "tinycolor2": "^1.1.2",
+            "url-regex": "^3.0.0"
           }
         },
         "jpeg-js": {
@@ -12691,8 +12705,8 @@
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
           "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
           "requires": {
-            "argparse": "1.0.10",
-            "esprima": "4.0.1"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           },
           "dependencies": {
             "esprima": {
@@ -12741,7 +12755,7 @@
           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -12800,7 +12814,7 @@
           "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-4.0.0.tgz",
           "integrity": "sha512-b4Myk7aQiQJvgssw2O8yITjELdqKRX4JQJUF1IUplgLaA8unv7s+UsAOwH6Q0/a09czSvlxEm306it2LBXrCzg==",
           "requires": {
-            "package-json": "5.0.0"
+            "package-json": "^5.0.0"
           }
         },
         "lcid": {
@@ -12809,7 +12823,7 @@
           "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true,
           "requires": {
-            "invert-kv": "1.0.0"
+            "invert-kv": "^1.0.0"
           }
         },
         "levn": {
@@ -12817,8 +12831,8 @@
           "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
           "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
           "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
           }
         },
         "lil-uuid": {
@@ -12839,13 +12853,13 @@
           "dev": true,
           "requires": {
             "buffer-equal": "0.0.1",
-            "mime": "1.6.0",
-            "parse-bmfont-ascii": "1.0.6",
-            "parse-bmfont-binary": "1.0.6",
-            "parse-bmfont-xml": "1.1.4",
-            "phin": "2.9.3",
-            "xhr": "2.5.0",
-            "xtend": "4.0.1"
+            "mime": "^1.3.4",
+            "parse-bmfont-ascii": "^1.0.3",
+            "parse-bmfont-binary": "^1.0.5",
+            "parse-bmfont-xml": "^1.1.4",
+            "phin": "^2.9.1",
+            "xhr": "^2.0.1",
+            "xtend": "^4.0.0"
           }
         },
         "load-json-file": {
@@ -12853,11 +12867,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "4.1.15",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "lodash": {
@@ -12876,8 +12890,8 @@
           "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
           "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
           "requires": {
-            "lodash._basecopy": "3.0.1",
-            "lodash.keys": "3.1.2"
+            "lodash._basecopy": "^3.0.0",
+            "lodash.keys": "^3.0.0"
           }
         },
         "lodash._basecopy": {
@@ -12911,9 +12925,9 @@
           "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
           "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
           "requires": {
-            "lodash._baseassign": "3.2.0",
-            "lodash._basecreate": "3.0.3",
-            "lodash._isiterateecall": "3.0.9"
+            "lodash._baseassign": "^3.0.0",
+            "lodash._basecreate": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0"
           }
         },
         "lodash.debounce": {
@@ -12941,9 +12955,9 @@
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
           "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
           "requires": {
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
+            "lodash._getnative": "^3.0.0",
+            "lodash.isarguments": "^3.0.0",
+            "lodash.isarray": "^3.0.0"
           }
         },
         "lodash.toarray": {
@@ -12958,7 +12972,7 @@
           "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
           "dev": true,
           "requires": {
-            "chalk": "2.4.2"
+            "chalk": "^2.0.1"
           },
           "dependencies": {
             "ansi-styles": {
@@ -12967,7 +12981,7 @@
               "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "dev": true,
               "requires": {
-                "color-convert": "1.9.3"
+                "color-convert": "^1.9.0"
               }
             },
             "chalk": {
@@ -12976,9 +12990,9 @@
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.5.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
               }
             },
             "supports-color": {
@@ -12987,7 +13001,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
               }
             }
           }
@@ -12998,9 +13012,9 @@
           "integrity": "sha1-+vZMEFa2NSpfu/CpO2Gpl5qEIsw=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "semver": "5.5.0",
-            "streamroller": "0.2.2"
+            "debug": "^2.2.0",
+            "semver": "^5.3.0",
+            "streamroller": "^0.2.1"
           }
         },
         "lolex": {
@@ -13013,8 +13027,8 @@
           "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
           "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
           "requires": {
-            "currently-unhandled": "0.4.1",
-            "signal-exit": "3.0.2"
+            "currently-unhandled": "^0.4.1",
+            "signal-exit": "^3.0.0"
           }
         },
         "lowercase-keys": {
@@ -13028,8 +13042,8 @@
           "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "make-fetch-happen": {
@@ -13038,17 +13052,17 @@
           "integrity": "sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==",
           "dev": true,
           "requires": {
-            "agentkeepalive": "3.5.2",
-            "cacache": "11.3.2",
-            "http-cache-semantics": "3.8.1",
-            "http-proxy-agent": "2.1.0",
-            "https-proxy-agent": "2.2.1",
-            "lru-cache": "4.1.5",
-            "mississippi": "3.0.0",
-            "node-fetch-npm": "2.0.2",
-            "promise-retry": "1.1.1",
-            "socks-proxy-agent": "4.0.2",
-            "ssri": "6.0.1"
+            "agentkeepalive": "^3.4.1",
+            "cacache": "^11.0.1",
+            "http-cache-semantics": "^3.8.1",
+            "http-proxy-agent": "^2.1.0",
+            "https-proxy-agent": "^2.2.1",
+            "lru-cache": "^4.1.2",
+            "mississippi": "^3.0.0",
+            "node-fetch-npm": "^2.0.2",
+            "promise-retry": "^1.1.1",
+            "socks-proxy-agent": "^4.0.0",
+            "ssri": "^6.0.0"
           },
           "dependencies": {
             "smart-buffer": {
@@ -13063,7 +13077,7 @@
               "integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
               "dev": true,
               "requires": {
-                "ip": "1.1.5",
+                "ip": "^1.1.5",
                 "smart-buffer": "4.0.2"
               }
             },
@@ -13073,8 +13087,8 @@
               "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
               "dev": true,
               "requires": {
-                "agent-base": "4.2.1",
-                "socks": "2.3.2"
+                "agent-base": "~4.2.1",
+                "socks": "~2.3.2"
               }
             }
           }
@@ -13094,7 +13108,7 @@
           "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
           "requires": {
-            "object-visit": "1.0.1"
+            "object-visit": "^1.0.0"
           }
         },
         "marked": {
@@ -13109,11 +13123,11 @@
           "integrity": "sha512-7UBFww1rdx0w9HehLMCVYa8/AxXaiDigDfMsJcj82/wgLQG9cj+oiMAVlJpeWD57VFJY2OYY+bKeEVIjIlxi+w==",
           "dev": true,
           "requires": {
-            "cardinal": "2.1.1",
-            "chalk": "2.4.2",
-            "cli-table": "0.3.1",
-            "lodash.assign": "4.2.0",
-            "node-emoji": "1.10.0"
+            "cardinal": "^2.1.1",
+            "chalk": "^2.4.1",
+            "cli-table": "^0.3.1",
+            "lodash.assign": "^4.2.0",
+            "node-emoji": "^1.4.1"
           },
           "dependencies": {
             "ansi-styles": {
@@ -13122,7 +13136,7 @@
               "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "dev": true,
               "requires": {
-                "color-convert": "1.9.3"
+                "color-convert": "^1.9.0"
               }
             },
             "chalk": {
@@ -13131,9 +13145,9 @@
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.5.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
               }
             },
             "cli-table": {
@@ -13157,7 +13171,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
               }
             }
           }
@@ -13172,16 +13186,16 @@
           "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "requires": {
-            "camelcase-keys": "2.1.0",
-            "decamelize": "1.2.0",
-            "loud-rejection": "1.6.0",
-            "map-obj": "1.0.1",
-            "minimist": "1.2.0",
-            "normalize-package-data": "2.5.0",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "redent": "1.0.0",
-            "trim-newlines": "1.0.0"
+            "camelcase-keys": "^2.0.0",
+            "decamelize": "^1.1.2",
+            "loud-rejection": "^1.0.0",
+            "map-obj": "^1.0.1",
+            "minimist": "^1.1.3",
+            "normalize-package-data": "^2.3.4",
+            "object-assign": "^4.0.1",
+            "read-pkg-up": "^1.0.1",
+            "redent": "^1.0.0",
+            "trim-newlines": "^1.0.0"
           },
           "dependencies": {
             "minimist": {
@@ -13202,19 +13216,19 @@
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.13",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         },
         "mime": {
@@ -13233,7 +13247,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
           "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
           "requires": {
-            "mime-db": "1.38.0"
+            "mime-db": "~1.38.0"
           }
         },
         "mimic-fn": {
@@ -13253,7 +13267,7 @@
           "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
           "dev": true,
           "requires": {
-            "dom-walk": "0.1.1"
+            "dom-walk": "^0.1.0"
           }
         },
         "minimatch": {
@@ -13261,7 +13275,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
           "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.0.0"
           }
         },
         "minimist": {
@@ -13275,8 +13289,8 @@
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.3"
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
           },
           "dependencies": {
             "yallist": {
@@ -13293,7 +13307,7 @@
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "requires": {
-            "minipass": "2.3.5"
+            "minipass": "^2.2.1"
           }
         },
         "mississippi": {
@@ -13302,16 +13316,16 @@
           "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
           "dev": true,
           "requires": {
-            "concat-stream": "1.6.2",
-            "duplexify": "3.7.1",
-            "end-of-stream": "1.4.1",
-            "flush-write-stream": "1.1.1",
-            "from2": "2.3.0",
-            "parallel-transform": "1.1.0",
-            "pump": "3.0.0",
-            "pumpify": "1.5.1",
-            "stream-each": "1.2.3",
-            "through2": "2.0.5"
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
           }
         },
         "mixin-deep": {
@@ -13319,8 +13333,8 @@
           "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
           "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
           "requires": {
-            "for-in": "1.0.2",
-            "is-extendable": "1.0.1"
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -13328,7 +13342,7 @@
               "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "requires": {
-                "is-plain-object": "2.0.4"
+                "is-plain-object": "^2.0.4"
               }
             }
           }
@@ -13364,7 +13378,7 @@
               "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
               "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
               "requires": {
-                "graceful-readlink": "1.0.1"
+                "graceful-readlink": ">= 1.0.0"
               }
             },
             "debug": {
@@ -13385,12 +13399,12 @@
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
               "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.2",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.2",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "has-flag": {
@@ -13408,7 +13422,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
               "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
               "requires": {
-                "has-flag": "1.0.0"
+                "has-flag": "^1.0.0"
               }
             }
           }
@@ -13419,12 +13433,12 @@
           "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
           "dev": true,
           "requires": {
-            "aproba": "1.2.0",
-            "copy-concurrently": "1.0.5",
-            "fs-write-stream-atomic": "1.0.10",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.3",
-            "run-queue": "1.0.3"
+            "aproba": "^1.1.1",
+            "copy-concurrently": "^1.0.0",
+            "fs-write-stream-atomic": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.3"
           },
           "dependencies": {
             "rimraf": {
@@ -13433,7 +13447,7 @@
               "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "dev": true,
               "requires": {
-                "glob": "7.1.3"
+                "glob": "^7.1.3"
               }
             }
           }
@@ -13465,17 +13479,17 @@
           "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
           "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "fragment-cache": "0.2.1",
-            "is-windows": "1.0.2",
-            "kind-of": "6.0.2",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           }
         },
         "nativescript-dev-xcode": {
@@ -13484,8 +13498,8 @@
           "integrity": "sha512-auQd2/qVdOwD/8v+rHKLflYE8jpT4o1wMwtEFkFGp7sewLkBQz7y9pH79oNM7ztyw0gnL/cFAhLT/ViGLWdw6w==",
           "dev": true,
           "requires": {
-            "simple-plist": "1.0.0",
-            "uuid": "3.3.2"
+            "simple-plist": "^1.0.0",
+            "uuid": "^3.3.2"
           },
           "dependencies": {
             "base64-js": {
@@ -13500,7 +13514,7 @@
               "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
               "dev": true,
               "requires": {
-                "big-integer": "1.6.43"
+                "big-integer": "^1.6.7"
               }
             },
             "plist": {
@@ -13509,9 +13523,9 @@
               "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
               "dev": true,
               "requires": {
-                "base64-js": "1.3.0",
-                "xmlbuilder": "9.0.7",
-                "xmldom": "0.1.21"
+                "base64-js": "^1.2.3",
+                "xmlbuilder": "^9.0.7",
+                "xmldom": "0.1.x"
               }
             },
             "simple-plist": {
@@ -13522,7 +13536,7 @@
               "requires": {
                 "bplist-creator": "0.0.7",
                 "bplist-parser": "0.1.1",
-                "plist": "3.0.1"
+                "plist": "^3.0.1"
               }
             },
             "uuid": {
@@ -13588,7 +13602,7 @@
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
               }
             },
             "tslint": {
@@ -13597,16 +13611,16 @@
               "integrity": "sha1-dhyEArgONHt3M6BDkKdXslNYBGc=",
               "dev": true,
               "requires": {
-                "babel-code-frame": "6.26.0",
-                "colors": "1.1.2",
-                "commander": "2.19.0",
-                "diff": "3.5.0",
-                "glob": "7.1.3",
-                "minimatch": "3.0.4",
-                "resolve": "1.10.0",
-                "semver": "5.5.0",
-                "tslib": "1.9.3",
-                "tsutils": "2.29.0"
+                "babel-code-frame": "^6.22.0",
+                "colors": "^1.1.2",
+                "commander": "^2.9.0",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.7.1",
+                "tsutils": "^2.3.0"
               }
             }
           }
@@ -13642,11 +13656,11 @@
           "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.10.tgz",
           "integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
           "requires": {
-            "@sinonjs/formatio": "3.2.1",
-            "@sinonjs/text-encoding": "0.7.1",
-            "just-extend": "4.0.2",
-            "lolex": "2.7.5",
-            "path-to-regexp": "1.7.0"
+            "@sinonjs/formatio": "^3.1.0",
+            "@sinonjs/text-encoding": "^0.7.1",
+            "just-extend": "^4.0.2",
+            "lolex": "^2.3.2",
+            "path-to-regexp": "^1.7.0"
           }
         },
         "node-emoji": {
@@ -13655,7 +13669,7 @@
           "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
           "dev": true,
           "requires": {
-            "lodash.toarray": "4.4.0"
+            "lodash.toarray": "^4.4.0"
           }
         },
         "node-fetch-npm": {
@@ -13664,9 +13678,9 @@
           "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
           "dev": true,
           "requires": {
-            "encoding": "0.1.12",
-            "json-parse-better-errors": "1.0.2",
-            "safe-buffer": "5.1.2"
+            "encoding": "^0.1.11",
+            "json-parse-better-errors": "^1.0.0",
+            "safe-buffer": "^5.1.1"
           }
         },
         "nopt": {
@@ -13674,7 +13688,7 @@
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "requires": {
-            "abbrev": "1.1.1"
+            "abbrev": "1"
           }
         },
         "normalize-package-data": {
@@ -13682,10 +13696,10 @@
           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
           "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
           "requires": {
-            "hosted-git-info": "2.7.1",
-            "resolve": "1.10.0",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.4"
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "normalize-path": {
@@ -13693,7 +13707,7 @@
           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "requires": {
-            "remove-trailing-separator": "1.1.0"
+            "remove-trailing-separator": "^1.0.1"
           }
         },
         "normalize-url": {
@@ -13701,9 +13715,9 @@
           "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
           "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
           "requires": {
-            "prepend-http": "2.0.0",
-            "query-string": "5.1.1",
-            "sort-keys": "2.0.0"
+            "prepend-http": "^2.0.0",
+            "query-string": "^5.0.1",
+            "sort-keys": "^2.0.0"
           }
         },
         "npm-bundled": {
@@ -13718,10 +13732,10 @@
           "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.7.1",
-            "osenv": "0.1.5",
-            "semver": "5.5.0",
-            "validate-npm-package-name": "3.0.0"
+            "hosted-git-info": "^2.6.0",
+            "osenv": "^0.1.5",
+            "semver": "^5.5.0",
+            "validate-npm-package-name": "^3.0.0"
           },
           "dependencies": {
             "osenv": {
@@ -13730,8 +13744,8 @@
               "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "dev": true,
               "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
               }
             }
           }
@@ -13742,8 +13756,8 @@
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.6"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npm-pick-manifest": {
@@ -13752,9 +13766,9 @@
           "integrity": "sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==",
           "dev": true,
           "requires": {
-            "figgy-pudding": "3.5.1",
-            "npm-package-arg": "6.1.0",
-            "semver": "5.5.0"
+            "figgy-pudding": "^3.5.1",
+            "npm-package-arg": "^6.0.0",
+            "semver": "^5.4.1"
           }
         },
         "npm-run-path": {
@@ -13762,7 +13776,7 @@
           "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
           "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
           "requires": {
-            "path-key": "1.0.0"
+            "path-key": "^1.0.0"
           }
         },
         "number-is-nan": {
@@ -13786,9 +13800,9 @@
           "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
           "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
           "requires": {
-            "copy-descriptor": "0.1.1",
-            "define-property": "0.2.5",
-            "kind-of": "3.2.2"
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
           },
           "dependencies": {
             "define-property": {
@@ -13796,7 +13810,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "kind-of": {
@@ -13804,7 +13818,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -13820,7 +13834,7 @@
           "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.0"
           }
         },
         "object.pick": {
@@ -13828,7 +13842,7 @@
           "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.1"
           }
         },
         "on-finished": {
@@ -13844,7 +13858,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "onetime": {
@@ -13853,7 +13867,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.2.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "open": {
@@ -13867,8 +13881,8 @@
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
           },
           "dependencies": {
             "wordwrap": {
@@ -13883,12 +13897,12 @@
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
           "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
           "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.6",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.4",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "wordwrap": "~1.0.0"
           }
         },
         "ora": {
@@ -13897,12 +13911,12 @@
           "integrity": "sha512-g+IR0nMUXq1k4nE3gkENbN4wkF0XsVZFyxznTF6CdmwQ9qeTGONGpSR9LM5//1l0TVvJoJF3MkMtJp6slUsWFg==",
           "dev": true,
           "requires": {
-            "chalk": "2.4.2",
-            "cli-cursor": "2.1.0",
-            "cli-spinners": "1.3.1",
-            "log-symbols": "2.2.0",
-            "strip-ansi": "4.0.0",
-            "wcwidth": "1.0.1"
+            "chalk": "^2.3.1",
+            "cli-cursor": "^2.1.0",
+            "cli-spinners": "^1.1.0",
+            "log-symbols": "^2.2.0",
+            "strip-ansi": "^4.0.0",
+            "wcwidth": "^1.0.1"
           },
           "dependencies": {
             "ansi-regex": {
@@ -13917,7 +13931,7 @@
               "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "dev": true,
               "requires": {
-                "color-convert": "1.9.3"
+                "color-convert": "^1.9.0"
               }
             },
             "chalk": {
@@ -13926,9 +13940,9 @@
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
               "dev": true,
               "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.5.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
               }
             },
             "strip-ansi": {
@@ -13937,7 +13951,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             },
             "supports-color": {
@@ -13946,7 +13960,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
               }
             }
           }
@@ -13962,7 +13976,7 @@
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
-            "lcid": "1.0.0"
+            "lcid": "^1.0.0"
           }
         },
         "os-tmpdir": {
@@ -13977,8 +13991,8 @@
           "integrity": "sha1-g88FxtZFj8TVrGNi6jJdkvJ1Qhc=",
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "p-cancelable": {
@@ -14001,7 +14015,7 @@
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
           "requires": {
-            "p-finally": "1.0.0"
+            "p-finally": "^1.0.0"
           }
         },
         "pac-proxy-agent": {
@@ -14010,14 +14024,14 @@
           "integrity": "sha512-cDNAN1Ehjbf5EHkNY5qnRhGPUCp6SnpyVof5fRzN800QV1Y2OkzbH9rmjZkbBRa8igof903yOnjIl6z0SlAhxA==",
           "dev": true,
           "requires": {
-            "agent-base": "4.2.1",
-            "debug": "3.2.6",
-            "get-uri": "2.0.3",
-            "http-proxy-agent": "2.1.0",
-            "https-proxy-agent": "2.2.1",
-            "pac-resolver": "3.0.0",
-            "raw-body": "2.3.3",
-            "socks-proxy-agent": "3.0.1"
+            "agent-base": "^4.2.0",
+            "debug": "^3.1.0",
+            "get-uri": "^2.0.0",
+            "http-proxy-agent": "^2.1.0",
+            "https-proxy-agent": "^2.2.1",
+            "pac-resolver": "^3.0.0",
+            "raw-body": "^2.2.0",
+            "socks-proxy-agent": "^3.0.0"
           },
           "dependencies": {
             "debug": {
@@ -14026,7 +14040,7 @@
               "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
               "dev": true,
               "requires": {
-                "ms": "2.1.1"
+                "ms": "^2.1.1"
               }
             },
             "ms": {
@@ -14043,11 +14057,11 @@
           "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "degenerator": "1.0.4",
-            "ip": "1.1.5",
-            "netmask": "1.0.6",
-            "thunkify": "2.1.2"
+            "co": "^4.6.0",
+            "degenerator": "^1.0.4",
+            "ip": "^1.1.5",
+            "netmask": "^1.0.6",
+            "thunkify": "^2.1.2"
           }
         },
         "package-json": {
@@ -14055,10 +14069,10 @@
           "resolved": "https://registry.npmjs.org/package-json/-/package-json-5.0.0.tgz",
           "integrity": "sha512-EeHQFFTlEmLrkIQoxbE9w0FuAWHoc1XpthDqnZ/i9keOt701cteyXwAxQFLpVqVjj3feh2TodkihjLaRUtIgLg==",
           "requires": {
-            "got": "8.3.2",
-            "registry-auth-token": "3.4.0",
-            "registry-url": "3.1.0",
-            "semver": "5.5.0"
+            "got": "^8.3.1",
+            "registry-auth-token": "^3.3.2",
+            "registry-url": "^3.1.0",
+            "semver": "^5.5.0"
           }
         },
         "pacote": {
@@ -14067,31 +14081,31 @@
           "integrity": "sha512-wTOOfpaAQNEQNtPEx92x9Y9kRWVu45v583XT8x2oEV2xRB74+xdqMZIeGW4uFvAyZdmSBtye+wKdyyLaT8pcmw==",
           "dev": true,
           "requires": {
-            "bluebird": "3.5.3",
-            "cacache": "11.3.2",
-            "get-stream": "3.0.0",
-            "glob": "7.1.3",
-            "lru-cache": "4.1.5",
-            "make-fetch-happen": "4.0.1",
-            "minimatch": "3.0.4",
-            "minipass": "2.3.5",
-            "mississippi": "3.0.0",
-            "mkdirp": "0.5.1",
-            "normalize-package-data": "2.5.0",
-            "npm-package-arg": "6.1.0",
-            "npm-packlist": "1.4.1",
-            "npm-pick-manifest": "2.2.3",
-            "osenv": "0.1.5",
-            "promise-inflight": "1.0.1",
-            "promise-retry": "1.1.1",
-            "protoduck": "5.0.1",
-            "rimraf": "2.6.3",
-            "safe-buffer": "5.1.2",
-            "semver": "5.5.0",
-            "ssri": "6.0.1",
-            "tar": "4.4.4",
-            "unique-filename": "1.1.1",
-            "which": "1.3.1"
+            "bluebird": "^3.5.1",
+            "cacache": "^11.0.2",
+            "get-stream": "^3.0.0",
+            "glob": "^7.1.2",
+            "lru-cache": "^4.1.3",
+            "make-fetch-happen": "^4.0.1",
+            "minimatch": "^3.0.4",
+            "minipass": "^2.3.3",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "normalize-package-data": "^2.4.0",
+            "npm-package-arg": "^6.1.0",
+            "npm-packlist": "^1.1.10",
+            "npm-pick-manifest": "^2.1.0",
+            "osenv": "^0.1.5",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^1.1.1",
+            "protoduck": "^5.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.2",
+            "semver": "^5.5.0",
+            "ssri": "^6.0.0",
+            "tar": "^4.4.3",
+            "unique-filename": "^1.1.0",
+            "which": "^1.3.0"
           },
           "dependencies": {
             "minimatch": {
@@ -14100,7 +14114,7 @@
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
               }
             },
             "osenv": {
@@ -14109,8 +14123,8 @@
               "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
               "dev": true,
               "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
               }
             },
             "rimraf": {
@@ -14119,7 +14133,7 @@
               "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
               "dev": true,
               "requires": {
-                "glob": "7.1.3"
+                "glob": "^7.1.3"
               }
             }
           }
@@ -14136,9 +14150,9 @@
           "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
           "dev": true,
           "requires": {
-            "cyclist": "0.2.2",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "cyclist": "~0.2.2",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.1.5"
           }
         },
         "parse-bmfont-ascii": {
@@ -14159,8 +14173,8 @@
           "integrity": "sha512-bjnliEOmGv3y1aMEfREMBJ9tfL3WR0i0CKPj61DnSLaoxWR3nLrsQrEbCId/8rF4NyRF0cCqisSVXyQYWM+mCQ==",
           "dev": true,
           "requires": {
-            "xml-parse-from-string": "1.0.1",
-            "xml2js": "0.4.19"
+            "xml-parse-from-string": "^1.0.0",
+            "xml2js": "^0.4.5"
           }
         },
         "parse-headers": {
@@ -14169,8 +14183,8 @@
           "integrity": "sha512-/LypJhzFmyBIDYP9aDVgeyEb5sQfbfY5mnDq4hVhlQ69js87wXfmEI5V3xI6vvXasqebp0oCytYFLxsBVfCzSg==",
           "dev": true,
           "requires": {
-            "for-each": "0.3.3",
-            "string.prototype.trim": "1.1.2"
+            "for-each": "^0.3.3",
+            "string.prototype.trim": "^1.1.2"
           }
         },
         "parse-json": {
@@ -14178,7 +14192,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "1.3.2"
+            "error-ex": "^1.2.0"
           }
         },
         "parseurl": {
@@ -14201,7 +14215,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-is-absolute": {
@@ -14244,9 +14258,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "4.1.15",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pathval": {
@@ -14293,7 +14307,7 @@
           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "pixelmatch": {
@@ -14302,7 +14316,7 @@
           "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
           "dev": true,
           "requires": {
-            "pngjs": "3.4.0"
+            "pngjs": "^3.0.0"
           }
         },
         "pkg-conf": {
@@ -14311,10 +14325,10 @@
           "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2",
-            "load-json-file": "1.1.0",
-            "object-assign": "4.1.1",
-            "symbol": "0.2.3"
+            "find-up": "^1.0.0",
+            "load-json-file": "^1.1.0",
+            "object-assign": "^4.0.1",
+            "symbol": "^0.2.1"
           }
         },
         "plist": {
@@ -14326,7 +14340,7 @@
             "base64-js": "0.0.6",
             "util-deprecate": "1.0.0",
             "xmlbuilder": "2.2.1",
-            "xmldom": "0.1.21"
+            "xmldom": "0.1.x"
           },
           "dependencies": {
             "base64-js": {
@@ -14347,7 +14361,7 @@
               "integrity": "sha1-kyZDDxMNh0NdTECGZDqikm4QWjI=",
               "dev": true,
               "requires": {
-                "lodash-node": "2.4.1"
+                "lodash-node": "~2.4.1"
               }
             }
           }
@@ -14376,7 +14390,7 @@
               "requires": {
                 "base64-js": "1.2.0",
                 "xmlbuilder": "8.2.2",
-                "xmldom": "0.1.21"
+                "xmldom": "0.1.x"
               }
             }
           }
@@ -14435,8 +14449,8 @@
           "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
           "dev": true,
           "requires": {
-            "err-code": "1.1.2",
-            "retry": "0.10.1"
+            "err-code": "^1.0.0",
+            "retry": "^0.10.0"
           }
         },
         "proper-lockfile": {
@@ -14445,9 +14459,9 @@
           "integrity": "sha512-iMghHHXv2bsxl6NchhEaFck8tvX3F9cknEEh1SUpguUOBjN7PAAW9BLzmbc1g/mCD1gY3EE2EABBHPJfFdHFmA==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.15",
-            "retry": "0.12.0",
-            "signal-exit": "3.0.2"
+            "graceful-fs": "^4.1.11",
+            "retry": "^0.12.0",
+            "signal-exit": "^3.0.2"
           },
           "dependencies": {
             "retry": {
@@ -14464,7 +14478,7 @@
           "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
           "dev": true,
           "requires": {
-            "genfun": "5.0.0"
+            "genfun": "^5.0.0"
           }
         },
         "proxy-agent": {
@@ -14473,14 +14487,14 @@
           "integrity": "sha512-CNKuhC1jVtm8KJYFTS2ZRO71VCBx3QSA92So/e6NrY6GoJonkx3Irnk4047EsCcswczwqAekRj3s8qLRGahSKg==",
           "dev": true,
           "requires": {
-            "agent-base": "4.2.1",
-            "debug": "3.2.6",
-            "http-proxy-agent": "2.1.0",
-            "https-proxy-agent": "2.2.1",
-            "lru-cache": "4.1.5",
-            "pac-proxy-agent": "2.0.2",
-            "proxy-from-env": "1.0.0",
-            "socks-proxy-agent": "3.0.1"
+            "agent-base": "^4.2.0",
+            "debug": "^3.1.0",
+            "http-proxy-agent": "^2.1.0",
+            "https-proxy-agent": "^2.2.1",
+            "lru-cache": "^4.1.2",
+            "pac-proxy-agent": "^2.0.1",
+            "proxy-from-env": "^1.0.0",
+            "socks-proxy-agent": "^3.0.0"
           },
           "dependencies": {
             "debug": {
@@ -14489,7 +14503,7 @@
               "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
               "dev": true,
               "requires": {
-                "ms": "2.1.1"
+                "ms": "^2.1.1"
               }
             },
             "ms": {
@@ -14521,8 +14535,8 @@
               "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
               "dev": true,
               "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
               }
             }
           }
@@ -14539,10 +14553,10 @@
           "integrity": "sha512-yDDkqrvhFrBYFZsI4EL0Atnilo00OrRR+hCw86iTlkinMMxQbZhdn5yePrSc3GUs62kn3xDC6b73zaIKUYwWFg==",
           "dev": true,
           "requires": {
-            "agentkeepalive": "3.5.2",
-            "lil-uuid": "0.1.1",
-            "superagent": "3.8.3",
-            "superagent-proxy": "1.0.3"
+            "agentkeepalive": "^3.1.0",
+            "lil-uuid": "^0.1.1",
+            "superagent": "^3.8.1",
+            "superagent-proxy": "^1.0.2"
           }
         },
         "pump": {
@@ -14551,8 +14565,8 @@
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "pumpify": {
@@ -14561,9 +14575,9 @@
           "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
           "dev": true,
           "requires": {
-            "duplexify": "3.7.1",
-            "inherits": "2.0.3",
-            "pump": "2.0.1"
+            "duplexify": "^3.6.0",
+            "inherits": "^2.0.3",
+            "pump": "^2.0.0"
           },
           "dependencies": {
             "pump": {
@@ -14572,8 +14586,8 @@
               "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
               "dev": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
               }
             }
           }
@@ -14607,9 +14621,9 @@
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "requires": {
-            "decode-uri-component": "0.2.0",
-            "object-assign": "4.1.1",
-            "strict-uri-encode": "1.1.0"
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
           }
         },
         "raw-body": {
@@ -14630,7 +14644,7 @@
               "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
               "dev": true,
               "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
               }
             }
           }
@@ -14640,10 +14654,10 @@
           "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "requires": {
-            "deep-extend": "0.6.0",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -14664,9 +14678,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.5.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -14674,8 +14688,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "readable-stream": {
@@ -14683,13 +14697,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "readdirp": {
@@ -14697,9 +14711,9 @@
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
           "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
           "requires": {
-            "graceful-fs": "4.1.15",
-            "micromatch": "3.1.10",
-            "readable-stream": "2.3.6"
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
           }
         },
         "readline2": {
@@ -14707,8 +14721,8 @@
           "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
           "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
             "mute-stream": "0.0.5"
           },
           "dependencies": {
@@ -14717,7 +14731,7 @@
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             }
           }
@@ -14727,7 +14741,7 @@
           "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
           "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
           "requires": {
-            "resolve": "1.10.0"
+            "resolve": "^1.1.6"
           }
         },
         "redent": {
@@ -14735,8 +14749,8 @@
           "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "requires": {
-            "indent-string": "2.1.0",
-            "strip-indent": "1.0.1"
+            "indent-string": "^2.1.0",
+            "strip-indent": "^1.0.1"
           }
         },
         "redeyed": {
@@ -14745,7 +14759,7 @@
           "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
           "dev": true,
           "requires": {
-            "esprima": "4.0.1"
+            "esprima": "~4.0.0"
           },
           "dependencies": {
             "esprima": {
@@ -14761,8 +14775,8 @@
           "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
           "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
           "requires": {
-            "extend-shallow": "3.0.2",
-            "safe-regex": "1.1.0"
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
           }
         },
         "registry-auth-token": {
@@ -14770,8 +14784,8 @@
           "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
           "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
           "requires": {
-            "rc": "1.2.8",
-            "safe-buffer": "5.1.2"
+            "rc": "^1.1.6",
+            "safe-buffer": "^5.0.1"
           }
         },
         "registry-url": {
@@ -14779,7 +14793,7 @@
           "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
           "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "requires": {
-            "rc": "1.2.8"
+            "rc": "^1.0.1"
           }
         },
         "remove-trailing-separator": {
@@ -14802,7 +14816,7 @@
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "request": {
@@ -14811,28 +14825,28 @@
           "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.8.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.7",
-            "extend": "3.0.2",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.3",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.22",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.2",
-            "safe-buffer": "5.1.2",
-            "stringstream": "0.0.6",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.3.2"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           },
           "dependencies": {
             "uuid": {
@@ -14860,8 +14874,8 @@
           "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
           "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
           "requires": {
-            "caller-path": "0.1.0",
-            "resolve-from": "1.0.1"
+            "caller-path": "^0.1.0",
+            "resolve-from": "^1.0.0"
           }
         },
         "resolve": {
@@ -14869,7 +14883,7 @@
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
           "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
           "requires": {
-            "path-parse": "1.0.6"
+            "path-parse": "^1.0.6"
           }
         },
         "resolve-from": {
@@ -14887,7 +14901,7 @@
           "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
           "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
           "requires": {
-            "lowercase-keys": "1.0.1"
+            "lowercase-keys": "^1.0.0"
           }
         },
         "restore-cursor": {
@@ -14896,8 +14910,8 @@
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
           }
         },
         "ret": {
@@ -14922,7 +14936,7 @@
           "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
           "dev": true,
           "requires": {
-            "is-promise": "2.1.0"
+            "is-promise": "^2.1.0"
           }
         },
         "run-queue": {
@@ -14931,7 +14945,7 @@
           "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
           "dev": true,
           "requires": {
-            "aproba": "1.2.0"
+            "aproba": "^1.1.1"
           }
         },
         "rx-lite": {
@@ -14945,7 +14959,7 @@
           "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
           "dev": true,
           "requires": {
-            "tslib": "1.9.3"
+            "tslib": "^1.9.0"
           }
         },
         "safe-buffer": {
@@ -14958,7 +14972,7 @@
           "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
           "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
           "requires": {
-            "ret": "0.1.15"
+            "ret": "~0.1.10"
           }
         },
         "safer-buffer": {
@@ -14992,10 +15006,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
           "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "split-string": "3.1.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -15003,7 +15017,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -15019,9 +15033,9 @@
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.6.tgz",
           "integrity": "sha1-N5zM+1a5HIYB5HkzVutTgpJN6a0=",
           "requires": {
-            "glob": "7.1.3",
-            "interpret": "1.2.0",
-            "rechoir": "0.6.2"
+            "glob": "^7.0.0",
+            "interpret": "^1.0.0",
+            "rechoir": "^0.6.2"
           }
         },
         "shortid": {
@@ -15030,7 +15044,7 @@
           "integrity": "sha512-sw0knB/ioTu/jVYgJz1IP1b5uhPZtZYwQ9ir/EqXZHI4+Jh8rzzGLM3LKptGHBKoDsgTBDfr4yCRNUX7hEIksQ==",
           "dev": true,
           "requires": {
-            "nanoid": "1.3.4"
+            "nanoid": "^1.0.7"
           }
         },
         "should": {
@@ -15092,7 +15106,7 @@
               "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
               "dev": true,
               "requires": {
-                "big-integer": "1.6.43"
+                "big-integer": "^1.6.7"
               }
             },
             "plist": {
@@ -15103,7 +15117,7 @@
               "requires": {
                 "base64-js": "1.1.2",
                 "xmlbuilder": "8.2.2",
-                "xmldom": "0.1.21"
+                "xmldom": "0.1.x"
               }
             }
           }
@@ -15114,7 +15128,7 @@
           "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
           "dev": true,
           "requires": {
-            "is-arrayish": "0.3.2"
+            "is-arrayish": "^0.3.1"
           }
         },
         "sinon": {
@@ -15122,13 +15136,13 @@
           "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.2.tgz",
           "integrity": "sha512-5uLBZPdCWl59Lpbf45ygKj7Z0LVol+ftBe7RDIXOQV/sF58pcFmbK8raA7bt6eljNuGnvBP+/ZxlicVn0emDjA==",
           "requires": {
-            "diff": "3.5.0",
+            "diff": "^3.1.0",
             "formatio": "1.2.0",
-            "lodash.get": "4.4.2",
-            "lolex": "2.7.5",
-            "nise": "1.4.10",
-            "supports-color": "4.5.0",
-            "type-detect": "4.0.8"
+            "lodash.get": "^4.4.2",
+            "lolex": "^2.2.0",
+            "nise": "^1.2.0",
+            "supports-color": "^4.4.0",
+            "type-detect": "^4.0.0"
           },
           "dependencies": {
             "has-flag": {
@@ -15141,7 +15155,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
               "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
               "requires": {
-                "has-flag": "2.0.0"
+                "has-flag": "^2.0.0"
               }
             }
           }
@@ -15162,14 +15176,14 @@
           "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
           "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
           "requires": {
-            "base": "0.11.2",
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "map-cache": "0.2.2",
-            "source-map": "0.5.6",
-            "source-map-resolve": "0.5.2",
-            "use": "3.1.1"
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -15177,7 +15191,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
@@ -15185,7 +15199,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -15195,9 +15209,9 @@
           "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
           "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
           "requires": {
-            "define-property": "1.0.0",
-            "isobject": "3.0.1",
-            "snapdragon-util": "3.0.1"
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -15205,7 +15219,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "is-accessor-descriptor": {
@@ -15213,7 +15227,7 @@
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
@@ -15221,7 +15235,7 @@
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
@@ -15229,9 +15243,9 @@
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             }
           }
@@ -15241,7 +15255,7 @@
           "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
           "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.2.0"
           },
           "dependencies": {
             "kind-of": {
@@ -15249,7 +15263,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -15260,7 +15274,7 @@
           "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
           "dev": true,
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           }
         },
         "socks": {
@@ -15269,8 +15283,8 @@
           "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
           "dev": true,
           "requires": {
-            "ip": "1.1.5",
-            "smart-buffer": "1.1.15"
+            "ip": "^1.1.4",
+            "smart-buffer": "^1.0.13"
           }
         },
         "socks-proxy-agent": {
@@ -15279,8 +15293,8 @@
           "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
           "dev": true,
           "requires": {
-            "agent-base": "4.2.1",
-            "socks": "1.1.10"
+            "agent-base": "^4.1.0",
+            "socks": "^1.1.10"
           }
         },
         "sort-keys": {
@@ -15288,7 +15302,7 @@
           "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
           "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
           "requires": {
-            "is-plain-obj": "1.1.0"
+            "is-plain-obj": "^1.0.0"
           }
         },
         "source-map": {
@@ -15301,11 +15315,11 @@
           "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
           "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
           "requires": {
-            "atob": "2.1.2",
-            "decode-uri-component": "0.2.0",
-            "resolve-url": "0.2.1",
-            "source-map-url": "0.4.0",
-            "urix": "0.1.0"
+            "atob": "^2.1.1",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
           }
         },
         "source-map-support": {
@@ -15313,7 +15327,7 @@
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
           "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
           "requires": {
-            "source-map": "0.6.1"
+            "source-map": "^0.6.0"
           },
           "dependencies": {
             "source-map": {
@@ -15333,8 +15347,8 @@
           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
           "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
           "requires": {
-            "spdx-expression-parse": "3.0.0",
-            "spdx-license-ids": "3.0.3"
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-exceptions": {
@@ -15347,8 +15361,8 @@
           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
           "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "requires": {
-            "spdx-exceptions": "2.2.0",
-            "spdx-license-ids": "3.0.3"
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-license-ids": {
@@ -15361,7 +15375,7 @@
           "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
           "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
           "requires": {
-            "extend-shallow": "3.0.2"
+            "extend-shallow": "^3.0.0"
           }
         },
         "sprintf-js": {
@@ -15375,15 +15389,15 @@
           "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
           "dev": true,
           "requires": {
-            "asn1": "0.2.4",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.2",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.2",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "safer-buffer": "2.1.2",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
           }
         },
         "ssri": {
@@ -15392,7 +15406,7 @@
           "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "dev": true,
           "requires": {
-            "figgy-pudding": "3.5.1"
+            "figgy-pudding": "^3.5.1"
           }
         },
         "static-extend": {
@@ -15400,8 +15414,8 @@
           "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
           "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
           "requires": {
-            "define-property": "0.2.5",
-            "object-copy": "0.1.0"
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -15409,7 +15423,7 @@
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             }
           }
@@ -15431,8 +15445,8 @@
           "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "stream-shift": "1.0.0"
+            "end-of-stream": "^1.1.0",
+            "stream-shift": "^1.0.0"
           }
         },
         "stream-shift": {
@@ -15453,7 +15467,7 @@
           "integrity": "sha1-JnmdkDqyAlyb1VCsRxcbAPjdgKk=",
           "dev": true,
           "requires": {
-            "stream-to": "0.2.2"
+            "stream-to": "~0.2.0"
           }
         },
         "streamroller": {
@@ -15462,9 +15476,9 @@
           "integrity": "sha1-oTQg4EFp5XPbBo9ZIO4j2IGr/jM=",
           "dev": true,
           "requires": {
-            "date-format": "0.0.0",
-            "debug": "0.7.4",
-            "readable-stream": "1.1.14"
+            "date-format": "^0.0.0",
+            "debug": "^0.7.2",
+            "readable-stream": "^1.1.7"
           },
           "dependencies": {
             "debug": {
@@ -15485,10 +15499,10 @@
               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "dev": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               }
             },
             "string_decoder": {
@@ -15509,8 +15523,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -15523,7 +15537,7 @@
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -15534,9 +15548,9 @@
           "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
           "dev": true,
           "requires": {
-            "define-properties": "1.1.3",
-            "es-abstract": "1.13.0",
-            "function-bind": "1.1.1"
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.5.0",
+            "function-bind": "^1.0.2"
           }
         },
         "string_decoder": {
@@ -15544,7 +15558,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         },
         "stringify-package": {
@@ -15564,7 +15578,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -15572,7 +15586,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-indent": {
@@ -15580,7 +15594,7 @@
           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "requires": {
-            "get-stdin": "4.0.1"
+            "get-stdin": "^4.0.1"
           }
         },
         "strip-json-comments": {
@@ -15594,16 +15608,16 @@
           "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
           "dev": true,
           "requires": {
-            "component-emitter": "1.2.1",
-            "cookiejar": "2.1.2",
-            "debug": "3.2.6",
-            "extend": "3.0.2",
-            "form-data": "2.3.3",
-            "formidable": "1.2.1",
-            "methods": "1.1.2",
-            "mime": "1.6.0",
-            "qs": "6.5.2",
-            "readable-stream": "2.3.6"
+            "component-emitter": "^1.2.0",
+            "cookiejar": "^2.1.0",
+            "debug": "^3.1.0",
+            "extend": "^3.0.0",
+            "form-data": "^2.3.1",
+            "formidable": "^1.2.0",
+            "methods": "^1.1.1",
+            "mime": "^1.4.1",
+            "qs": "^6.5.1",
+            "readable-stream": "^2.3.5"
           },
           "dependencies": {
             "debug": {
@@ -15612,7 +15626,7 @@
               "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
               "dev": true,
               "requires": {
-                "ms": "2.1.1"
+                "ms": "^2.1.1"
               }
             },
             "ms": {
@@ -15629,8 +15643,8 @@
           "integrity": "sha512-79Ujg1lRL2ICfuHUdX+H2MjIw73kB7bXsIkxLwHURz3j0XUmEEEoJ+u/wq+mKwna21Uejsm2cGR3OESA00TIjA==",
           "dev": true,
           "requires": {
-            "debug": "3.2.6",
-            "proxy-agent": "2.3.1"
+            "debug": "^3.1.0",
+            "proxy-agent": "2"
           },
           "dependencies": {
             "debug": {
@@ -15639,7 +15653,7 @@
               "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
               "dev": true,
               "requires": {
-                "ms": "2.1.1"
+                "ms": "^2.1.1"
               }
             },
             "ms": {
@@ -15666,12 +15680,12 @@
           "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
           "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
           "requires": {
-            "ajv": "4.11.8",
-            "ajv-keywords": "1.5.1",
-            "chalk": "1.1.3",
-            "lodash": "4.17.11",
+            "ajv": "^4.7.0",
+            "ajv-keywords": "^1.0.0",
+            "chalk": "^1.1.1",
+            "lodash": "^4.0.0",
             "slice-ansi": "0.0.4",
-            "string-width": "2.1.1"
+            "string-width": "^2.0.0"
           },
           "dependencies": {
             "ajv": {
@@ -15679,8 +15693,8 @@
               "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
               "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
               "requires": {
-                "co": "4.6.0",
-                "json-stable-stringify": "1.0.1"
+                "co": "^4.6.0",
+                "json-stable-stringify": "^1.0.1"
               }
             },
             "chalk": {
@@ -15688,11 +15702,11 @@
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               }
             }
           }
@@ -15708,13 +15722,13 @@
           "integrity": "sha512-mq9ixIYfNF9SK0IS/h2HKMu8Q2iaCuhDDsZhdEag/FHv8fOaYld4vN7ouMgcSSt5WKZzPs8atclTcJm36OTh4w==",
           "dev": true,
           "requires": {
-            "chownr": "1.1.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.3.5",
-            "minizlib": "1.2.1",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.3"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.3",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
           },
           "dependencies": {
             "yallist": {
@@ -15731,8 +15745,8 @@
           "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2",
-            "rimraf": "2.2.8"
+            "os-tmpdir": "^1.0.0",
+            "rimraf": "~2.2.6"
           }
         },
         "text-table": {
@@ -15757,8 +15771,8 @@
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         },
         "thunkify": {
@@ -15777,12 +15791,12 @@
           "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.1.tgz",
           "integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
           "requires": {
-            "body-parser": "1.14.2",
-            "debug": "2.2.0",
-            "faye-websocket": "0.10.0",
-            "livereload-js": "2.4.0",
-            "parseurl": "1.3.2",
-            "qs": "5.1.0"
+            "body-parser": "~1.14.0",
+            "debug": "~2.2.0",
+            "faye-websocket": "~0.10.0",
+            "livereload-js": "^2.2.0",
+            "parseurl": "~1.3.0",
+            "qs": "~5.1.0"
           },
           "dependencies": {
             "debug": {
@@ -15817,7 +15831,7 @@
           "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2"
+            "os-tmpdir": "~1.0.2"
           }
         },
         "to-object-path": {
@@ -15825,7 +15839,7 @@
           "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
           "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -15833,7 +15847,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -15843,10 +15857,10 @@
           "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
           "requires": {
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "regex-not": "1.0.2",
-            "safe-regex": "1.1.0"
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
           }
         },
         "to-regex-range": {
@@ -15854,8 +15868,8 @@
           "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "requires": {
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1"
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
           }
         },
         "tough-cookie": {
@@ -15864,7 +15878,7 @@
           "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
           "dev": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "trim-newlines": {
@@ -15882,19 +15896,19 @@
           "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.14.0.tgz",
           "integrity": "sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==",
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "builtin-modules": "1.1.1",
-            "chalk": "2.4.2",
-            "commander": "2.19.0",
-            "diff": "3.5.0",
-            "glob": "7.1.3",
-            "js-yaml": "3.13.0",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "resolve": "1.10.0",
-            "semver": "5.5.0",
-            "tslib": "1.9.3",
-            "tsutils": "2.29.0"
+            "babel-code-frame": "^6.22.0",
+            "builtin-modules": "^1.1.1",
+            "chalk": "^2.3.0",
+            "commander": "^2.12.1",
+            "diff": "^3.2.0",
+            "glob": "^7.1.1",
+            "js-yaml": "^3.7.0",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
+            "resolve": "^1.3.2",
+            "semver": "^5.3.0",
+            "tslib": "^1.8.0",
+            "tsutils": "^2.29.0"
           },
           "dependencies": {
             "ansi-styles": {
@@ -15902,7 +15916,7 @@
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
               "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
               "requires": {
-                "color-convert": "1.9.3"
+                "color-convert": "^1.9.0"
               }
             },
             "chalk": {
@@ -15910,9 +15924,9 @@
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
               "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.5.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
               }
             },
             "minimatch": {
@@ -15920,7 +15934,7 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
               }
             },
             "supports-color": {
@@ -15928,7 +15942,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
               }
             }
           }
@@ -15938,7 +15952,7 @@
           "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-6.1.0.tgz",
           "integrity": "sha512-8DgmiPTgNQSYTjrKKv/h1aHnDd7EkGAjTxatrjfSDp5jUXENGI7Qj7qi7T8xBdTZN9Z3nb80u0NhdBBOMcQFHg==",
           "requires": {
-            "tsutils": "2.28.0"
+            "tsutils": "^2.27.2 <2.29.0"
           },
           "dependencies": {
             "tsutils": {
@@ -15946,7 +15960,7 @@
               "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.28.0.tgz",
               "integrity": "sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==",
               "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.8.1"
               }
             }
           }
@@ -15956,7 +15970,7 @@
           "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
           "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
           "requires": {
-            "tslib": "1.9.3"
+            "tslib": "^1.8.1"
           }
         },
         "tunnel-agent": {
@@ -15965,7 +15979,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -15979,7 +15993,7 @@
           "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
           "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
           "requires": {
-            "prelude-ls": "1.1.2"
+            "prelude-ls": "~1.1.2"
           }
         },
         "type-detect": {
@@ -15993,7 +16007,7 @@
           "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
           "requires": {
             "media-typer": "0.3.0",
-            "mime-types": "2.1.22"
+            "mime-types": "~2.1.18"
           }
         },
         "typedarray": {
@@ -16012,8 +16026,8 @@
           "integrity": "sha512-rIQPT2UMDnk4jRX+w4WO84/pebU2jiLsjgIyrCktYgSvx28enOE3iYQMr+BD1rHiitWnDmpu0cY/LfIEpKcjcw==",
           "optional": true,
           "requires": {
-            "commander": "2.19.0",
-            "source-map": "0.6.1"
+            "commander": "~2.19.0",
+            "source-map": "~0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -16040,10 +16054,10 @@
           "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
           "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
           "requires": {
-            "arr-union": "3.1.0",
-            "get-value": "2.0.6",
-            "is-extendable": "0.1.1",
-            "set-value": "0.4.3"
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
           },
           "dependencies": {
             "extend-shallow": {
@@ -16051,7 +16065,7 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "set-value": {
@@ -16059,10 +16073,10 @@
               "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
               "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
               "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "to-object-path": "0.3.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
               }
             }
           }
@@ -16073,7 +16087,7 @@
           "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
           "dev": true,
           "requires": {
-            "unique-slug": "2.0.1"
+            "unique-slug": "^2.0.0"
           }
         },
         "unique-slug": {
@@ -16082,7 +16096,7 @@
           "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
           "dev": true,
           "requires": {
-            "imurmurhash": "0.1.4"
+            "imurmurhash": "^0.1.4"
           }
         },
         "universal-analytics": {
@@ -16091,10 +16105,10 @@
           "integrity": "sha512-9Dt6WBWsHsmv74G+N/rmEgi6KFZxVvQXkVhr0disegeUryybQAUQwMD1l5EtqaOu+hSOGbhL/hPPQYisZIqPRw==",
           "dev": true,
           "requires": {
-            "async": "1.2.1",
-            "request": "2.85.0",
-            "underscore": "1.9.1",
-            "uuid": "3.0.1"
+            "async": "1.2.x",
+            "request": "2.x",
+            "underscore": "1.x",
+            "uuid": "^3.0.0"
           }
         },
         "unpipe": {
@@ -16107,8 +16121,8 @@
           "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
           "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
           "requires": {
-            "has-value": "0.3.1",
-            "isobject": "3.0.1"
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
           },
           "dependencies": {
             "has-value": {
@@ -16116,9 +16130,9 @@
               "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
               "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
               "requires": {
-                "get-value": "2.0.6",
-                "has-values": "0.1.4",
-                "isobject": "2.1.0"
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
               },
               "dependencies": {
                 "isobject": {
@@ -16153,7 +16167,7 @@
           "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
           "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
           "requires": {
-            "prepend-http": "2.0.0"
+            "prepend-http": "^2.0.0"
           }
         },
         "url-regex": {
@@ -16162,7 +16176,7 @@
           "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
           "dev": true,
           "requires": {
-            "ip-regex": "1.0.3"
+            "ip-regex": "^1.0.1"
           }
         },
         "url-to-options": {
@@ -16180,7 +16194,7 @@
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
           "requires": {
-            "os-homedir": "1.0.2"
+            "os-homedir": "^1.0.0"
           }
         },
         "util-deprecate": {
@@ -16199,8 +16213,8 @@
           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
           "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
           "requires": {
-            "spdx-correct": "3.1.0",
-            "spdx-expression-parse": "3.0.0"
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
           }
         },
         "validate-npm-package-name": {
@@ -16209,7 +16223,7 @@
           "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "dev": true,
           "requires": {
-            "builtins": "1.0.3"
+            "builtins": "^1.0.3"
           }
         },
         "verror": {
@@ -16218,9 +16232,9 @@
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "dev": true,
           "requires": {
-            "assert-plus": "1.0.0",
+            "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
+            "extsprintf": "^1.2.0"
           }
         },
         "wcwidth": {
@@ -16229,7 +16243,7 @@
           "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
           "dev": true,
           "requires": {
-            "defaults": "1.0.3"
+            "defaults": "^1.0.3"
           }
         },
         "websocket-driver": {
@@ -16237,8 +16251,8 @@
           "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
           "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
           "requires": {
-            "http-parser-js": "0.5.0",
-            "websocket-extensions": "0.1.3"
+            "http-parser-js": ">=0.4.0",
+            "websocket-extensions": ">=0.1.1"
           }
         },
         "websocket-extensions": {
@@ -16251,7 +16265,7 @@
           "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "which-module": {
@@ -16283,8 +16297,8 @@
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -16293,7 +16307,7 @@
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "string-width": {
@@ -16302,9 +16316,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -16319,7 +16333,7 @@
           "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
           "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
           "requires": {
-            "mkdirp": "0.5.1"
+            "mkdirp": "^0.5.1"
           }
         },
         "ws": {
@@ -16328,7 +16342,7 @@
           "integrity": "sha512-7KU/qkUXtJW9aa5WRKlo0puE1ejEoAgDb0D/Pt+lWpTkKF7Kp+MqFOtwNFwnuiYeeDpFjp0qyMniE84OjKIEqQ==",
           "dev": true,
           "requires": {
-            "async-limiter": "1.0.0"
+            "async-limiter": "~1.0.0"
           }
         },
         "xhr": {
@@ -16337,10 +16351,10 @@
           "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
           "dev": true,
           "requires": {
-            "global": "4.3.2",
-            "is-function": "1.0.1",
-            "parse-headers": "2.0.2",
-            "xtend": "4.0.1"
+            "global": "~4.3.0",
+            "is-function": "^1.0.1",
+            "parse-headers": "^2.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "xml-parse-from-string": {
@@ -16354,8 +16368,8 @@
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
           "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
           "requires": {
-            "sax": "1.2.4",
-            "xmlbuilder": "9.0.7"
+            "sax": ">=0.6.0",
+            "xmlbuilder": "~9.0.1"
           },
           "dependencies": {
             "xmlbuilder": {
@@ -16406,19 +16420,19 @@
           "integrity": "sha1-kAR5306L9qsOhyFvXtKydguWg0U=",
           "dev": true,
           "requires": {
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.3",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "window-size": "0.2.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "window-size": "^0.2.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^4.0.2"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -16427,7 +16441,7 @@
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "string-width": {
@@ -16436,9 +16450,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -16449,7 +16463,7 @@
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "^3.0.0"
           }
         },
         "yauzl": {
@@ -16458,8 +16472,8 @@
           "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
           "dev": true,
           "requires": {
-            "buffer-crc32": "0.2.13",
-            "fd-slicer": "1.1.0"
+            "buffer-crc32": "~0.2.3",
+            "fd-slicer": "~1.1.0"
           }
         },
         "zipstream": {
@@ -16474,8 +16488,8 @@
       "resolved": "https://registry.npmjs.org/nativescript-angular/-/nativescript-angular-7.2.1.tgz",
       "integrity": "sha512-8r5j0ftG6dpWkCAH1H/GsDZKABffdUZPlANO0ETdYeL9oQCNHaO1VMyMYi6uP9KmDChd84BMJaQ68rmKzt0qHA==",
       "requires": {
-        "nativescript-intl": "3.0.0",
-        "reflect-metadata": "0.1.12"
+        "nativescript-intl": "^3.0.0",
+        "reflect-metadata": "^0.1.8"
       }
     },
     "nativescript-checkbox": {
@@ -16489,11 +16503,11 @@
       "integrity": "sha512-BQtNfR7VVpDQsNGM8ctFF9rId5QdvgZoyqyoacNZAZ7Drh0LUIRS9JE/fSB8ttHauyAijcOMA2pCZN5FZkeKig==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.2",
+        "bluebird": "^3.4.6",
         "chokidar": "2.0.2",
-        "glob": "7.1.3",
-        "nativescript-hook": "0.2.4",
-        "node-sass": "4.12.0"
+        "glob": "^7.1.2",
+        "nativescript-hook": "^0.2.0",
+        "node-sass": "^4.7.1"
       },
       "dependencies": {
         "chokidar": {
@@ -16502,31 +16516,31 @@
           "integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
           "dev": true,
           "requires": {
-            "anymatch": "2.0.0",
-            "async-each": "1.0.1",
-            "braces": "2.3.2",
-            "fsevents": "1.2.4",
-            "glob-parent": "3.1.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "4.0.1",
-            "normalize-path": "2.1.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.1.0",
-            "upath": "1.1.2"
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.0",
+            "braces": "^2.3.0",
+            "fsevents": "^1.0.0",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^2.1.1",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0",
+            "upath": "^1.0.0"
           }
         }
       }
     },
     "nativescript-dev-typescript": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/nativescript-dev-typescript/-/nativescript-dev-typescript-0.8.0.tgz",
-      "integrity": "sha512-Ry1fO8ORuy28Wbxagw03qDG2A7/bJ2Jz2aPBWjHIUqJqWw3e0ULq/9jtNTjfjEe6v4NZbDifwoq6L8WM7MjKLw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/nativescript-dev-typescript/-/nativescript-dev-typescript-0.10.0.tgz",
+      "integrity": "sha512-8NqJVNg+HEkEEEZ7ZyPnHSUjg18ewB0atyFBcIHFPbim4QYsgP+DCz/QxrsqcBKs6uQRFctBM06mYXUjX9JcMA==",
       "dev": true,
       "requires": {
-        "nativescript-hook": "0.2.4",
+        "nativescript-hook": "^0.2.0",
         "semver": "5.5.0",
-        "typescript": "3.1.6"
+        "typescript": "~3.4.5"
       },
       "dependencies": {
         "semver": {
@@ -16534,50 +16548,58 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true
+        },
+        "typescript": {
+          "version": "3.4.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+          "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+          "dev": true
         }
       }
     },
     "nativescript-dev-webpack": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/nativescript-dev-webpack/-/nativescript-dev-webpack-0.21.2.tgz",
-      "integrity": "sha512-3O/1tbqU+r8q83A5hkBrcB3ubBPExFr0M6X8iV36kYpQOQ8QnujdeoGGlKdXunT/gRXLgL3g/kmp46QhwRHTOA==",
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/nativescript-dev-webpack/-/nativescript-dev-webpack-0.24.1.tgz",
+      "integrity": "sha512-M6ZwJJw/zA8g5pTb6Q06pbpTNJPUdfRumtDf2TW9CnV0nkaHdRtM4GZfudY0ovKaOyA1m2XcAn2sNfXu72ulvQ==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "7.2.4",
-        "clean-webpack-plugin": "1.0.1",
-        "copy-webpack-plugin": "4.6.0",
-        "css-loader": "1.0.1",
+        "@angular-devkit/core": "8.0.0",
+        "clean-webpack-plugin": "~1.0.0",
+        "copy-webpack-plugin": "~4.6.0",
+        "css-loader": "~2.1.1",
+        "fork-ts-checker-webpack-plugin": "1.3.0",
         "global-modules-path": "2.0.0",
         "minimatch": "3.0.4",
         "nativescript-hook": "0.2.4",
-        "nativescript-worker-loader": "0.9.5",
+        "nativescript-worker-loader": "~0.9.0",
         "proxy-lib": "0.4.0",
-        "raw-loader": "0.5.1",
+        "raw-loader": "~0.5.1",
         "request": "2.88.0",
-        "resolve-url-loader": "3.0.1",
-        "sass-loader": "7.1.0",
+        "resolve-url-loader": "~3.0.0",
+        "sass-loader": "~7.1.0",
         "schema-utils": "0.4.5",
-        "semver": "5.4.1",
+        "semver": "^6.0.0",
         "shelljs": "0.6.0",
         "tapable": "1.0.0",
-        "ts-loader": "5.4.5",
-        "uglifyjs-webpack-plugin": "1.2.7",
-        "webpack": "4.27.1",
-        "webpack-bundle-analyzer": "3.0.4",
-        "webpack-cli": "3.1.2",
-        "webpack-sources": "1.3.0"
+        "terser": "3.17.0",
+        "terser-webpack-plugin": "1.2.3",
+        "ts-loader": "^5.3.1",
+        "webpack": "~4.27.0",
+        "webpack-bundle-analyzer": "~3.0.2",
+        "webpack-cli": "~3.1.1",
+        "webpack-sources": "~1.3.0"
       },
       "dependencies": {
         "@angular-devkit/core": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-7.2.4.tgz",
-          "integrity": "sha512-XHF59tIHg2qEM1Wd415xhykBLjjfOK6yMB7CjNk1bToUMX2QDT87izJF4y1Vwa0lIw9G0jdgP/4/M/OqXcbYmA==",
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-8.0.0.tgz",
+          "integrity": "sha512-wYf4zzpYj5Y673DG8iteK0GsDDuXBKN/TOXm4lUwmXcz8QHTD+BfR6qA5TBDqlMGpU7CP1/0vgbv2px17CDETQ==",
           "dev": true,
           "requires": {
-            "ajv": "6.6.2",
-            "chokidar": "2.0.4",
+            "ajv": "6.10.0",
             "fast-json-stable-stringify": "2.0.0",
-            "rxjs": "6.3.3",
+            "magic-string": "0.25.2",
+            "rxjs": "6.4.0",
             "source-map": "0.7.3"
           }
         },
@@ -16593,19 +16615,47 @@
           "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
           "dev": true,
           "requires": {
-            "acorn": "5.7.3"
+            "acorn": "^5.0.0"
           }
         },
         "ajv": {
-          "version": "6.6.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
-          "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+          "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "2.0.1",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.4.1",
-            "uri-js": "4.2.2"
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "bluebird": {
+          "version": "3.5.5",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
+          "dev": true
+        },
+        "cacache": {
+          "version": "11.3.2",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
+          "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.3",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.1.15",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
+            "y18n": "^4.0.0"
           }
         },
         "fast-deep-equal": {
@@ -16614,11 +16664,141 @@
           "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
           "dev": true
         },
+        "find-cache-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+          "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^2.0.0",
+            "pkg-dir": "^3.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.15",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+          "dev": true
+        },
         "json-schema-traverse": {
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+              "dev": true
+            }
+          }
+        },
+        "mississippi": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+          "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+          "dev": true,
+          "requires": {
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
         },
         "raw-loader": {
           "version": "0.5.1",
@@ -16626,25 +16806,34 @@
           "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
           "dev": true
         },
+        "rxjs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+          "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "schema-utils": {
           "version": "0.4.5",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
           "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
           "dev": true,
           "requires": {
-            "ajv": "6.6.2",
-            "ajv-keywords": "3.4.0"
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
           }
         },
         "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+          "integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
           "dev": true
         },
         "shelljs": {
           "version": "0.6.0",
-          "resolved": "http://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz",
           "integrity": "sha1-zh7YN7Sw5Vtew9q4QlGrnb3Ax+w=",
           "dev": true
         },
@@ -16654,11 +16843,55 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
         },
+        "ssri": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "dev": true,
+          "requires": {
+            "figgy-pudding": "^3.5.1"
+          }
+        },
         "tapable": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.0.0.tgz",
           "integrity": "sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg==",
           "dev": true
+        },
+        "terser-webpack-plugin": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz",
+          "integrity": "sha512-GOK7q85oAb/5kE12fMuLdn2btOS9OBZn4VsecpHDywoUC/jLhSAKOiYo0ezx7ss2EXPMzyEWFoE0s1WLE+4+oA==",
+          "dev": true,
+          "requires": {
+            "cacache": "^11.0.2",
+            "find-cache-dir": "^2.0.0",
+            "schema-utils": "^1.0.0",
+            "serialize-javascript": "^1.4.0",
+            "source-map": "^0.6.1",
+            "terser": "^3.16.1",
+            "webpack-sources": "^1.1.0",
+            "worker-farm": "^1.5.2"
+          },
+          "dependencies": {
+            "schema-utils": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+              "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+              "dev": true,
+              "requires": {
+                "ajv": "^6.1.0",
+                "ajv-errors": "^1.0.0",
+                "ajv-keywords": "^3.1.0"
+              }
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "dev": true
+            }
+          }
         },
         "webpack": {
           "version": "4.27.1",
@@ -16670,26 +16903,26 @@
             "@webassemblyjs/helper-module-context": "1.7.11",
             "@webassemblyjs/wasm-edit": "1.7.11",
             "@webassemblyjs/wasm-parser": "1.7.11",
-            "acorn": "5.7.3",
-            "acorn-dynamic-import": "3.0.0",
-            "ajv": "6.6.2",
-            "ajv-keywords": "3.4.0",
-            "chrome-trace-event": "1.0.0",
-            "enhanced-resolve": "4.1.0",
-            "eslint-scope": "4.0.3",
-            "json-parse-better-errors": "1.0.2",
-            "loader-runner": "2.4.0",
-            "loader-utils": "1.1.0",
-            "memory-fs": "0.4.1",
-            "micromatch": "3.1.10",
-            "mkdirp": "0.5.1",
-            "neo-async": "2.6.0",
-            "node-libs-browser": "2.2.0",
-            "schema-utils": "0.4.5",
-            "tapable": "1.1.3",
-            "terser-webpack-plugin": "1.2.2",
-            "watchpack": "1.6.0",
-            "webpack-sources": "1.3.0"
+            "acorn": "^5.6.2",
+            "acorn-dynamic-import": "^3.0.0",
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0",
+            "chrome-trace-event": "^1.0.0",
+            "enhanced-resolve": "^4.1.0",
+            "eslint-scope": "^4.0.0",
+            "json-parse-better-errors": "^1.0.2",
+            "loader-runner": "^2.3.0",
+            "loader-utils": "^1.1.0",
+            "memory-fs": "~0.4.1",
+            "micromatch": "^3.1.8",
+            "mkdirp": "~0.5.0",
+            "neo-async": "^2.5.0",
+            "node-libs-browser": "^2.0.0",
+            "schema-utils": "^0.4.4",
+            "tapable": "^1.1.0",
+            "terser-webpack-plugin": "^1.1.0",
+            "watchpack": "^1.5.0",
+            "webpack-sources": "^1.3.0"
           },
           "dependencies": {
             "tapable": {
@@ -16718,8 +16951,8 @@
       "integrity": "sha1-5ZHh2a1BWotPMwnBVzFXevRKPdQ=",
       "dev": true,
       "requires": {
-        "glob": "6.0.4",
-        "mkdirp": "0.5.1"
+        "glob": "^6.0.1",
+        "mkdirp": "^0.5.1"
       },
       "dependencies": {
         "glob": {
@@ -16728,11 +16961,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         }
       }
@@ -16747,8 +16980,8 @@
       "resolved": "https://registry.npmjs.org/nativescript-orientation/-/nativescript-orientation-2.2.1.tgz",
       "integrity": "sha512-VnQ6QTzyAex6arb5Pw6GXSFZzyj/KkAI6gdkLApFiwQq6pi/wYoTGTxL28zFCDb22J669wnZHEZeedfrWgu22g==",
       "requires": {
-        "nativescript-dom": "2.0.2",
-        "nativescript-globalevents": "1.2.2"
+        "nativescript-dom": "^2.0.0",
+        "nativescript-globalevents": "^1.2.1"
       }
     },
     "nativescript-platform": {
@@ -16761,8 +16994,8 @@
       "resolved": "https://registry.npmjs.org/nativescript-platform-css/-/nativescript-platform-css-1.6.6.tgz",
       "integrity": "sha512-Qe8n7ERUQMjhZjBbTKau4w5FEJhOmQ3490+CBbV+CkgTpRzaTuLWvdaQwOmX1ffylAO3ngaZA+f6w1X7jS9sxg==",
       "requires": {
-        "nativescript-globalevents": "1.2.2",
-        "nativescript-platform": "1.2.4"
+        "nativescript-globalevents": "^1.2.2",
+        "nativescript-platform": "^1.2.4"
       },
       "dependencies": {
         "nativescript-globalevents": {
@@ -16782,7 +17015,7 @@
       "resolved": "https://registry.npmjs.org/nativescript-ui-chart/-/nativescript-ui-chart-3.11.1.tgz",
       "integrity": "sha512-eq9lh/z0zK8tvFmphQ3jz6guBRdojedyAZQws1Xcw5jYnZdyGKjHgotHxmud5HKspr7fZerYSNvhUR8t3wwwwA==",
       "requires": {
-        "nativescript-ui-core": "2.0.1"
+        "nativescript-ui-core": "~2.0.0"
       }
     },
     "nativescript-ui-core": {
@@ -16795,7 +17028,7 @@
       "resolved": "https://registry.npmjs.org/nativescript-ui-listview/-/nativescript-ui-listview-6.3.0.tgz",
       "integrity": "sha512-zPpHFQcOyccAaf95SgcPwm0WgbW19C2eWZpmumzHfDomdrAGEhlWDPeyD7ar/YfOMlJm/1cGsebHLZiO0yulRw==",
       "requires": {
-        "nativescript-ui-core": "2.0.1"
+        "nativescript-ui-core": "~2.0.0"
       }
     },
     "nativescript-webview-interface": {
@@ -16814,8 +17047,8 @@
       "integrity": "sha512-FYLN0Vmrxwr9B1RofmuOH/2s/ghBxpDLe16qEDwcVUcyzOLlBzvZ+FHF/Kp59IXl7jINoAhMlnXhNbAYKE93Pw==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "schema-utils": "0.3.0"
+        "loader-utils": "^1.0.2",
+        "schema-utils": "^0.3.0"
       },
       "dependencies": {
         "ajv": {
@@ -16824,10 +17057,10 @@
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         },
         "schema-utils": {
@@ -16836,7 +17069,7 @@
           "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
           "dev": true,
           "requires": {
-            "ajv": "5.5.2"
+            "ajv": "^5.0.0"
           }
         }
       }
@@ -16855,7 +17088,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
@@ -16877,9 +17110,9 @@
       "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
       "dev": true,
       "requires": {
-        "encoding": "0.1.12",
-        "json-parse-better-errors": "1.0.2",
-        "safe-buffer": "5.1.2"
+        "encoding": "^0.1.11",
+        "json-parse-better-errors": "^1.0.0",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node-forge": {
@@ -16894,18 +17127,18 @@
       "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
       "dev": true,
       "requires": {
-        "fstream": "1.0.11",
-        "glob": "7.1.3",
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.2",
-        "osenv": "0.1.5",
-        "request": "2.88.0",
-        "rimraf": "2.6.2",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "which": "1.3.1"
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
       },
       "dependencies": {
         "semver": {
@@ -16920,9 +17153,9 @@
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           }
         }
       }
@@ -16933,28 +17166,28 @@
       "integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
       "dev": true,
       "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.2.0",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.2.0",
-        "events": "3.0.0",
-        "https-browserify": "1.0.0",
-        "os-browserify": "0.3.0",
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^3.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
         "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.6",
-        "stream-browserify": "2.0.2",
-        "stream-http": "2.8.3",
-        "string_decoder": "1.1.1",
-        "timers-browserify": "2.0.10",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
         "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.11.1",
+        "url": "^0.11.0",
+        "util": "^0.11.0",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -16972,7 +17205,7 @@
       "integrity": "sha512-/mnVgm6u/8OwlIsoyRXtTI0RfQcxZoAZbdwyXap0EeWwcOpDDymyCHM2/aR9XKmHXrvizHoPAOs0pcbiJ6RUaA==",
       "dev": true,
       "requires": {
-        "semver": "5.5.1"
+        "semver": "^5.3.0"
       }
     },
     "node-sass": {
@@ -16981,23 +17214,23 @@
       "integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
       "dev": true,
       "requires": {
-        "async-foreach": "0.1.3",
-        "chalk": "1.1.3",
-        "cross-spawn": "3.0.1",
-        "gaze": "1.1.3",
-        "get-stdin": "4.0.1",
-        "glob": "7.1.3",
-        "in-publish": "2.0.0",
-        "lodash": "4.17.11",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nan": "2.13.2",
-        "node-gyp": "3.8.0",
-        "npmlog": "4.1.2",
-        "request": "2.88.0",
-        "sass-graph": "2.2.4",
-        "stdout-stream": "1.4.1",
-        "true-case-path": "1.0.3"
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash": "^4.17.11",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.13.2",
+        "node-gyp": "^3.8.0",
+        "npmlog": "^4.0.0",
+        "request": "^2.88.0",
+        "sass-graph": "^2.2.4",
+        "stdout-stream": "^1.4.0",
+        "true-case-path": "^1.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -17012,11 +17245,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "nan": {
@@ -17039,7 +17272,7 @@
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -17048,10 +17281,10 @@
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.7.1",
-        "resolve": "1.10.1",
-        "semver": "5.5.1",
-        "validate-npm-package-license": "3.0.4"
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       },
       "dependencies": {
         "resolve": {
@@ -17060,7 +17293,7 @@
           "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
           "dev": true,
           "requires": {
-            "path-parse": "1.0.6"
+            "path-parse": "^1.0.6"
           }
         }
       }
@@ -17071,7 +17304,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-range": {
@@ -17092,10 +17325,10 @@
       "integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.7.1",
-        "osenv": "0.1.5",
-        "semver": "5.5.1",
-        "validate-npm-package-name": "3.0.0"
+        "hosted-git-info": "^2.6.0",
+        "osenv": "^0.1.5",
+        "semver": "^5.5.0",
+        "validate-npm-package-name": "^3.0.0"
       }
     },
     "npm-packlist": {
@@ -17104,8 +17337,8 @@
       "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
       "dev": true,
       "requires": {
-        "ignore-walk": "3.0.1",
-        "npm-bundled": "1.0.6"
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1"
       }
     },
     "npm-pick-manifest": {
@@ -17114,9 +17347,9 @@
       "integrity": "sha512-+IluBC5K201+gRU85vFlUwX3PFShZAbAgDNp2ewJdWMVSppdo/Zih0ul2Ecky/X7b51J7LrrUAP+XOmOCvYZqA==",
       "dev": true,
       "requires": {
-        "figgy-pudding": "3.5.1",
-        "npm-package-arg": "6.1.0",
-        "semver": "5.5.1"
+        "figgy-pudding": "^3.5.1",
+        "npm-package-arg": "^6.0.0",
+        "semver": "^5.4.1"
       }
     },
     "npm-registry-client": {
@@ -17125,18 +17358,18 @@
       "integrity": "sha512-Qs6P6nnopig+Y8gbzpeN/dkt+n7IyVd8f45NTMotGk6Qo7GfBmzwYx6jRLoOOgKiMnaQfYxsuyQlD8Mc3guBhg==",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.2",
-        "graceful-fs": "4.1.11",
-        "normalize-package-data": "2.5.0",
-        "npm-package-arg": "6.1.0",
-        "npmlog": "4.1.2",
-        "once": "1.4.0",
-        "request": "2.88.0",
-        "retry": "0.10.1",
-        "safe-buffer": "5.1.2",
-        "semver": "5.5.1",
-        "slide": "1.1.6",
-        "ssri": "5.3.0"
+        "concat-stream": "^1.5.2",
+        "graceful-fs": "^4.1.6",
+        "normalize-package-data": "~1.0.1 || ^2.0.0",
+        "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "npmlog": "2 || ^3.1.0 || ^4.0.0",
+        "once": "^1.3.3",
+        "request": "^2.74.0",
+        "retry": "^0.10.0",
+        "safe-buffer": "^5.1.1",
+        "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+        "slide": "^1.1.3",
+        "ssri": "^5.2.4"
       }
     },
     "npm-registry-fetch": {
@@ -17145,12 +17378,12 @@
       "integrity": "sha512-srwmt8YhNajAoSAaDWndmZgx89lJwIZ1GWxOuckH4Coek4uHv5S+o/l9FLQe/awA+JwTnj4FJHldxhlXdZEBmw==",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.5",
-        "bluebird": "3.5.2",
-        "figgy-pudding": "3.5.1",
-        "lru-cache": "4.1.5",
-        "make-fetch-happen": "4.0.1",
-        "npm-package-arg": "6.1.0"
+        "JSONStream": "^1.3.4",
+        "bluebird": "^3.5.1",
+        "figgy-pudding": "^3.4.1",
+        "lru-cache": "^4.1.3",
+        "make-fetch-happen": "^4.0.1",
+        "npm-package-arg": "^6.1.0"
       }
     },
     "npm-run-path": {
@@ -17159,7 +17392,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "npmlog": {
@@ -17168,10 +17401,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.5",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "null-check": {
@@ -17216,9 +17449,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -17227,7 +17460,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "kind-of": {
@@ -17236,7 +17469,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -17253,7 +17486,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.0"
       }
     },
     "object.omit": {
@@ -17262,8 +17495,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       },
       "dependencies": {
         "for-own": {
@@ -17272,7 +17505,7 @@
           "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
           "dev": true,
           "requires": {
-            "for-in": "1.0.2"
+            "for-in": "^1.0.1"
           }
         }
       }
@@ -17283,7 +17516,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "obuf": {
@@ -17313,7 +17546,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -17322,7 +17555,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       },
       "dependencies": {
         "mimic-fn": {
@@ -17339,7 +17572,7 @@
       "integrity": "sha512-/yb5mVZBz7mHLySMiSj2DcLtMBbFPJk5JBKEkHVZFxZAPzeg3L026O0T+lbdz1B2nyDnkClRSwRQJdeVUIF7zw==",
       "dev": true,
       "requires": {
-        "is-wsl": "1.1.0"
+        "is-wsl": "^1.1.0"
       }
     },
     "opener": {
@@ -17354,7 +17587,7 @@
       "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
       "dev": true,
       "requires": {
-        "is-wsl": "1.1.0"
+        "is-wsl": "^1.1.0"
       }
     },
     "optimist": {
@@ -17363,8 +17596,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "wordwrap": {
@@ -17387,7 +17620,7 @@
       "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
       "dev": true,
       "requires": {
-        "url-parse": "1.4.7"
+        "url-parse": "^1.4.3"
       }
     },
     "os-browserify": {
@@ -17408,7 +17641,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "1.0.0"
+        "lcid": "^1.0.0"
       }
     },
     "os-tmpdir": {
@@ -17423,8 +17656,8 @@
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "p-defer": {
@@ -17451,7 +17684,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -17460,7 +17693,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.3.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-map": {
@@ -17481,33 +17714,33 @@
       "integrity": "sha512-WQ1KL/phGMkedYEQx9ODsjj7xvwLSpdFJJdEXrLyw5SILMxcTNt5DTxT2Z93fXuLFYJBlZJdnwdalrQdB/rX5w==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.4",
-        "cacache": "11.3.2",
-        "figgy-pudding": "3.5.1",
-        "get-stream": "4.1.0",
-        "glob": "7.1.3",
-        "lru-cache": "5.1.1",
-        "make-fetch-happen": "4.0.1",
-        "minimatch": "3.0.4",
-        "minipass": "2.3.5",
-        "mississippi": "3.0.0",
-        "mkdirp": "0.5.1",
-        "normalize-package-data": "2.5.0",
-        "npm-package-arg": "6.1.0",
-        "npm-packlist": "1.4.1",
-        "npm-pick-manifest": "2.2.3",
-        "npm-registry-fetch": "3.9.0",
-        "osenv": "0.1.5",
-        "promise-inflight": "1.0.1",
-        "promise-retry": "1.1.1",
-        "protoduck": "5.0.1",
-        "rimraf": "2.6.2",
-        "safe-buffer": "5.1.2",
-        "semver": "5.7.0",
-        "ssri": "6.0.1",
-        "tar": "4.4.8",
-        "unique-filename": "1.1.1",
-        "which": "1.3.1"
+        "bluebird": "^3.5.3",
+        "cacache": "^11.3.2",
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.1.0",
+        "glob": "^7.1.3",
+        "lru-cache": "^5.1.1",
+        "make-fetch-happen": "^4.0.1",
+        "minimatch": "^3.0.4",
+        "minipass": "^2.3.5",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "normalize-package-data": "^2.4.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-packlist": "^1.1.12",
+        "npm-pick-manifest": "^2.2.3",
+        "npm-registry-fetch": "^3.8.0",
+        "osenv": "^0.1.5",
+        "promise-inflight": "^1.0.1",
+        "promise-retry": "^1.1.1",
+        "protoduck": "^5.0.1",
+        "rimraf": "^2.6.2",
+        "safe-buffer": "^5.1.2",
+        "semver": "^5.6.0",
+        "ssri": "^6.0.1",
+        "tar": "^4.4.8",
+        "unique-filename": "^1.1.1",
+        "which": "^1.3.1"
       },
       "dependencies": {
         "bluebird": {
@@ -17522,20 +17755,20 @@
           "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
           "dev": true,
           "requires": {
-            "bluebird": "3.5.4",
-            "chownr": "1.1.1",
-            "figgy-pudding": "3.5.1",
-            "glob": "7.1.3",
-            "graceful-fs": "4.1.15",
-            "lru-cache": "5.1.1",
-            "mississippi": "3.0.0",
-            "mkdirp": "0.5.1",
-            "move-concurrently": "1.0.1",
-            "promise-inflight": "1.0.1",
-            "rimraf": "2.6.2",
-            "ssri": "6.0.1",
-            "unique-filename": "1.1.1",
-            "y18n": "4.0.0"
+            "bluebird": "^3.5.3",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.1.15",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
+            "y18n": "^4.0.0"
           }
         },
         "get-stream": {
@@ -17544,7 +17777,7 @@
           "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         },
         "graceful-fs": {
@@ -17559,7 +17792,7 @@
           "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "dev": true,
           "requires": {
-            "yallist": "3.0.3"
+            "yallist": "^3.0.2"
           }
         },
         "mississippi": {
@@ -17568,16 +17801,16 @@
           "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
           "dev": true,
           "requires": {
-            "concat-stream": "1.6.2",
-            "duplexify": "3.7.1",
-            "end-of-stream": "1.4.1",
-            "flush-write-stream": "1.1.1",
-            "from2": "2.3.0",
-            "parallel-transform": "1.1.0",
-            "pump": "3.0.0",
-            "pumpify": "1.5.1",
-            "stream-each": "1.2.3",
-            "through2": "2.0.5"
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
           }
         },
         "pump": {
@@ -17586,8 +17819,8 @@
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "semver": {
@@ -17602,7 +17835,7 @@
           "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "dev": true,
           "requires": {
-            "figgy-pudding": "3.5.1"
+            "figgy-pudding": "^3.5.1"
           }
         }
       }
@@ -17619,9 +17852,9 @@
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "dev": true,
       "requires": {
-        "cyclist": "0.2.2",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
       }
     },
     "parse-asn1": {
@@ -17630,12 +17863,12 @@
       "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
       "dev": true,
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.2.0",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.17",
-        "safe-buffer": "5.1.2"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
       }
     },
     "parse-color": {
@@ -17644,7 +17877,7 @@
       "integrity": "sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=",
       "dev": true,
       "requires": {
-        "color-convert": "0.5.3"
+        "color-convert": "~0.5.0"
       },
       "dependencies": {
         "color-convert": {
@@ -17661,10 +17894,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       },
       "dependencies": {
         "is-extglob": {
@@ -17679,7 +17912,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           }
         }
       }
@@ -17690,7 +17923,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "parse5": {
@@ -17705,7 +17938,7 @@
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseuri": {
@@ -17714,7 +17947,7 @@
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseurl": {
@@ -17783,7 +18016,7 @@
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "pbkdf2": {
@@ -17792,11 +18025,11 @@
       "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
-        "sha.js": "2.4.11"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "performance-now": {
@@ -17823,7 +18056,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -17832,7 +18065,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       }
     },
     "portfinder": {
@@ -17841,9 +18074,9 @@
       "integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1"
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
       },
       "dependencies": {
         "async": {
@@ -17866,9 +18099,9 @@
       "integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.2",
-        "source-map": "0.6.1",
-        "supports-color": "6.1.0"
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
       },
       "dependencies": {
         "chalk": {
@@ -17877,9 +18110,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           },
           "dependencies": {
             "supports-color": {
@@ -17888,7 +18121,7 @@
               "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
               }
             }
           }
@@ -17905,7 +18138,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -17916,10 +18149,10 @@
       "integrity": "sha512-3Gti33dmCjyKBgimqGxL3vcV8w9+bsHwO5UrBawp796+jdardbcFl4RP5w/76BwNL7aGzpKstIfF9I+kdE8pTw==",
       "dev": true,
       "requires": {
-        "postcss": "7.0.14",
-        "postcss-value-parser": "3.3.1",
-        "read-cache": "1.0.0",
-        "resolve": "1.1.7"
+        "postcss": "^7.0.1",
+        "postcss-value-parser": "^3.2.3",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
       }
     },
     "postcss-load-config": {
@@ -17928,8 +18161,8 @@
       "integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "4.0.0",
-        "import-cwd": "2.1.0"
+        "cosmiconfig": "^4.0.0",
+        "import-cwd": "^2.0.0"
       }
     },
     "postcss-loader": {
@@ -17938,123 +18171,67 @@
       "integrity": "sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "postcss": "7.0.14",
-        "postcss-load-config": "2.0.0",
-        "schema-utils": "1.0.0"
+        "loader-utils": "^1.1.0",
+        "postcss": "^7.0.0",
+        "postcss-load-config": "^2.0.0",
+        "schema-utils": "^1.0.0"
       }
     },
     "postcss-modules-extract-imports": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.2.1.tgz",
-      "integrity": "sha512-6jt9XZwUhwmRUhb/CkyJY020PYaPJsCyt3UjbaWo6XEbH/94Hmv6MP7fG2C5NDU/BcHzyGYxNtHvM+LTf9HrYw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+      "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.23"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.4.1",
-            "source-map": "0.6.1",
-            "supports-color": "5.5.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
+        "postcss": "^7.0.5"
       }
     },
     "postcss-modules-local-by-default": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
-      "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.6.tgz",
+      "integrity": "sha512-oLUV5YNkeIBa0yQl7EYnxMgy4N6noxmiwZStaEJUSe2xPMcdNc8WmBQuQCx18H5psYbVxz8zoHk0RAAYZXP9gA==",
       "dev": true,
       "requires": {
-        "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.23"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.4.1",
-            "source-map": "0.6.1",
-            "supports-color": "5.5.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0",
+        "postcss-value-parser": "^3.3.1"
       }
     },
     "postcss-modules-scope": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
-      "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.0.tgz",
+      "integrity": "sha512-91Rjps0JnmtUB0cujlc8KIKCsJXWjzuxGeT/+Q2i2HXKZ7nBUeF9YQTZZTNvHVoNYj1AthsjnGLtqDUE0Op79A==",
       "dev": true,
       "requires": {
-        "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.23"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.4.1",
-            "source-map": "0.6.1",
-            "supports-color": "5.5.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0"
       }
     },
     "postcss-modules-values": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
-      "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-2.0.0.tgz",
+      "integrity": "sha512-Ki7JZa7ff1N3EIMlPnGTZfUMe69FFwiQPnVSXC9mnn3jozCRBYIxiZd44yJOV2AmabOo4qFf8s0dC/+lweG7+w==",
       "dev": true,
       "requires": {
-        "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.23"
+        "icss-replace-symbols": "^1.1.0",
+        "postcss": "^7.0.6"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+      "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+      "dev": true,
+      "requires": {
+        "cssesc": "^3.0.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
       },
       "dependencies": {
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.4.1",
-            "source-map": "0.6.1",
-            "supports-color": "5.5.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+        "cssesc": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+          "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
           "dev": true
         }
       }
@@ -18083,8 +18260,8 @@
       "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0",
-        "ansi-styles": "3.2.1"
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -18100,7 +18277,7 @@
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.15.0.tgz",
       "integrity": "sha512-Lf2JrFYx8FanHrjoV5oL8YHCclLQgbJcVZR+gikGGMqz6ub5QVWDTM6YIwm3BuPxM/LOV+rKns3LssXNLIf+DA==",
       "requires": {
-        "clipboard": "2.0.1"
+        "clipboard": "^2.0.0"
       }
     },
     "process": {
@@ -18122,7 +18299,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "promise-inflight": {
@@ -18137,8 +18314,8 @@
       "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
       "dev": true,
       "requires": {
-        "err-code": "1.1.2",
-        "retry": "0.10.1"
+        "err-code": "^1.0.0",
+        "retry": "^0.10.0"
       }
     },
     "protoduck": {
@@ -18147,7 +18324,7 @@
       "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
       "dev": true,
       "requires": {
-        "genfun": "5.0.0"
+        "genfun": "^5.0.0"
       }
     },
     "protractor": {
@@ -18156,21 +18333,21 @@
       "integrity": "sha512-pw4uwwiy5lHZjIguxNpkEwJJa7hVz+bJsvaTI+IbXlfn2qXwzbF8eghW/RmrZwE2sGx82I8etb8lVjQ+JrjejA==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.117",
-        "@types/q": "0.0.32",
-        "@types/selenium-webdriver": "2.53.43",
-        "blocking-proxy": "1.0.1",
-        "chalk": "1.1.3",
-        "glob": "7.1.3",
+        "@types/node": "^6.0.46",
+        "@types/q": "^0.0.32",
+        "@types/selenium-webdriver": "~2.53.39",
+        "blocking-proxy": "^1.0.0",
+        "chalk": "^1.1.3",
+        "glob": "^7.0.3",
         "jasmine": "2.8.0",
-        "jasminewd2": "2.2.0",
-        "optimist": "0.6.1",
+        "jasminewd2": "^2.1.0",
+        "optimist": "~0.6.0",
         "q": "1.4.1",
-        "saucelabs": "1.5.0",
+        "saucelabs": "^1.5.0",
         "selenium-webdriver": "3.6.0",
-        "source-map-support": "0.4.18",
-        "webdriver-js-extender": "1.0.0",
-        "webdriver-manager": "12.1.0"
+        "source-map-support": "~0.4.0",
+        "webdriver-js-extender": "^1.0.0",
+        "webdriver-manager": "^12.0.6"
       },
       "dependencies": {
         "@types/node": {
@@ -18197,11 +18374,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "del": {
@@ -18210,13 +18387,13 @@
           "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
           "dev": true,
           "requires": {
-            "globby": "5.0.0",
-            "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.1",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "rimraf": "2.6.2"
+            "globby": "^5.0.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "globby": {
@@ -18225,12 +18402,12 @@
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.1.3",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "minimist": {
@@ -18257,7 +18434,7 @@
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7"
+            "source-map": "^0.5.6"
           }
         },
         "supports-color": {
@@ -18272,17 +18449,17 @@
           "integrity": "sha512-oEc5fmkpz6Yh6udhwir5m0eN5mgRPq9P/NU5YWuT3Up5slt6Zz+znhLU7q4+8rwCZz/Qq3Fgpr/4oao7NPCm2A==",
           "dev": true,
           "requires": {
-            "adm-zip": "0.4.11",
-            "chalk": "1.1.3",
-            "del": "2.2.2",
-            "glob": "7.1.3",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "q": "1.4.1",
-            "request": "2.88.0",
-            "rimraf": "2.6.2",
-            "semver": "5.5.1",
-            "xml2js": "0.4.19"
+            "adm-zip": "^0.4.9",
+            "chalk": "^1.1.1",
+            "del": "^2.2.0",
+            "glob": "^7.0.3",
+            "ini": "^1.3.4",
+            "minimist": "^1.2.0",
+            "q": "^1.4.1",
+            "request": "^2.87.0",
+            "rimraf": "^2.5.2",
+            "semver": "^5.3.0",
+            "xml2js": "^0.4.17"
           }
         }
       }
@@ -18293,7 +18470,7 @@
       "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.0"
       }
     },
@@ -18312,8 +18489,8 @@
           "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         }
       }
@@ -18342,12 +18519,12 @@
       "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "parse-asn1": "5.1.4",
-        "randombytes": "2.1.0",
-        "safe-buffer": "5.1.2"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "pump": {
@@ -18356,8 +18533,8 @@
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -18366,9 +18543,9 @@
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
-        "duplexify": "3.7.1",
-        "inherits": "2.0.3",
-        "pump": "2.0.1"
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       }
     },
     "punycode": {
@@ -18396,7 +18573,7 @@
       "dev": true,
       "requires": {
         "invariant": "2.2.2",
-        "lodash": "4.17.11"
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "invariant": {
@@ -18405,7 +18582,7 @@
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "dev": true,
           "requires": {
-            "loose-envify": "1.4.0"
+            "loose-envify": "^1.0.0"
           }
         }
       }
@@ -18434,9 +18611,9 @@
       "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
       "dev": true,
       "requires": {
-        "is-number": "4.0.0",
-        "kind-of": "6.0.2",
-        "math-random": "1.0.1"
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
       },
       "dependencies": {
         "is-number": {
@@ -18453,7 +18630,7 @@
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -18462,8 +18639,8 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "2.1.0",
-        "safe-buffer": "5.1.2"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -18490,8 +18667,8 @@
       "integrity": "sha512-Uqy5AqELpytJTRxYT4fhltcKPj0TyaEpzJDcGz7DFJi+pQOOi3GjR/DOdxTkTsF+NzhnldIoG6TORaBlInUuqA==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "schema-utils": "1.0.0"
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^1.0.0"
       }
     },
     "read-cache": {
@@ -18500,7 +18677,7 @@
       "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
       "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.3.0"
       },
       "dependencies": {
         "pify": {
@@ -18517,9 +18694,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.5.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       },
       "dependencies": {
         "path-type": {
@@ -18528,9 +18705,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -18547,8 +18724,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -18557,8 +18734,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-exists": {
@@ -18567,7 +18744,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         }
       }
@@ -18578,13 +18755,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -18593,10 +18770,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.6",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "rechoir": {
@@ -18605,7 +18782,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.1.7"
+        "resolve": "^1.1.6"
       }
     },
     "redent": {
@@ -18614,8 +18791,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "reflect-metadata": {
@@ -18641,7 +18818,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-not": {
@@ -18650,8 +18827,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2",
-        "safe-regex": "1.1.0"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regex-parser": {
@@ -18666,9 +18843,9 @@
       "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
       "dev": true,
       "requires": {
-        "regenerate": "1.4.0",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "regjsgen": {
@@ -18683,7 +18860,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -18718,7 +18895,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -18727,26 +18904,26 @@
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.8.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.1.0",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.20",
-        "oauth-sign": "0.9.0",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.4.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       }
     },
     "require-directory": {
@@ -18791,7 +18968,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "3.0.0"
+        "resolve-from": "^3.0.0"
       }
     },
     "resolve-from": {
@@ -18842,7 +19019,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "1.2.0"
+            "minimist": "^1.2.0"
           }
         },
         "loader-utils": {
@@ -18851,9 +19028,9 @@
           "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
           "dev": true,
           "requires": {
-            "big.js": "5.2.2",
-            "emojis-list": "2.1.0",
-            "json5": "1.0.1"
+            "big.js": "^5.2.2",
+            "emojis-list": "^2.0.0",
+            "json5": "^1.0.1"
           }
         },
         "minimist": {
@@ -18876,8 +19053,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -18898,13 +19075,13 @@
       "integrity": "sha1-MIBqhBNCtUUQqkEQhQzUhTQUSqc=",
       "dev": true,
       "requires": {
-        "convert-source-map": "0.3.5",
-        "css": "2.2.4"
+        "convert-source-map": "^0.3.3",
+        "css": "^2.0.0"
       },
       "dependencies": {
         "convert-source-map": {
           "version": "0.3.5",
-          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
           "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA=",
           "dev": true
         }
@@ -18928,7 +19105,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.3"
+        "glob": "^7.0.5"
       }
     },
     "ripemd160": {
@@ -18937,8 +19114,8 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "run-async": {
@@ -18947,7 +19124,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "run-queue": {
@@ -18956,7 +19133,7 @@
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0"
+        "aproba": "^1.1.1"
       }
     },
     "rxjs": {
@@ -18964,7 +19141,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
       "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -18979,7 +19156,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "safer-buffer": {
@@ -18994,10 +19171,10 @@
       "integrity": "sha1-xl5soxA8vPL8oNzYGwfk5JpsxYM=",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.2",
-        "gonzales-pe": "4.2.3",
-        "parse-color": "1.0.0",
-        "query-ast": "1.0.2"
+        "bluebird": "^3.4.7",
+        "gonzales-pe": "^4.2.2",
+        "parse-color": "^1.0.0",
+        "query-ast": "^1.0.1"
       }
     },
     "sass-extract-loader": {
@@ -19006,7 +19183,7 @@
       "integrity": "sha1-rU5xI7glM/jLvegU40L0SryyEFQ=",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0"
+        "loader-utils": "^1.1.0"
       }
     },
     "sass-graph": {
@@ -19015,10 +19192,10 @@
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
-        "glob": "7.1.3",
-        "lodash": "4.17.11",
-        "scss-tokenizer": "0.2.3",
-        "yargs": "7.1.0"
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^7.0.0"
       }
     },
     "sass-loader": {
@@ -19027,12 +19204,12 @@
       "integrity": "sha512-+G+BKGglmZM2GUSfT9TLuEp6tzehHPjAMoRRItOojWIqIGPloVCMhNIQuG639eJ+y033PaGTSjLaTHts8Kw79w==",
       "dev": true,
       "requires": {
-        "clone-deep": "2.0.2",
-        "loader-utils": "1.1.0",
-        "lodash.tail": "4.1.1",
-        "neo-async": "2.6.0",
-        "pify": "3.0.0",
-        "semver": "5.5.1"
+        "clone-deep": "^2.0.1",
+        "loader-utils": "^1.0.1",
+        "lodash.tail": "^4.1.1",
+        "neo-async": "^2.5.0",
+        "pify": "^3.0.0",
+        "semver": "^5.5.0"
       }
     },
     "saucelabs": {
@@ -19041,7 +19218,7 @@
       "integrity": "sha512-jlX3FGdWvYf4Q3LFfFWS1QvPg3IGCGWxIc8QBFdPTbpTJnt/v17FHXYVAn7C8sHf1yUXo2c7yIM0isDryfYtHQ==",
       "dev": true,
       "requires": {
-        "https-proxy-agent": "2.2.1"
+        "https-proxy-agent": "^2.2.1"
       }
     },
     "sax": {
@@ -19056,9 +19233,9 @@
       "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
       "dev": true,
       "requires": {
-        "ajv": "6.9.1",
-        "ajv-errors": "1.0.1",
-        "ajv-keywords": "3.4.0"
+        "ajv": "^6.1.0",
+        "ajv-errors": "^1.0.0",
+        "ajv-keywords": "^3.1.0"
       }
     },
     "schematics-utilities": {
@@ -19067,12 +19244,12 @@
       "integrity": "sha512-HhY15I4pugKtzu/g3gnSNPkz3ah8fAm1asp+fbElzp7rpm69PgGWkp4ta0ubyCbpj2qSV4TvZE87n10KpdE9zw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "7.3.8",
-        "@angular-devkit/schematics": "7.3.8",
-        "npm-registry-client": "8.6.0",
-        "parse5": "5.1.0",
-        "rxjs": "6.5.2",
-        "typescript": "3.4.5"
+        "@angular-devkit/core": "^7.3.6",
+        "@angular-devkit/schematics": "^7.3.6",
+        "npm-registry-client": "^8.5.1",
+        "parse5": "^5.0.0",
+        "rxjs": "^6.4.0",
+        "typescript": "^3.3.3333"
       },
       "dependencies": {
         "parse5": {
@@ -19087,7 +19264,7 @@
           "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
           "dev": true,
           "requires": {
-            "tslib": "1.9.3"
+            "tslib": "^1.9.0"
           }
         },
         "typescript": {
@@ -19104,8 +19281,8 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.5.1",
-        "source-map": "0.4.4"
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
       },
       "dependencies": {
         "source-map": {
@@ -19114,7 +19291,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -19137,10 +19314,10 @@
       "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
       "dev": true,
       "requires": {
-        "jszip": "3.1.5",
-        "rimraf": "2.6.2",
+        "jszip": "^3.1.3",
+        "rimraf": "^2.5.4",
         "tmp": "0.0.30",
-        "xml2js": "0.4.19"
+        "xml2js": "^0.4.17"
       },
       "dependencies": {
         "tmp": {
@@ -19149,7 +19326,7 @@
           "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
           "dev": true,
           "requires": {
-            "os-tmpdir": "1.0.2"
+            "os-tmpdir": "~1.0.1"
           }
         }
       }
@@ -19175,7 +19352,7 @@
       "integrity": "sha1-02eN5VVeimH2Ke7QJTZq5fJzQKA=",
       "dev": true,
       "requires": {
-        "semver": "5.5.1"
+        "semver": "^5.3.0"
       }
     },
     "semver-intersect": {
@@ -19184,7 +19361,7 @@
       "integrity": "sha512-d8fvGg5ycKAq0+I6nfWeCx6ffaWJCsBYU0H2Rq56+/zFePYfT8mXkB3tWBSjR5BerkHNZ5eTPIk1/LBYas35xQ==",
       "dev": true,
       "requires": {
-        "semver": "5.5.1"
+        "semver": "^5.0.0"
       }
     },
     "send": {
@@ -19194,18 +19371,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       },
       "dependencies": {
         "mime": {
@@ -19228,13 +19405,13 @@
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.7",
+        "accepts": "~1.3.4",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "1.0.3",
-        "http-errors": "1.6.3",
-        "mime-types": "2.1.20",
-        "parseurl": "1.3.3"
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
       }
     },
     "serve-static": {
@@ -19243,9 +19420,9 @@
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.3",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -19267,10 +19444,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -19279,7 +19456,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -19302,8 +19479,8 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shallow-clone": {
@@ -19312,9 +19489,9 @@
       "integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
       "dev": true,
       "requires": {
-        "is-extendable": "0.1.1",
-        "kind-of": "5.1.0",
-        "mixin-object": "2.0.1"
+        "is-extendable": "^0.1.1",
+        "kind-of": "^5.0.0",
+        "mixin-object": "^2.0.1"
       },
       "dependencies": {
         "kind-of": {
@@ -19331,7 +19508,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -19346,10 +19523,10 @@
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "dev": true,
       "requires": {
-        "array-filter": "0.0.1",
-        "array-map": "0.0.0",
-        "array-reduce": "0.0.0",
-        "jsonify": "0.0.0"
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
       }
     },
     "shelljs": {
@@ -19358,9 +19535,9 @@
       "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
       "dev": true,
       "requires": {
-        "glob": "7.1.3",
-        "interpret": "1.2.0",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "signal-exit": {
@@ -19393,14 +19570,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.2",
-        "use": "3.1.1"
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -19409,7 +19586,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "extend-shallow": {
@@ -19418,7 +19595,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         }
       }
@@ -19429,9 +19606,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -19440,7 +19617,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "1.0.2"
+            "is-descriptor": "^1.0.0"
           }
         },
         "is-accessor-descriptor": {
@@ -19449,7 +19626,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-data-descriptor": {
@@ -19458,7 +19635,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
+            "kind-of": "^6.0.0"
           }
         },
         "is-descriptor": {
@@ -19467,9 +19644,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -19480,7 +19657,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.2.0"
       },
       "dependencies": {
         "kind-of": {
@@ -19489,7 +19666,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -19500,12 +19677,12 @@
       "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
       "dev": true,
       "requires": {
-        "debug": "3.1.0",
-        "engine.io": "3.2.1",
-        "has-binary2": "1.0.3",
-        "socket.io-adapter": "1.1.1",
+        "debug": "~3.1.0",
+        "engine.io": "~3.2.0",
+        "has-binary2": "~1.0.2",
+        "socket.io-adapter": "~1.1.0",
         "socket.io-client": "2.1.1",
-        "socket.io-parser": "3.2.0"
+        "socket.io-parser": "~3.2.0"
       },
       "dependencies": {
         "debug": {
@@ -19535,15 +19712,15 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "3.1.0",
-        "engine.io-client": "3.2.1",
-        "has-binary2": "1.0.3",
+        "debug": "~3.1.0",
+        "engine.io-client": "~3.2.0",
+        "has-binary2": "~1.0.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "3.2.0",
+        "socket.io-parser": "~3.2.0",
         "to-array": "0.1.4"
       },
       "dependencies": {
@@ -19571,7 +19748,7 @@
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "3.1.0",
+        "debug": "~3.1.0",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -19604,8 +19781,8 @@
       "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
       "dev": true,
       "requires": {
-        "faye-websocket": "0.10.0",
-        "uuid": "3.3.2"
+        "faye-websocket": "^0.10.0",
+        "uuid": "^3.0.1"
       }
     },
     "sockjs-client": {
@@ -19614,12 +19791,12 @@
       "integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
       "dev": true,
       "requires": {
-        "debug": "3.2.6",
-        "eventsource": "1.0.7",
-        "faye-websocket": "0.11.1",
-        "inherits": "2.0.3",
-        "json3": "3.3.2",
-        "url-parse": "1.4.7"
+        "debug": "^3.2.5",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "~0.11.1",
+        "inherits": "^2.0.3",
+        "json3": "^3.3.2",
+        "url-parse": "^1.4.3"
       },
       "dependencies": {
         "debug": {
@@ -19628,7 +19805,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "faye-websocket": {
@@ -19637,7 +19814,7 @@
           "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
           "dev": true,
           "requires": {
-            "websocket-driver": "0.7.0"
+            "websocket-driver": ">=0.5.1"
           }
         },
         "ms": {
@@ -19654,7 +19831,7 @@
       "integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
       "dev": true,
       "requires": {
-        "ip": "1.1.5",
+        "ip": "^1.1.5",
         "smart-buffer": "4.0.2"
       }
     },
@@ -19664,8 +19841,8 @@
       "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.1",
-        "socks": "2.3.2"
+        "agent-base": "~4.2.1",
+        "socks": "~2.3.2"
       }
     },
     "source-list-map": {
@@ -19686,8 +19863,8 @@
       "integrity": "sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==",
       "dev": true,
       "requires": {
-        "async": "2.6.2",
-        "loader-utils": "1.1.0"
+        "async": "^2.5.0",
+        "loader-utils": "^1.1.0"
       }
     },
     "source-map-resolve": {
@@ -19696,11 +19873,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "2.1.2",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
       }
     },
     "source-map-support": {
@@ -19709,8 +19886,8 @@
       "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.1.1",
-        "source-map": "0.6.1"
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       },
       "dependencies": {
         "source-map": {
@@ -19739,8 +19916,8 @@
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.4"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -19755,8 +19932,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.2.0",
-        "spdx-license-ids": "3.0.4"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -19771,11 +19948,11 @@
       "integrity": "sha512-ot0oEGT/PGUpzf/6uk4AWLqkq+irlqHXkrdbk51oWONh3bxQmBuljxPNl66zlRRcIJStWq0QkLUCPOPjgjvU0Q==",
       "dev": true,
       "requires": {
-        "debug": "4.1.1",
-        "handle-thing": "2.0.0",
-        "http-deceiver": "1.2.7",
-        "select-hose": "2.0.0",
-        "spdy-transport": "3.0.0"
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
       },
       "dependencies": {
         "debug": {
@@ -19784,7 +19961,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -19801,12 +19978,12 @@
       "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
       "dev": true,
       "requires": {
-        "debug": "4.1.1",
-        "detect-node": "2.0.4",
-        "hpack.js": "2.1.6",
-        "obuf": "1.1.2",
-        "readable-stream": "3.3.0",
-        "wbuf": "1.7.3"
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.2",
+        "readable-stream": "^3.0.6",
+        "wbuf": "^1.7.3"
       },
       "dependencies": {
         "debug": {
@@ -19815,7 +19992,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -19830,9 +20007,9 @@
           "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
@@ -19843,7 +20020,7 @@
       "integrity": "sha512-qVIkJvbtS9j/UeZumbdfz0vg+QfG/zxonAjzefZrqzkr7xOncLVXkeGbTpzd1gjCBM4PmVNkWlkeTVhgskAGSQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1"
+        "chalk": "^2.0.1"
       }
     },
     "split-string": {
@@ -19852,7 +20029,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "3.0.2"
+        "extend-shallow": "^3.0.0"
       }
     },
     "sprintf-js": {
@@ -19867,15 +20044,15 @@
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
     },
     "ssri": {
@@ -19884,7 +20061,7 @@
       "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.1.1"
       }
     },
     "static-extend": {
@@ -19893,8 +20070,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -19903,7 +20080,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         }
       }
@@ -19914,7 +20091,7 @@
       "integrity": "sha512-NT0YGhwuQ0EOX+uPhhUcI6/+1Sq/pMzNuSCBVT4GbFl/ac6I/JZefBcjlECNfAb1t3GOx5dEj1Z7x0cAxeeVLQ==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
+        "lodash": "^4.17.4"
       }
     },
     "statuses": {
@@ -19929,7 +20106,7 @@
       "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.1"
       }
     },
     "stream-browserify": {
@@ -19938,8 +20115,8 @@
       "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-each": {
@@ -19948,8 +20125,8 @@
       "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
       "dev": true,
       "requires": {
-        "end-of-stream": "1.4.1",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "stream-http": {
@@ -19958,11 +20135,11 @@
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "stream-shift": {
@@ -19977,11 +20154,11 @@
       "integrity": "sha512-Wc2Gm5ygjSX8ZpW9J7Y9FwiSzTlKSvcl0FTTMd3rn7RoxDXpBW+xD9TY5sWL2n0UR61COB0LG1BQvN6nTUQbLQ==",
       "dev": true,
       "requires": {
-        "async": "2.6.2",
-        "date-format": "2.0.0",
-        "debug": "3.2.6",
-        "fs-extra": "7.0.1",
-        "lodash": "4.17.11"
+        "async": "^2.6.1",
+        "date-format": "^2.0.0",
+        "debug": "^3.1.0",
+        "fs-extra": "^7.0.0",
+        "lodash": "^4.17.10"
       },
       "dependencies": {
         "debug": {
@@ -19990,7 +20167,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "ms": {
@@ -20007,9 +20184,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -20018,7 +20195,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -20027,7 +20204,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -20036,7 +20213,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-eof": {
@@ -20051,7 +20228,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "style-loader": {
@@ -20060,8 +20237,8 @@
       "integrity": "sha512-XK+uv9kWwhZMZ1y7mysB+zoihsEj4wneFWAS5qoiLwzW0WzSqMrrsIy+a3zkQJq0ipFtBpX5W3MqyRIBF/WFGg==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "schema-utils": "1.0.0"
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^1.0.0"
       }
     },
     "stylus": {
@@ -20070,12 +20247,12 @@
       "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
       "dev": true,
       "requires": {
-        "css-parse": "1.7.0",
-        "debug": "2.6.9",
-        "glob": "7.0.6",
-        "mkdirp": "0.5.1",
-        "sax": "0.5.8",
-        "source-map": "0.1.43"
+        "css-parse": "1.7.x",
+        "debug": "*",
+        "glob": "7.0.x",
+        "mkdirp": "0.5.x",
+        "sax": "0.5.x",
+        "source-map": "0.1.x"
       },
       "dependencies": {
         "glob": {
@@ -20084,12 +20261,12 @@
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "source-map": {
@@ -20098,7 +20275,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -20109,9 +20286,9 @@
       "integrity": "sha512-+VomPdZ6a0razP+zinir61yZgpw2NfljeSsdUF5kJuEzlo3khXhY19Fn6l8QQz1GRJGtMCo8nG5C04ePyV7SUA==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0",
-        "lodash.clonedeep": "4.5.0",
-        "when": "3.6.4"
+        "loader-utils": "^1.0.2",
+        "lodash.clonedeep": "^4.5.0",
+        "when": "~3.6.x"
       }
     },
     "subarg": {
@@ -20120,7 +20297,7 @@
       "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
       "dev": true,
       "requires": {
-        "minimist": "1.2.0"
+        "minimist": "^1.1.0"
       },
       "dependencies": {
         "minimist": {
@@ -20137,7 +20314,7 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "symbol-observable": {
@@ -20158,13 +20335,13 @@
       "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
       "dev": true,
       "requires": {
-        "chownr": "1.1.1",
-        "fs-minipass": "1.2.5",
-        "minipass": "2.3.5",
-        "minizlib": "1.2.1",
-        "mkdirp": "0.5.1",
-        "safe-buffer": "5.1.2",
-        "yallist": "3.0.3"
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.3.4",
+        "minizlib": "^1.1.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.2"
       }
     },
     "terser": {
@@ -20173,9 +20350,9 @@
       "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
       "dev": true,
       "requires": {
-        "commander": "2.20.0",
-        "source-map": "0.6.1",
-        "source-map-support": "0.5.12"
+        "commander": "^2.19.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.10"
       },
       "dependencies": {
         "commander": {
@@ -20196,8 +20373,8 @@
           "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
           "dev": true,
           "requires": {
-            "buffer-from": "1.1.1",
-            "source-map": "0.6.1"
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
           }
         }
       }
@@ -20208,14 +20385,14 @@
       "integrity": "sha512-1DMkTk286BzmfylAvLXwpJrI7dWa5BnFmscV/2dCr8+c56egFcbaeFAl7+sujAjdmpLam21XRdhA4oifLyiWWg==",
       "dev": true,
       "requires": {
-        "cacache": "11.3.2",
-        "find-cache-dir": "2.1.0",
-        "schema-utils": "1.0.0",
-        "serialize-javascript": "1.7.0",
-        "source-map": "0.6.1",
-        "terser": "3.17.0",
-        "webpack-sources": "1.3.0",
-        "worker-farm": "1.7.0"
+        "cacache": "^11.0.2",
+        "find-cache-dir": "^2.0.0",
+        "schema-utils": "^1.0.0",
+        "serialize-javascript": "^1.4.0",
+        "source-map": "^0.6.1",
+        "terser": "^3.16.1",
+        "webpack-sources": "^1.1.0",
+        "worker-farm": "^1.5.2"
       },
       "dependencies": {
         "bluebird": {
@@ -20230,20 +20407,20 @@
           "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
           "dev": true,
           "requires": {
-            "bluebird": "3.5.4",
-            "chownr": "1.1.1",
-            "figgy-pudding": "3.5.1",
-            "glob": "7.1.3",
-            "graceful-fs": "4.1.15",
-            "lru-cache": "5.1.1",
-            "mississippi": "3.0.0",
-            "mkdirp": "0.5.1",
-            "move-concurrently": "1.0.1",
-            "promise-inflight": "1.0.1",
-            "rimraf": "2.6.2",
-            "ssri": "6.0.1",
-            "unique-filename": "1.1.1",
-            "y18n": "4.0.0"
+            "bluebird": "^3.5.3",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.1.15",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
+            "y18n": "^4.0.0"
           }
         },
         "find-cache-dir": {
@@ -20252,9 +20429,9 @@
           "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
           "dev": true,
           "requires": {
-            "commondir": "1.0.1",
-            "make-dir": "2.1.0",
-            "pkg-dir": "3.0.0"
+            "commondir": "^1.0.1",
+            "make-dir": "^2.0.0",
+            "pkg-dir": "^3.0.0"
           }
         },
         "find-up": {
@@ -20263,7 +20440,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "3.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "graceful-fs": {
@@ -20278,8 +20455,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "3.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "lru-cache": {
@@ -20288,7 +20465,7 @@
           "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "dev": true,
           "requires": {
-            "yallist": "3.0.3"
+            "yallist": "^3.0.2"
           }
         },
         "make-dir": {
@@ -20297,8 +20474,8 @@
           "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
           "dev": true,
           "requires": {
-            "pify": "4.0.1",
-            "semver": "5.7.0"
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
           }
         },
         "mississippi": {
@@ -20307,16 +20484,16 @@
           "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
           "dev": true,
           "requires": {
-            "concat-stream": "1.6.2",
-            "duplexify": "3.7.1",
-            "end-of-stream": "1.4.1",
-            "flush-write-stream": "1.1.1",
-            "from2": "2.3.0",
-            "parallel-transform": "1.1.0",
-            "pump": "3.0.0",
-            "pumpify": "1.5.1",
-            "stream-each": "1.2.3",
-            "through2": "2.0.5"
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
           }
         },
         "p-limit": {
@@ -20325,7 +20502,7 @@
           "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "dev": true,
           "requires": {
-            "p-try": "2.2.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
@@ -20334,7 +20511,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "2.2.0"
+            "p-limit": "^2.0.0"
           }
         },
         "p-try": {
@@ -20355,7 +20532,7 @@
           "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "dev": true,
           "requires": {
-            "find-up": "3.0.0"
+            "find-up": "^3.0.0"
           }
         },
         "pump": {
@@ -20364,8 +20541,8 @@
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "semver": {
@@ -20386,7 +20563,7 @@
           "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "dev": true,
           "requires": {
-            "figgy-pudding": "3.5.1"
+            "figgy-pudding": "^3.5.1"
           }
         }
       }
@@ -20403,8 +20580,8 @@
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6",
-        "xtend": "4.0.1"
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
       }
     },
     "thunky": {
@@ -20419,7 +20596,7 @@
       "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "dev": true,
       "requires": {
-        "setimmediate": "1.0.5"
+        "setimmediate": "^1.0.4"
       }
     },
     "tiny-emitter": {
@@ -20434,22 +20611,22 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "tns-core-modules": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/tns-core-modules/-/tns-core-modules-5.2.0.tgz",
-      "integrity": "sha512-Zu2j8oW8+HVOtyjOS5Lss2Wk9rDiihPL7AbiyRcfiS9PYFoGOfZ8dYCWW/kgn6yCs/AuRPjwk1fpoB7YbDOTSg==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/tns-core-modules/-/tns-core-modules-5.4.2.tgz",
+      "integrity": "sha512-KSmKkX3LW6T2Sc4CVpgKbgG2VYLZ9PfB9dlC1fqjzktg+A1wChKMiNKvHfi17DOhzcVHqVM989Dn0OUqcxNMdA==",
       "requires": {
-        "tns-core-modules-widgets": "5.2.0",
-        "tslib": "1.9.3"
+        "tns-core-modules-widgets": "5.4.2",
+        "tslib": "^1.9.3"
       }
     },
     "tns-core-modules-widgets": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/tns-core-modules-widgets/-/tns-core-modules-widgets-5.2.0.tgz",
-      "integrity": "sha512-OHzP0Fnd2ya3m2kx+ilfjQRSzZNUr0SQovRSPwblP7hXe8gSJMb1dmn1Q+WWVkbHMKt74NtIQb+X6ez45CUviA=="
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/tns-core-modules-widgets/-/tns-core-modules-widgets-5.4.2.tgz",
+      "integrity": "sha512-ZbZd6yeT3mKuiXwjGm3Vpg4d0k3InVEa3zeff7JDTWvKTnMs1P4pbLzzxEpJk+dOL42u3heY2jNHpRgv7dt/GA=="
     },
     "tns-platform-declarations": {
       "version": "5.2.2",
@@ -20481,7 +20658,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -20490,7 +20667,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -20501,10 +20678,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "2.0.2",
-        "extend-shallow": "3.0.2",
-        "regex-not": "1.0.2",
-        "safe-regex": "1.1.0"
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "to-regex-range": {
@@ -20513,8 +20690,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
       }
     },
     "tough-cookie": {
@@ -20523,8 +20700,8 @@
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
-        "psl": "1.1.29",
-        "punycode": "1.4.1"
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -20559,7 +20736,7 @@
       "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
       "dev": true,
       "requires": {
-        "glob": "7.1.3"
+        "glob": "^7.1.2"
       }
     },
     "tryer": {
@@ -20574,11 +20751,11 @@
       "integrity": "sha512-XYsjfnRQCBum9AMRZpk2rTYSVpdZBpZK+kDh0TeT3kxmQNBDVIeUjdPjY5RZry4eIAb8XHc4gYSUiUWPYvzSRw==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "enhanced-resolve": "4.1.0",
-        "loader-utils": "1.1.0",
-        "micromatch": "3.1.10",
-        "semver": "5.5.1"
+        "chalk": "^2.3.0",
+        "enhanced-resolve": "^4.0.0",
+        "loader-utils": "^1.0.2",
+        "micromatch": "^3.1.4",
+        "semver": "^5.0.1"
       }
     },
     "ts-node": {
@@ -20587,14 +20764,14 @@
       "integrity": "sha512-XK7QmDcNHVmZkVtkiwNDWiERRHPyU8nBqZB1+iv2UhOG0q3RQ9HsZ2CMqISlFbxjrYFGfG2mX7bW4dAyxBVzUw==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "chalk": "2.4.1",
-        "diff": "3.5.0",
-        "make-error": "1.3.5",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.5.9",
-        "yn": "2.0.0"
+        "arrify": "^1.0.0",
+        "chalk": "^2.3.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.5.3",
+        "yn": "^2.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -20616,18 +20793,18 @@
       "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "builtin-modules": "1.1.1",
-        "chalk": "2.4.1",
-        "commander": "2.17.1",
-        "diff": "3.5.0",
-        "glob": "7.1.3",
-        "js-yaml": "3.13.1",
-        "minimatch": "3.0.4",
-        "resolve": "1.8.1",
-        "semver": "5.5.1",
-        "tslib": "1.9.3",
-        "tsutils": "2.29.0"
+        "babel-code-frame": "^6.22.0",
+        "builtin-modules": "^1.1.1",
+        "chalk": "^2.3.0",
+        "commander": "^2.12.1",
+        "diff": "^3.2.0",
+        "glob": "^7.1.1",
+        "js-yaml": "^3.7.0",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.3.2",
+        "semver": "^5.3.0",
+        "tslib": "^1.8.0",
+        "tsutils": "^2.12.1"
       },
       "dependencies": {
         "resolve": {
@@ -20636,7 +20813,7 @@
           "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
           "dev": true,
           "requires": {
-            "path-parse": "1.0.6"
+            "path-parse": "^1.0.5"
           }
         }
       }
@@ -20647,9 +20824,9 @@
       "integrity": "sha512-4FX9JIx/1rKHIPJNfMb+ooX1gPk5Vg3vNi7+dyFYpLO+O57F4g+b/fo1+W/G0SUOkBLHB/YKScxjX/P+7ZT/Tw==",
       "dev": true,
       "requires": {
-        "eslint-plugin-prettier": "2.7.0",
-        "lines-and-columns": "1.1.6",
-        "tslib": "1.9.3"
+        "eslint-plugin-prettier": "^2.2.0",
+        "lines-and-columns": "^1.1.6",
+        "tslib": "^1.7.1"
       }
     },
     "tsutils": {
@@ -20658,7 +20835,7 @@
       "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
       "dev": true,
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.8.1"
       }
     },
     "tty-browserify": {
@@ -20673,7 +20850,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -20690,7 +20867,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.24"
+        "mime-types": "~2.1.24"
       },
       "dependencies": {
         "mime-db": {
@@ -20729,8 +20906,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "2.17.1",
-        "source-map": "0.6.1"
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -20739,56 +20916,6 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true,
           "optional": true
-        }
-      }
-    },
-    "uglifyjs-webpack-plugin": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.7.tgz",
-      "integrity": "sha512-1VicfKhCYHLS8m1DCApqBhoulnASsEoJ/BvpUpP4zoNAPpKzdH+ghk0olGJMmwX2/jprK2j3hAHdUbczBSy2FA==",
-      "dev": true,
-      "requires": {
-        "cacache": "10.0.4",
-        "find-cache-dir": "1.0.0",
-        "schema-utils": "0.4.7",
-        "serialize-javascript": "1.7.0",
-        "source-map": "0.6.1",
-        "uglify-es": "3.3.9",
-        "webpack-sources": "1.3.0",
-        "worker-farm": "1.7.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-          "dev": true
-        },
-        "schema-utils": {
-          "version": "0.4.7",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "6.9.1",
-            "ajv-keywords": "3.4.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "uglify-es": {
-          "version": "3.3.9",
-          "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-          "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-          "dev": true,
-          "requires": {
-            "commander": "2.13.0",
-            "source-map": "0.6.1"
-          }
         }
       }
     },
@@ -20804,10 +20931,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -20816,7 +20943,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "set-value": {
@@ -20825,13 +20952,19 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
           }
         }
       }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
     },
     "unique-filename": {
       "version": "1.1.1",
@@ -20839,7 +20972,7 @@
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
       "dev": true,
       "requires": {
-        "unique-slug": "2.0.1"
+        "unique-slug": "^2.0.0"
       }
     },
     "unique-slug": {
@@ -20848,7 +20981,7 @@
       "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
       "dev": true,
       "requires": {
-        "imurmurhash": "0.1.4"
+        "imurmurhash": "^0.1.4"
       }
     },
     "universalify": {
@@ -20869,8 +21002,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
       },
       "dependencies": {
         "has-value": {
@@ -20879,9 +21012,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -20915,7 +21048,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "urix": {
@@ -20948,8 +21081,8 @@
       "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
       "dev": true,
       "requires": {
-        "querystringify": "2.1.1",
-        "requires-port": "1.0.0"
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "use": {
@@ -20964,8 +21097,8 @@
       "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.5",
-        "tmp": "0.0.33"
+        "lru-cache": "4.1.x",
+        "tmp": "0.0.x"
       }
     },
     "util": {
@@ -20996,9 +21129,9 @@
       "dev": true
     },
     "v8-compile-cache": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz",
-      "integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
+      "integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -21007,8 +21140,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.1.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "validate-npm-package-name": {
@@ -21017,7 +21150,7 @@
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "requires": {
-        "builtins": "1.0.3"
+        "builtins": "^1.0.3"
       }
     },
     "vary": {
@@ -21032,9 +21165,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vm-browserify": {
@@ -21064,9 +21197,9 @@
       "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "dev": true,
       "requires": {
-        "chokidar": "2.0.4",
-        "graceful-fs": "4.1.11",
-        "neo-async": "2.6.0"
+        "chokidar": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "neo-async": "^2.5.0"
       }
     },
     "wbuf": {
@@ -21075,7 +21208,7 @@
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dev": true,
       "requires": {
-        "minimalistic-assert": "1.0.1"
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "webdriver-js-extender": {
@@ -21084,8 +21217,8 @@
       "integrity": "sha1-gcUzqeM9W/tZe05j4s2yW1R3dRU=",
       "dev": true,
       "requires": {
-        "@types/selenium-webdriver": "2.53.43",
-        "selenium-webdriver": "2.53.3"
+        "@types/selenium-webdriver": "^2.53.35",
+        "selenium-webdriver": "^2.53.2"
       },
       "dependencies": {
         "sax": {
@@ -21101,9 +21234,9 @@
           "dev": true,
           "requires": {
             "adm-zip": "0.4.4",
-            "rimraf": "2.6.2",
+            "rimraf": "^2.2.8",
             "tmp": "0.0.24",
-            "ws": "1.1.2",
+            "ws": "^1.0.1",
             "xml2js": "0.4.4"
           }
         },
@@ -21119,8 +21252,8 @@
           "integrity": "sha1-MREBAAMAiuGSQOuhdJe1fHKcVV0=",
           "dev": true,
           "requires": {
-            "sax": "0.6.1",
-            "xmlbuilder": "9.0.7"
+            "sax": "0.6.x",
+            "xmlbuilder": ">=1.0.0"
           }
         }
       }
@@ -21135,26 +21268,26 @@
         "@webassemblyjs/helper-module-context": "1.7.11",
         "@webassemblyjs/wasm-edit": "1.7.11",
         "@webassemblyjs/wasm-parser": "1.7.11",
-        "acorn": "6.1.1",
-        "acorn-dynamic-import": "4.0.0",
-        "ajv": "6.9.1",
-        "ajv-keywords": "3.4.0",
-        "chrome-trace-event": "1.0.0",
-        "enhanced-resolve": "4.1.0",
-        "eslint-scope": "4.0.3",
-        "json-parse-better-errors": "1.0.2",
-        "loader-runner": "2.4.0",
-        "loader-utils": "1.1.0",
-        "memory-fs": "0.4.1",
-        "micromatch": "3.1.10",
-        "mkdirp": "0.5.1",
-        "neo-async": "2.6.0",
-        "node-libs-browser": "2.2.0",
-        "schema-utils": "0.4.7",
-        "tapable": "1.1.3",
-        "terser-webpack-plugin": "1.2.2",
-        "watchpack": "1.6.0",
-        "webpack-sources": "1.3.0"
+        "acorn": "^6.0.5",
+        "acorn-dynamic-import": "^4.0.0",
+        "ajv": "^6.1.0",
+        "ajv-keywords": "^3.1.0",
+        "chrome-trace-event": "^1.0.0",
+        "enhanced-resolve": "^4.1.0",
+        "eslint-scope": "^4.0.0",
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^2.3.0",
+        "loader-utils": "^1.1.0",
+        "memory-fs": "~0.4.1",
+        "micromatch": "^3.1.8",
+        "mkdirp": "~0.5.0",
+        "neo-async": "^2.5.0",
+        "node-libs-browser": "^2.0.0",
+        "schema-utils": "^0.4.4",
+        "tapable": "^1.1.0",
+        "terser-webpack-plugin": "^1.1.0",
+        "watchpack": "^1.5.0",
+        "webpack-sources": "^1.3.0"
       },
       "dependencies": {
         "schema-utils": {
@@ -21163,8 +21296,8 @@
           "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
           "dev": true,
           "requires": {
-            "ajv": "6.9.1",
-            "ajv-keywords": "3.4.0"
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
           }
         }
       }
@@ -21175,18 +21308,18 @@
       "integrity": "sha512-ggDUgtKuQki4vmc93Ej65GlYxeCUR/0THa7gA+iqAGC2FFAxO+r+RM9sAUa8HWdw4gJ3/NZHX/QUcVgRjdIsDg==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.3",
-        "bfj": "6.1.1",
-        "chalk": "2.4.1",
-        "commander": "2.20.0",
-        "ejs": "2.6.1",
-        "express": "4.16.4",
-        "filesize": "3.6.1",
-        "gzip-size": "5.1.0",
-        "lodash": "4.17.11",
-        "mkdirp": "0.5.1",
-        "opener": "1.5.1",
-        "ws": "6.2.1"
+        "acorn": "^5.7.3",
+        "bfj": "^6.1.1",
+        "chalk": "^2.4.1",
+        "commander": "^2.18.0",
+        "ejs": "^2.6.1",
+        "express": "^4.16.3",
+        "filesize": "^3.6.1",
+        "gzip-size": "^5.0.0",
+        "lodash": "^4.17.10",
+        "mkdirp": "^0.5.1",
+        "opener": "^1.5.1",
+        "ws": "^6.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -21207,7 +21340,7 @@
           "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
           "dev": true,
           "requires": {
-            "async-limiter": "1.0.0"
+            "async-limiter": "~1.0.0"
           }
         }
       }
@@ -21218,16 +21351,16 @@
       "integrity": "sha512-Cnqo7CeqeSvC6PTdts+dywNi5CRlIPbLx1AoUPK2T6vC1YAugMG3IOoO9DmEscd+Dghw7uRlnzV1KwOe5IrtgQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "cross-spawn": "6.0.5",
-        "enhanced-resolve": "4.1.0",
-        "global-modules-path": "2.3.1",
-        "import-local": "2.0.0",
-        "interpret": "1.2.0",
-        "loader-utils": "1.1.0",
-        "supports-color": "5.5.0",
-        "v8-compile-cache": "2.0.2",
-        "yargs": "12.0.5"
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "enhanced-resolve": "^4.1.0",
+        "global-modules-path": "^2.3.0",
+        "import-local": "^2.0.0",
+        "interpret": "^1.1.0",
+        "loader-utils": "^1.1.0",
+        "supports-color": "^5.5.0",
+        "v8-compile-cache": "^2.0.2",
+        "yargs": "^12.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -21248,9 +21381,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "cross-spawn": {
@@ -21259,11 +21392,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "1.0.5",
-            "path-key": "2.0.1",
-            "semver": "5.5.1",
-            "shebang-command": "1.2.0",
-            "which": "1.3.1"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "execa": {
@@ -21272,13 +21405,13 @@
           "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
-            "cross-spawn": "6.0.5",
-            "get-stream": "4.1.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "find-up": {
@@ -21287,7 +21420,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "3.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "get-stream": {
@@ -21296,7 +21429,7 @@
           "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         },
         "global-modules-path": {
@@ -21323,7 +21456,7 @@
           "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
-            "invert-kv": "2.0.0"
+            "invert-kv": "^2.0.0"
           }
         },
         "locate-path": {
@@ -21332,8 +21465,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "3.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "os-locale": {
@@ -21342,9 +21475,9 @@
           "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
-            "execa": "1.0.0",
-            "lcid": "2.0.0",
-            "mem": "4.3.0"
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
           }
         },
         "p-limit": {
@@ -21353,7 +21486,7 @@
           "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "dev": true,
           "requires": {
-            "p-try": "2.2.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
@@ -21362,7 +21495,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "2.2.0"
+            "p-limit": "^2.0.0"
           }
         },
         "p-try": {
@@ -21377,8 +21510,8 @@
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "string-width": {
@@ -21387,8 +21520,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -21397,7 +21530,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "which-module": {
@@ -21412,18 +21545,18 @@
           "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
           "dev": true,
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "3.0.0",
-            "get-caller-file": "1.0.3",
-            "os-locale": "3.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "4.0.0",
-            "yargs-parser": "11.1.1"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
           }
         },
         "yargs-parser": {
@@ -21432,8 +21565,8 @@
           "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
           "dev": true,
           "requires": {
-            "camelcase": "5.3.1",
-            "decamelize": "1.2.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -21444,8 +21577,8 @@
       "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
       "dev": true,
       "requires": {
-        "source-list-map": "0.1.8",
-        "source-map": "0.4.4"
+        "source-list-map": "~0.1.7",
+        "source-map": "~0.4.1"
       },
       "dependencies": {
         "source-list-map": {
@@ -21460,7 +21593,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -21471,10 +21604,10 @@
       "integrity": "sha512-4dwCh/AyMOYAybggUr8fiCkRnjVDp+Cqlr9c+aaNB3GJYgRGYQWJ1YX/WAKUNA9dPNHZ6QSN2lYDKqjKSI8Vqw==",
       "dev": true,
       "requires": {
-        "memory-fs": "0.4.1",
-        "mime": "2.4.2",
-        "range-parser": "1.2.0",
-        "webpack-log": "2.0.0"
+        "memory-fs": "~0.4.1",
+        "mime": "^2.3.1",
+        "range-parser": "^1.0.3",
+        "webpack-log": "^2.0.0"
       },
       "dependencies": {
         "mime": {
@@ -21492,34 +21625,34 @@
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
-        "bonjour": "3.5.0",
-        "chokidar": "2.0.4",
-        "compression": "1.7.4",
-        "connect-history-api-fallback": "1.6.0",
-        "debug": "3.2.6",
-        "del": "3.0.0",
-        "express": "4.16.4",
-        "html-entities": "1.2.1",
-        "http-proxy-middleware": "0.18.0",
-        "import-local": "2.0.0",
-        "internal-ip": "3.0.1",
-        "ip": "1.1.5",
-        "killable": "1.0.1",
-        "loglevel": "1.6.1",
-        "opn": "5.5.0",
-        "portfinder": "1.0.20",
-        "schema-utils": "1.0.0",
-        "selfsigned": "1.10.4",
-        "semver": "5.7.0",
-        "serve-index": "1.9.1",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^2.0.0",
+        "internal-ip": "^3.0.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "semver": "^5.6.0",
+        "serve-index": "^1.7.2",
         "sockjs": "0.3.19",
         "sockjs-client": "1.3.0",
-        "spdy": "4.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "5.5.0",
-        "url": "0.11.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "url": "^0.11.0",
         "webpack-dev-middleware": "3.4.0",
-        "webpack-log": "2.0.0",
+        "webpack-log": "^2.0.0",
         "yargs": "12.0.2"
       },
       "dependencies": {
@@ -21541,9 +21674,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "strip-ansi": {
@@ -21552,7 +21685,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -21563,11 +21696,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "1.0.5",
-            "path-key": "2.0.1",
-            "semver": "5.7.0",
-            "shebang-command": "1.2.0",
-            "which": "1.3.1"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "debug": {
@@ -21576,7 +21709,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.1.1"
+            "ms": "^2.1.1"
           }
         },
         "decamelize": {
@@ -21594,13 +21727,13 @@
           "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
-            "cross-spawn": "6.0.5",
-            "get-stream": "4.1.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "find-up": {
@@ -21609,7 +21742,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "3.0.0"
+            "locate-path": "^3.0.0"
           }
         },
         "get-stream": {
@@ -21618,7 +21751,7 @@
           "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         },
         "invert-kv": {
@@ -21639,7 +21772,7 @@
           "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
-            "invert-kv": "2.0.0"
+            "invert-kv": "^2.0.0"
           }
         },
         "locate-path": {
@@ -21648,8 +21781,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "3.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
           }
         },
         "mime": {
@@ -21670,9 +21803,9 @@
           "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
-            "execa": "1.0.0",
-            "lcid": "2.0.0",
-            "mem": "4.3.0"
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
           }
         },
         "p-limit": {
@@ -21681,7 +21814,7 @@
           "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "dev": true,
           "requires": {
-            "p-try": "2.2.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
@@ -21690,7 +21823,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "2.2.0"
+            "p-limit": "^2.0.0"
           }
         },
         "p-try": {
@@ -21705,8 +21838,8 @@
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "semver": {
@@ -21721,8 +21854,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "strip-ansi": {
@@ -21731,7 +21864,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -21742,10 +21875,10 @@
           "integrity": "sha512-Q9Iyc0X9dP9bAsYskAVJ/hmIZZQwf/3Sy4xCAZgL5cUkjZmUZLt4l5HpbST/Pdgjn3u6pE7u5OdGd1apgzRujA==",
           "dev": true,
           "requires": {
-            "memory-fs": "0.4.1",
-            "mime": "2.4.2",
-            "range-parser": "1.2.0",
-            "webpack-log": "2.0.0"
+            "memory-fs": "~0.4.1",
+            "mime": "^2.3.1",
+            "range-parser": "^1.0.3",
+            "webpack-log": "^2.0.0"
           }
         },
         "which-module": {
@@ -21760,18 +21893,18 @@
           "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
           "dev": true,
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "2.0.0",
-            "find-up": "3.0.0",
-            "get-caller-file": "1.0.3",
-            "os-locale": "3.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "4.0.0",
-            "yargs-parser": "10.1.0"
+            "cliui": "^4.0.0",
+            "decamelize": "^2.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^10.1.0"
           }
         },
         "yargs-parser": {
@@ -21780,7 +21913,7 @@
           "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -21791,8 +21924,8 @@
       "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
       "dev": true,
       "requires": {
-        "ansi-colors": "3.2.4",
-        "uuid": "3.3.2"
+        "ansi-colors": "^3.0.0",
+        "uuid": "^3.3.2"
       }
     },
     "webpack-merge": {
@@ -21801,7 +21934,7 @@
       "integrity": "sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.11"
+        "lodash": "^4.17.5"
       }
     },
     "webpack-sources": {
@@ -21810,8 +21943,8 @@
       "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
       "dev": true,
       "requires": {
-        "source-list-map": "2.0.1",
-        "source-map": "0.6.1"
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -21828,7 +21961,7 @@
       "integrity": "sha512-Az7y8xTniNhaA0620AV1KPwWOqawurVVDzQSpPAeR5RwNbL91GoBSJAAo9cfd+GiFHwsS5bbHepBw1e6Hzxy4w==",
       "dev": true,
       "requires": {
-        "webpack-core": "0.6.9"
+        "webpack-core": "^0.6.8"
       }
     },
     "websocket-driver": {
@@ -21837,8 +21970,8 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.5.0",
-        "websocket-extensions": "0.1.3"
+        "http-parser-js": ">=0.4.0",
+        "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
@@ -21859,7 +21992,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -21874,7 +22007,7 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2 || 2"
       }
     },
     "worker-farm": {
@@ -21883,7 +22016,16 @@
       "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
       "dev": true,
       "requires": {
-        "errno": "0.1.7"
+        "errno": "~0.1.7"
+      }
+    },
+    "worker-rpc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/worker-rpc/-/worker-rpc-0.1.1.tgz",
+      "integrity": "sha512-P1WjMrUB3qgJNI9jfmpZ/htmBEjFh//6l/5y8SD9hg1Ef5zTTVVoRjTrTEzPrNBQvmhMxkoTsjOXN10GWU7aCg==",
+      "dev": true,
+      "requires": {
+        "microevent.ts": "~0.1.1"
       }
     },
     "wrap-ansi": {
@@ -21892,8 +22034,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -21908,8 +22050,8 @@
       "integrity": "sha1-iiRPoFJAHgjJiGz0SoUYnh/UBn8=",
       "dev": true,
       "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
+        "options": ">=0.0.5",
+        "ultron": "1.0.x"
       }
     },
     "xml2js": {
@@ -21918,8 +22060,8 @@
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "dev": true,
       "requires": {
-        "sax": "1.2.4",
-        "xmlbuilder": "9.0.7"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
       },
       "dependencies": {
         "sax": {
@@ -21972,19 +22114,19 @@
       "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.3",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "5.0.0"
+        "camelcase": "^3.0.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^1.4.0",
+        "read-pkg-up": "^1.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^1.0.2",
+        "which-module": "^1.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^5.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -22007,7 +22149,7 @@
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0"
+        "camelcase": "^3.0.0"
       },
       "dependencies": {
         "camelcase": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-junit-reporter": "^1.2.0",
     "karma-spec-reporter": "0.0.32",
-    "nativescript": "^5.3.4",
+    "nativescript": "^5.4.0",
     "nativescript-dev-sass": "^1.7.0",
     "nativescript-dev-typescript": "^0.10.0",
     "nativescript-dev-webpack": "^0.24.1",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "nativescript": {
     "id": "dk.kirby.design.system",
     "tns-ios": {
-      "version": "5.2.0"
+      "version": "5.4.0"
     },
     "tns-android": {
-      "version": "5.2.0"
+      "version": "5.4.0"
     }
   },
   "version": "0.0.179",
@@ -21,12 +21,12 @@
     "lint:fix": "tslint './src/**/*.ts' --fix",
     "e2e": "ng e2e",
     "dist": "ng build --prod --aot --progress false",
-    "android": "tns run android --hmr",
-    "android-debug": "tns debug android --bundle",
-    "ios": "tns run ios --hmr",
-    "ios-debug": "tns debug ios --bundle --device 'iPhone X'",
-    "dist:ios": "tns build ios --bundle --for-device --provision dk.kirby.design.system --copy-to dist/designsystem.ipa",
-    "dist:android": "tns build android --for-device --bundle --copy-to dist/designsystem.apk",
+    "android": "tns run android",
+    "android-debug": "tns debug android",
+    "ios": "tns run ios",
+    "ios-debug": "tns debug ios --device 'iPhone X'",
+    "dist:ios": "tns build ios --for-device --provision dk.kirby.design.system --copy-to dist/designsystem.ipa",
+    "dist:android": "tns build android --for-device --copy-to dist/designsystem.apk",
     "pack-copy-to-dist-folder-watch": "cpx \"src\\kirby\\**\\!(*.spec.ts)\" dist-lib --watch",
     "postinstall": "npm run build-polyfills && npm run transpile:tools",
     "postversion": "git push && git push --tags",
@@ -60,7 +60,7 @@
     "prismjs": "^1.15.0",
     "reflect-metadata": "~0.1.8",
     "rxjs": "^6.3.3",
-    "tns-core-modules": "^5.2.0",
+    "tns-core-modules": "^5.4.0",
     "zone.js": "^0.8.4"
   },
   "devDependencies": {
@@ -87,8 +87,8 @@
     "karma-spec-reporter": "0.0.32",
     "nativescript": "^5.3.4",
     "nativescript-dev-sass": "^1.7.0",
-    "nativescript-dev-typescript": "^0.8.0",
-    "nativescript-dev-webpack": "^0.21.2",
+    "nativescript-dev-typescript": "^0.10.0",
+    "nativescript-dev-webpack": "^0.24.1",
     "ng-mocks": "^7.7.0",
     "prettier": "^1.15.3",
     "protractor": "~5.3.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,8 +11,9 @@ const CleanWebpackPlugin = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 const { NativeScriptWorkerPlugin } = require("nativescript-worker-loader/NativeScriptWorkerPlugin");
-const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
-const { AngularCompilerPlugin } = require("@ngtools/webpack");
+const TerserPlugin = require("terser-webpack-plugin");
+const { getAngularCompilerPlugin } = require("nativescript-dev-webpack/plugins/NativeScriptAngularCompilerPlugin");
+const hashSalt = Date.now().toString();
 
 module.exports = env => {
     // Add your custom Activities, Services and other Android app components here.
@@ -26,6 +27,7 @@ module.exports = env => {
         throw new Error("You need to provide a target platform!");
     }
 
+    const AngularCompilerPlugin = getAngularCompilerPlugin(platform);
     const projectRoot = __dirname;
 
     // Default destination inside platforms/<platform>/...
@@ -45,15 +47,23 @@ module.exports = env => {
         uglify, // --env.uglify
         report, // --env.report
         sourceMap, // --env.sourceMap
+        hiddenSourceMap, // --env.hiddenSourceMap
         hmr, // --env.hmr,
+        unitTesting, // --env.unitTesting
     } = env;
 
+    const isAnySourceMapEnabled = !!sourceMap || !!hiddenSourceMap;
     const externals = nsWebpack.getConvertedExternals(env.externals);
     const appFullPath = resolve(projectRoot, appPath);
     const appResourcesFullPath = resolve(projectRoot, appResourcesPath);
     const tsConfigName = "tsconfig.tns.json";
-    const entryModule = `${nsWebpack.getEntryModule(appFullPath)}.ts`;
+    const entryModule = `${nsWebpack.getEntryModule(appFullPath, platform)}.ts`;
     const entryPath = `.${sep}${entryModule}`;
+    const entries = { bundle: entryPath };
+    if (platform === "ios") {
+        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules.js";
+    };
+
     const ngCompilerTransformers = [];
     const additionalLazyModuleResources = [];
     if (aot) {
@@ -80,13 +90,15 @@ module.exports = env => {
 
     const ngCompilerPlugin = new AngularCompilerPlugin({
         hostReplacementPaths: nsWebpack.getResolver([platform, "tns"]),
-        platformTransformers: ngCompilerTransformers.map(t => t(() => ngCompilerPlugin, resolve(appFullPath, entryModule))),
-        mainPath: resolve(appPath, entryModule),
+        platformTransformers: ngCompilerTransformers.map(t => t(() => ngCompilerPlugin, resolve(appFullPath, entryModule), projectRoot)),
+        mainPath: join(appFullPath, entryModule),
         tsConfigPath: join(__dirname, tsConfigName),
         skipCodeGeneration: !aot,
-        sourceMap: !!sourceMap,
+        sourceMap: !!isAnySourceMapEnabled,
         additionalLazyModuleResources: additionalLazyModuleResources
     });
+
+    let sourceMapFilename = nsWebpack.getSourceMapFilename(hiddenSourceMap, __dirname, dist);
 
     const config = {
         mode: uglify ? "production" : "development",
@@ -100,15 +112,15 @@ module.exports = env => {
             ]
         },
         target: nativescriptTarget,
-        entry: {
-            bundle: entryPath,
-        },
+        entry: entries,
         output: {
             pathinfo: false,
             path: dist,
+            sourceMapFilename,
             libraryTarget: "commonjs2",
             filename: "[name].js",
             globalObject: "global",
+            hashSalt
         },
         resolve: {
             extensions: [".ts", ".js", ".scss", ".css"],
@@ -135,8 +147,9 @@ module.exports = env => {
             "fs": "empty",
             "__dirname": false,
         },
-        devtool: sourceMap ? "inline-source-map" : "none",
+        devtool: hiddenSourceMap ? "hidden-source-map" : (sourceMap ? "inline-source-map" : "none"),
         optimization: {
+            runtimeChunk: "single",
             splitChunks: {
                 cacheGroups: {
                     vendor: {
@@ -153,12 +166,14 @@ module.exports = env => {
             },
             minimize: !!uglify,
             minimizer: [
-                new UglifyJsPlugin({
+                new TerserPlugin({
                     parallel: true,
                     cache: true,
-                    uglifyOptions: {
+                    sourceMap: isAnySourceMapEnabled,
+                    terserOptions: {
                         output: {
                             comments: false,
+                            semicolons: !isAnySourceMapEnabled
                         },
                         compress: {
                             // The Android SBG has problems parsing the output
@@ -173,7 +188,7 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    test: new RegExp(entryPath),
+                    test: nsWebpack.getEntryPathRegExp(appFullPath, entryPath),
                     use: [
                         // Require all Android app components
                         platform === "android" && {
@@ -186,6 +201,9 @@ module.exports = env => {
                             options: {
                                 angular: true,
                                 loadCss: !snapshot, // load the application css if in debug mode
+                                unitTesting,
+                                appFullPath,
+                                projectRoot,
                             }
                         },
                     ].filter(loader => !!loader)
@@ -198,14 +216,14 @@ module.exports = env => {
                     test: /[\/|\\]app\.css$/,
                     use: [
                         "nativescript-dev-webpack/style-hot-loader",
-                        { loader: "css-loader", options: { minimize: false, url: false } }
+                        { loader: "css-loader", options: { url: false } }
                     ]
                 },
                 {
                     test: /[\/|\\]app\.scss$/,
                     use: [
                         "nativescript-dev-webpack/style-hot-loader",
-                        { loader: "css-loader", options: { minimize: false, url: false } },
+                        { loader: "css-loader", options: { url: false } },
                         "sass-loader"
                     ]
                 },
@@ -239,14 +257,6 @@ module.exports = env => {
             }),
             // Remove all files from the out dir.
             new CleanWebpackPlugin([`${dist}/**/*`]),
-            // Copy native app resources to out dir.
-            new CopyWebpackPlugin([
-                {
-                    from: `${appResourcesFullPath}/${appResourcesPlatformDir}`,
-                    to: `${dist}/App_Resources/${appResourcesPlatformDir}`,
-                    context: projectRoot
-                },
-            ]),
             // Copy assets to out dir. Add your own globs as needed.
             new CopyWebpackPlugin([
                 { from: { glob: "fonts/**" } },
@@ -260,10 +270,16 @@ module.exports = env => {
                 { from: "../node_modules/nativescript-webview-interface/www/nativescript-webview-interface.js", to: "chart" },
             ], { ignore: [`${relative(appPath, appResourcesFullPath)}/**`] }),
             // Generate a bundle starter script and activate it in package.json
-            new nsWebpack.GenerateBundleStarterPlugin([
-                "./vendor",
-                "./bundle",
-            ]),
+            new nsWebpack.GenerateBundleStarterPlugin(
+                // Don't include `runtime.js` when creating a snapshot. The plugin
+                // configures the WebPack runtime to be generated inside the snapshot
+                // module and no `runtime.js` module exist.
+                (snapshot ? [] : ["./runtime"])
+                    .concat([
+                        "./vendor",
+                        "./bundle",
+                    ])
+            ),
             // For instructions on how to set up workers with webpack
             // check out https://github.com/nativescript/worker-loader
             new NativeScriptWorkerPlugin(),
@@ -272,6 +288,18 @@ module.exports = env => {
             new nsWebpack.WatchStateLoggerPlugin(),
         ],
     };
+
+    // Copy the native app resources to the out dir
+    // only if doing a full build (tns run/build) and not previewing (tns preview)
+    if (!externals || externals.length === 0) {
+        config.plugins.push(new CopyWebpackPlugin([
+            {
+                from: `${appResourcesFullPath}/${appResourcesPlatformDir}`,
+                to: `${dist}/App_Resources/${appResourcesPlatformDir}`,
+                context: projectRoot
+            },
+        ]));
+    }
 
 
     if (report) {


### PR DESCRIPTION
### Update to {N} 5.4 (more on its benefits [here](https://www.nativescript.org/blog/may-the-54th-release-be-with-you)). 
>Requires {N} CLI ^5.4
- because the new workflow uses --bundle and --hmr by default I removed the redundant params in npm scripts