### PR TITLE
Enhancement/Modal - hideAll function

### DIFF
--- a/src/kirby/components/modal/services/modal.controller.ts
+++ b/src/kirby/components/modal/services/modal.controller.ts
@@ -73,4 +73,8 @@ export class ModalController implements IModalController {
   private forgetTopmost(): void {
     this.modals.pop();
   }
+
+  public hideAll(): void {
+    this.modals.forEach((modal) => modal.close());
+  }
 }


### PR DESCRIPTION
There is a bug where on a timeout then modals isn't closed correctly - so the welcome page can still be visible even though you aren't logged in. 

So we have to somehow trigger a close everything when timing out. So that is why we've added a hideAll function to the modal.