### PR TITLE
Color fix

### DIFF
--- a/src/app/examples/calendar-example/calendar-card-example.component.tns.scss
+++ b/src/app/examples/calendar-example/calendar-card-example.component.tns.scss
@@ -1,7 +1,7 @@
 @import '../../../kirby/scss/native-imports';
 
 .wrapper {
-    background-color: get-color("base-color");
+    background-color: get-color('background-color');
     padding: 10;
 }
 

--- a/src/app/examples/calendar-example/calendar-example.component.tns.scss
+++ b/src/app/examples/calendar-example/calendar-example.component.tns.scss
@@ -1,6 +1,6 @@
 @import '../../../kirby/scss/native-imports';
 
 .wrapper {
-    background-color: get-color("base-color");
+    background-color: get-color('background-color');
     padding: 10;
 }

--- a/src/app/examples/toggle-example/toggle-example.component.tns.scss
+++ b/src/app/examples/toggle-example/toggle-example.component.tns.scss
@@ -1,7 +1,7 @@
 @import '../../../kirby/scss/native-imports';
 
 .background {
-    background-color: get-color("base-color");
+    background-color: get-color('background-color');
     padding: size('s');
 
     StackLayout {

--- a/src/app/showcase/colors-showcase/colors-showcase.component.html
+++ b/src/app/showcase/colors-showcase/colors-showcase.component.html
@@ -24,8 +24,9 @@
   <p>The <code>get-color</code> function will output CSS variables for web and output the color values directly for Nativescript.</p>
 </div>
 
+<h2>Brand Colors</h2>
 <ul class="color-palette">
-  <li *ngFor="let entry of colorPalette" class="color-box" (click)="onColorClick(entry)">
+  <li *ngFor="let entry of brandColors" class="color-box" (click)="onColorClick(entry)">
     <h2 class="color-name">{{entry.name}}</h2>
     <div class="color-samples">
       <div class="color-sample {{entry.name}}"><span class="h3" [ngStyle]="{color: entry.contrast.hex}">{{entry.name | slice:0:2 | uppercase }}</span></div>
@@ -45,3 +46,46 @@
   </li>
 </ul>
 
+<h2>Notification colors</h2>
+<ul class="color-palette">
+  <li *ngFor="let entry of notificationColors" class="color-box" (click)="onColorClick(entry)">
+    <h2 class="color-name">{{entry.name}}</h2>
+    <div class="color-samples">
+      <div class="color-sample {{entry.name}}"><span class="h3" [ngStyle]="{color: entry.contrast.hex}">{{entry.name | slice:0:2 | uppercase }}</span></div>
+      <div class="color-sample {{entry.tint.name}}"></div>
+      <div class="color-sample {{entry.shade.name}}"></div>
+    </div>
+    <dl class="kirby-text-xsmall color-values">
+      <dt>Base</dt>
+      <dd>{{entry.value.hex}}</dd>
+      <dt>Tint</dt>
+      <dd>{{entry.tint.hex}}</dd>
+      <dt>Shade</dt>
+      <dd>{{entry.shade.hex}}</dd>
+      <dt>Contrast</dt>
+      <dd>{{entry.contrast.hex}}</dd>
+    </dl>
+  </li>
+</ul>
+
+<h2>System colors</h2>
+<ul class="color-palette">
+  <li *ngFor="let entry of systemColors" class="color-box" (click)="onColorClick(entry)">
+    <h2 class="color-name">{{entry.name}}</h2>
+    <div class="color-samples">
+      <div class="color-sample {{entry.name}}"><span class="h3" [ngStyle]="{color: entry.contrast.hex}">{{entry.name | slice:0:2 | uppercase }}</span></div>
+      <div class="color-sample {{entry.tint.name}}"></div>
+      <div class="color-sample {{entry.shade.name}}"></div>
+    </div>
+    <dl class="kirby-text-xsmall color-values">
+      <dt>Base</dt>
+      <dd>{{entry.value.hex}}</dd>
+      <dt>Tint</dt>
+      <dd>{{entry.tint.hex}}</dd>
+      <dt>Shade</dt>
+      <dd>{{entry.shade.hex}}</dd>
+      <dt>Contrast</dt>
+      <dd>{{entry.contrast.hex}}</dd>
+    </dl>
+  </li>  
+</ul>

--- a/src/app/showcase/colors-showcase/colors-showcase.component.scss
+++ b/src/app/showcase/colors-showcase/colors-showcase.component.scss
@@ -6,7 +6,7 @@
   }
 }
 
-@each $color-name, $color-value in $main-colors {
+@each $color-name, $color-value in getAllColors() {
   .#{$color-name} {
     color: get-color($color-name + '-contrast');
   }
@@ -108,7 +108,7 @@
   grid-gap: size('m');
   list-style: none;
   padding: 0;
-  margin: 0;
+  margin: 0 0 size('xl');
 
   li {
     display: flex;

--- a/src/app/showcase/colors-showcase/colors-showcase.component.scss
+++ b/src/app/showcase/colors-showcase/colors-showcase.component.scss
@@ -6,6 +6,12 @@
   }
 }
 
+@each $color-name, $color-value in $main-colors {
+  .#{$color-name} {
+    color: get-color($color-name + '-contrast');
+  }
+}
+
 .color-box {
   background-color: get-color('white');
   border: 1px solid get-color('medium');

--- a/src/app/showcase/colors-showcase/colors-showcase.component.spec.ts
+++ b/src/app/showcase/colors-showcase/colors-showcase.component.spec.ts
@@ -30,7 +30,7 @@ describe('ColorsShowcaseComponent', () => {
     const colorElm = fixture.debugElement.nativeElement.querySelector('.color-box');
     colorElm.click();
     expect(component.onColorClick).toHaveBeenCalledWith(jasmine.any(Object));
-    expect(component.selectedColor).toBe(component.colorPalette[0].name);
-    expect(component.selectedOnColor).toBe(component.colorPalette[0].contrast.name);
+    expect(component.selectedColor).toBe(component.brandColors[0].name);
+    expect(component.selectedOnColor).toBe(component.brandColors[0].contrast.name);
   });
 });

--- a/src/app/showcase/colors-showcase/colors-showcase.component.ts
+++ b/src/app/showcase/colors-showcase/colors-showcase.component.ts
@@ -13,10 +13,14 @@ const style = require('sass-extract-loader!./colors-showcase.component.scss');
 export class ColorsShowcaseComponent {
   selectedColor = 'primary';
   selectedOnColor = 'primary-contrast';
-  colorPalette = [];
+  brandColors = [];
+  systemColors = [];
+  notificationColors = [];
 
   constructor() {
-    this.colorPalette = this.getThemeColors();
+    this.brandColors = this.getColors('$brand-colors');
+    this.systemColors = this.getColors('$system-colors');
+    this.notificationColors = this.getColors('$notification-colors');
   }
 
   onColorClick(sassColor: SassColor) {
@@ -24,9 +28,9 @@ export class ColorsShowcaseComponent {
     this.selectedOnColor = sassColor.name + '-contrast';
   }
 
-  private getThemeColors() {
+  private getColors(colorType: string) {
     const colors = [];
-    const mainColors = style.global['$main-colors'].value;
+    const mainColors = style.global[colorType].value;
     const generatedColors = style.global['$kirby-colors'].value;
     for (const [value, type] of Object.entries(mainColors)) {
       const sassColor = <SassColor>type;

--- a/src/kirby/components/calendar/calendar.component.scss
+++ b/src/kirby/components/calendar/calendar.component.scss
@@ -89,12 +89,12 @@ table.calendar-table {
 }
 
 .day.today {
-  color: get-color('contrast-dark');
+  color: get-color('black');
   background-color: get-color('medium-shade');
 }
 
 .day.selected {
-  color: get-color('contrast-dark');
+  color: get-color('black');
   background-color: get-color('primary');
   pointer-events: none;
 }
@@ -105,6 +105,6 @@ table.calendar-table {
 }
 
 .day.selectable:not(.selected):hover {
-  color: get-color('contrast-dark');
+  color: get-color('black');
   background-color: get-color('light');
 }

--- a/src/kirby/components/calendar/calendar.component.scss
+++ b/src/kirby/components/calendar/calendar.component.scss
@@ -89,7 +89,7 @@ table.calendar-table {
 }
 
 .day.today {
-  color: get-color('black');
+  color: get-color('medium-contrast');
   background-color: get-color('medium-shade');
 }
 
@@ -105,6 +105,6 @@ table.calendar-table {
 }
 
 .day.selectable:not(.selected):hover {
-  color: get-color('black');
+  color: get-color('light-contrast');
   background-color: get-color('light');
 }

--- a/src/kirby/components/icon/icon.component.scss
+++ b/src/kirby/components/icon/icon.component.scss
@@ -5,7 +5,9 @@
   //default to icon size 'sm'
   @include _icon-size('sm');
 
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   font-size: var(--kirby-icon-font-size);
 
   .outline {

--- a/src/kirby/components/list/list.component.tns.scss
+++ b/src/kirby/components/list/list.component.tns.scss
@@ -23,7 +23,7 @@ RadListView {
 }
 
 .row {
-  background-color: get-color('contrast-light');
+  background-color: get-color('white');
   //TODO: Add shadow on each section for list WITH sections
 
   &.first {

--- a/src/kirby/components/list/list.component.tns.scss
+++ b/src/kirby/components/list/list.component.tns.scss
@@ -2,7 +2,7 @@
 
 
 RadListView {
-  background-color:  get-color('base-color');
+  background-color:  get-color('background-color');
   //TODO: Add shadow for entire list for list WITHOUT sections
 }
 
@@ -11,7 +11,7 @@ RadListView {
 }
 
 .row.divider {
-  border-color: get-color('base-color');
+  border-color: get-color('background-color');
   border-bottom-width: 1;
 }
 

--- a/src/kirby/scss/themes/_colors.scss
+++ b/src/kirby/scss/themes/_colors.scss
@@ -1,5 +1,3 @@
-$kirby-background-color: #f6f6f6;
-
 $brand-colors: (
   'primary': #00e89a,
   'secondary': #005c3c,
@@ -13,36 +11,32 @@ $notification-colors: (
 );
 
 $system-colors: (
-  'black': #1c1c1c,
-  'white': #ffffff,  
-  'light': #f2f2f2,
-  'semi-light': #ebebeb,
-  'medium': #d1d1d1,
-  'semi-dark': #767676,
-  'dark': #353535,
   'background-color': #f6f6f6,  
-);
-
-$main-colors: (
-  'black': #1c1c1c,
   'white': #ffffff,  
   'light': #f2f2f2,
   'semi-light': #ebebeb,
   'medium': #d1d1d1,
   'semi-dark': #767676,
-  'dark': #353535,
-  'success': #2cf287,
-  'warning': #ffca3a,
-  'danger': #ff595e,
-  'primary': #00e89a,
-  'secondary': #005c3c,
-  'tertiary': #01352c,
+  'dark': #353535,  
+  'black': #1c1c1c,
 );
 
-$kirby-contrast-light: map-get($main-colors, 'white');
-$kirby-contrast-dark: map-get($main-colors, 'black');
+@function getAllColors() {
+  @return 
+    map-merge(
+      map-merge($brand-colors, $notification-colors),
+      $system-colors
+    );
+}
 
-@function _get-color-contrast($color, $contrast-dark: $kirby-contrast-dark, $contrast-light: $kirby-contrast-light) {
+$_color-palette: getAllColors();
+
+// TODO Deprecated variable, used to generate colors in some components - don't use it anymore! 
+$main-colors: map-remove($_color-palette, 'background-color', 'black', 'white', 'semi-light', 'semi-dark');
+
+@function _get-color-contrast($color) {
+  $contrast-light: map-get($system-colors, 'white');
+  $contrast-dark: map-get($system-colors, 'black');
   $red: red($color);
   $green: green($color);
   $blue: blue($color);
@@ -72,7 +66,7 @@ $kirby-contrast-dark: map-get($main-colors, 'black');
   @return red($color), green($color), blue($color);
 }
 
-@function generate-colors($colors: $main-colors) {
+@function generate-colors($colors: $_color-palette) {
   $color-list: ();
   @each $color-name, $color-value in $colors {
       $color-list: map-merge(
@@ -90,9 +84,3 @@ $kirby-contrast-dark: map-get($main-colors, 'black');
 }
 
 $kirby-colors: generate-colors();
-$kirby-colors: map-merge(
-  (
-    'background-color': $kirby-background-color,
-  ),
-  $kirby-colors
-);

--- a/src/kirby/scss/themes/_colors.scss
+++ b/src/kirby/scss/themes/_colors.scss
@@ -1,6 +1,27 @@
 $kirby-background-color: #f6f6f6;
-$kirby-contrast-light: #fff;
-$kirby-contrast-dark: #1c1c1c;
+
+$brand-colors: (
+  'primary': #00e89a,
+  'secondary': #005c3c,
+  'tertiary': #01352c,  
+);
+
+$notification-colors: (
+  'success': #2cf287,
+  'warning': #ffca3a,
+  'danger': #ff595e,
+);
+
+$system-colors: (
+  'black': #1c1c1c,
+  'white': #ffffff,  
+  'light': #f2f2f2,
+  'semi-light': #ebebeb,
+  'medium': #d1d1d1,
+  'semi-dark': #767676,
+  'dark': #353535,
+  'background-color': #f6f6f6,  
+);
 
 $main-colors: (
   'black': #1c1c1c,
@@ -17,6 +38,9 @@ $main-colors: (
   'secondary': #005c3c,
   'tertiary': #01352c,
 );
+
+$kirby-contrast-light: map-get($main-colors, 'white');
+$kirby-contrast-dark: map-get($main-colors, 'black');
 
 @function _get-color-contrast($color, $contrast-dark: $kirby-contrast-dark, $contrast-light: $kirby-contrast-light) {
   $red: red($color);
@@ -68,10 +92,7 @@ $main-colors: (
 $kirby-colors: generate-colors();
 $kirby-colors: map-merge(
   (
-    'base-color': $kirby-background-color,
     'background-color': $kirby-background-color,
-    'contrast-light': $kirby-contrast-light,
-    'contrast-dark': $kirby-contrast-dark
   ),
   $kirby-colors
 );

--- a/src/kirby/scss/web/_web-styles.scss
+++ b/src/kirby/scss/web/_web-styles.scss
@@ -45,10 +45,10 @@
 
 .kirby-alert-btn {
     cursor: pointer;
-    --ion-color-primary: #{get-color(contrast-dark)};
+    --ion-color-primary: #{get-color('black')};
 
     &.cancel {
-        --ion-color-primary: #{get-color(danger)};
+        --ion-color-primary: #{get-color('danger')};
     }
 }
 


### PR DESCRIPTION
Color array has  been split up into:

$brand-colors
$notification-colors
$system-colors

The showcase also reflects this change.

The $main-colors variable are still available, but will be removed later. 

Also added a little fix to alignment of icon: 
![Artboard](https://user-images.githubusercontent.com/20906135/60594057-679c3a80-9da4-11e9-8ed6-ac494a185182.png)
