### PR TITLE
Fixed list header for native.

### DIFF
--- a/src/kirby/components/list/list.component.tns.html
+++ b/src/kirby/components/list/list.component.tns.html
@@ -37,7 +37,9 @@
 
     <!-- HEADER -->
     <ng-template tkListViewHeader *ngIf="listHeaderTemplate">
-      <ng-container *ngTemplateOutlet="listHeaderTemplate"></ng-container>
+      <StackLayout>
+        <ng-container *ngTemplateOutlet="listHeaderTemplate"></ng-container>
+      </StackLayout>
     </ng-template>
 
     <!-- FOOTER -->


### PR DESCRIPTION
Fix for #418 .

I wrapped the template outlet with a `StackLayout` as suggested in [here](https://github.com/NativeScript/nativescript-angular/issues/93) and it removed the issue in the cookbook.