### PR TITLE
feat(chip): support theming for chip native and web

### DIFF
--- a/src/app/examples/chip-example/chip-example.component.html
+++ b/src/app/examples/chip-example/chip-example.component.html
@@ -1,2 +1,4 @@
-<kirby-chip text="kirby"></kirby-chip>
-<kirby-chip text="kirby" isSelected="true"></kirby-chip>
+<kirby-card class="chip-card" [themeColor]="themeColor">
+    <kirby-chip text="kirby"></kirby-chip>
+    <kirby-chip text="kirby" isSelected="true"></kirby-chip>
+</kirby-card>

--- a/src/app/examples/chip-example/chip-example.component.scss
+++ b/src/app/examples/chip-example/chip-example.component.scss
@@ -1,3 +1,12 @@
 :host {
     display: flex;
+
+    ::ng-deep .chip-card {
+        flex-direction: initial;
+        height: initial;
+        justify-content: initial;
+        min-height: initial;
+        min-width: initial;
+        padding: 25px;
+    }
 }

--- a/src/app/examples/chip-example/chip-example.component.tns.html
+++ b/src/app/examples/chip-example/chip-example.component.tns.html
@@ -1,4 +1,24 @@
-<WrapLayout orientation="horizontal" class="chip-example">
-  <kirby-chip text="kirby"></kirby-chip>
-  <kirby-chip text="kirby" isSelected="true"></kirby-chip>
-</WrapLayout>
+<ScrollView>
+    <Stacklayout class="wrapper">
+      <kirby-segmented-control [items]="[{ text: 'Default', id: 'default', checked: true }, { text: 'Themes', id: 'themes' }]" (segmentClick)="onSegmentClick($event)">
+      </kirby-segmented-control>
+      <ng-container *ngIf="activeTab === 'default'">
+          <WrapLayout orientation="horizontal" class="chip-example">
+            <kirby-chip text="kirby"></kirby-chip>
+            <kirby-chip text="kirby" isSelected="true"></kirby-chip>
+          </WrapLayout>
+      </ng-container>
+      <ng-container *ngIf="activeTab === 'themes'">
+          <kirby-card [themeColor]="themeColor" class="card">
+          <Stacklayout orientation="horizontal">
+              <kirby-chip text="kirby"></kirby-chip>
+              <kirby-chip text="kirby" isSelected="true"></kirby-chip>    
+            </Stacklayout>
+          </kirby-card>
+          <ListPicker #themeColorPicker [items]="items"
+            textField="text"
+            valueField="value"
+           (selectedValueChange)="themeColor = themeColorPicker.selectedValue;"></ListPicker>
+        </ng-container>
+    </Stacklayout>
+</ScrollView>

--- a/src/app/examples/chip-example/chip-example.component.tns.scss
+++ b/src/app/examples/chip-example/chip-example.component.tns.scss
@@ -1,3 +1,28 @@
-.chip-example {
-    margin-top: 30px;
+@import '../../../kirby/scss/native-imports';
+
+:host {
+    .chip-example {
+        margin-top: 30px;
+    }
+    
+    .wrapper {
+        background-color: get-color('background-color');
+        padding: 0 20;
+    }
+
+    kirby-chip {
+        margin-top: 10;
+        width: 100;
+    }
+    
+    Label.h3 {
+        margin-top: 30;
+    }
+    
+    .card {
+    
+        StackLayout {
+            padding: 20;
+        }
+    }
 }

--- a/src/app/examples/chip-example/chip-example.component.ts
+++ b/src/app/examples/chip-example/chip-example.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
+
+import { ThemeColor } from '@kirbydesign/designsystem/helpers/theme-color.type';
 
 @Component({
   selector: 'kirby-chip-example',
@@ -7,5 +9,6 @@ import { Component, OnInit } from '@angular/core';
 })
 export class ChipExampleComponent implements OnInit {
   constructor() {}
+  @Input() themeColor: ThemeColor | '' = '';
   ngOnInit() {}
 }

--- a/src/app/examples/chip-example/chip-example.component.ts
+++ b/src/app/examples/chip-example/chip-example.component.ts
@@ -1,14 +1,30 @@
 import { Component, OnInit, Input } from '@angular/core';
 
 import { ThemeColor } from '@kirbydesign/designsystem/helpers/theme-color.type';
+import { Color, ColorHelper } from '@kirbydesign/designsystem/helpers/color-helper';
 
 @Component({
   selector: 'kirby-chip-example',
   templateUrl: './chip-example.component.html',
   styleUrls: ['./chip-example.component.scss'],
 })
-export class ChipExampleComponent implements OnInit {
-  constructor() {}
+export class ChipExampleComponent {
+  activeTab = 'default';
   @Input() themeColor: ThemeColor | '' = '';
-  ngOnInit() {}
+  colors: Color[] = ColorHelper.getMainColors();
+  items = [
+    { text: 'Card color: None', value: '' },
+    ...this.colors
+      .filter((color) => ['light', 'dark'].includes(color.name))
+      .map((color) => {
+        return {
+          text: `Card color: ${color.name}`,
+          value: color.name,
+        };
+      }),
+  ];
+
+  onSegmentClick(segment) {
+    this.activeTab = segment.id;
+  }
 }

--- a/src/app/showcase/chip-showcase/chip-showcase.component.html
+++ b/src/app/showcase/chip-showcase/chip-showcase.component.html
@@ -1,5 +1,11 @@
 <div class="example">
-    <kirby-chip-example></kirby-chip-example>
+    <kirby-chip-example [themeColor]="themeColor"></kirby-chip-example>
+    <div>
+        <select (change)="onThemeChange($event.target.value)">
+            <option value="">Card color: None</option>
+            <option *ngFor="let color of themeColors" value="{{color}}" [attr.selected]="themeColor === color ? true : null">Card color: {{ color }}</option>
+        </select>
+    </div>
     <kirby-code-viewer [html]="exampleHtml"></kirby-code-viewer>
     <h4>Properties:</h4>
     <table class="cookbook-properties">

--- a/src/app/showcase/chip-showcase/chip-showcase.component.ts
+++ b/src/app/showcase/chip-showcase/chip-showcase.component.ts
@@ -7,9 +7,15 @@ declare var require: any;
   styleUrls: ['./chip-showcase.component.scss'],
 })
 export class ChipShowcaseComponent implements OnInit {
+  themeColors = ['light', 'dark'];
+  themeColor = '';
   exampleHtml: string = require('../../examples/chip-example/chip-example.component.html');
 
   constructor() {}
 
   ngOnInit() {}
+
+  onThemeChange(themeColor) {
+    this.themeColor = themeColor;
+  }
 }

--- a/src/kirby/components/chip/chip.component.scss
+++ b/src/kirby/components/chip/chip.component.scss
@@ -12,5 +12,24 @@
   &:hover,
   &.is-selected {
     background-color: get-color("medium");
+  } 
+  
+  :host-context(.default),
+  :host-context(.kirby-color-brightness-white) {
+    &:hover,
+    &.is-selected {
+      background-color: get-color("medium");
+    } 
+  }
+
+  :host-context(.kirby-color-brightness-dark) {
+
+    color: get-color("white");
+
+    &:hover,
+    &.is-selected {
+      background-color: get-color("white");
+      color: get-color("black");
+    }
   }
 }

--- a/src/kirby/components/chip/chip.component.tns.global.scss
+++ b/src/kirby/components/chip/chip.component.tns.global.scss
@@ -1,0 +1,22 @@
+@import '../../scss/native-imports';
+$min-chip-width: 50;
+.chip {
+  border-radius: 25;
+  margin-right: 10;
+  padding: 10 15;
+  font-size: font-size('xs');
+  min-width: $min-chip-width;
+  &.is-selected {
+      background: get-color('medium');
+  }
+}
+
+.dark, .kirby-color-brightness-dark {
+  .chip {
+    color: get-color('white');
+      &.is-selected {
+        background-color: get-color("white");
+        color: get-color("black");
+      }
+    }
+}

--- a/src/kirby/components/chip/chip.component.tns.scss
+++ b/src/kirby/components/chip/chip.component.tns.scss
@@ -1,12 +1,2 @@
-@import '../../scss/native-imports';
-$min-chip-width: 50;
-.chip {
-  border-radius: 25;
-  margin-right: 10;
-  padding:10 15;
-  font-size: font-size('xs');
-  min-width: $min-chip-width;
-  &.is-selected {
-      background: get-color('medium');
-  }
-}
+// Style is applied in global styles
+// This file ensures web styles are not applied in addition to those

--- a/src/kirby/scss/native/_native-common.scss
+++ b/src/kirby/scss/native/_native-common.scss
@@ -1,6 +1,7 @@
 // Place any CSS rules you want to apply on both iOS and Android here.
 // This is where the vast majority of your CSS code goes.
 @import '../../components/button/button.component.tns.global.scss';
+@import '../../components/chip/chip.component.tns.global.scss';
 @import '../../components/icon/icon.component.tns.global.scss';
 @import '../../components/avatar/avatar.component.tns.global.scss';
 


### PR DESCRIPTION
Closes #380

- Support theming for chip button. Native and web.
- Added global style for chip native to overcome the view encapsulation
- Updated cookbook with theming examples for chip

Web:
![image](https://user-images.githubusercontent.com/9210691/61643755-c79b4800-aca3-11e9-9b88-2f0c15ea9796.png)

Native:
![image](https://user-images.githubusercontent.com/9210691/61643725-bd794980-aca3-11e9-926c-f130be017b42.png)
