### PR TITLE
Fix / Icon name typo

### DIFF
--- a/src/app/examples/nativescript-only/list-section-example/list-section-example.component.tns.html
+++ b/src/app/examples/nativescript-only/list-section-example/list-section-example.component.tns.html
@@ -12,7 +12,7 @@
 
     <GridLayout *kirbyListItem="let item" rows="*" columns="*, 3*, *, auto">
         <StackLayout col="0" [ngClass]="{'hide-check': !item.selected}">
-            <kirby-icon name="verifiy"></kirby-icon>
+            <kirby-icon name="verify"></kirby-icon>
         </StackLayout>
         <StackLayout col="1">
             <Label [text]="item?.title" class="primary"></Label>


### PR DESCRIPTION
Renamed an occurrence of verifiy to verify resulting in an error when the list with sections example is opened