### PR TITLE
feat(card): only apply padding for content and no breaking

### DIFF
--- a/src/app/examples/card-example/card-example.component.html
+++ b/src/app/examples/card-example/card-example.component.html
@@ -1,21 +1,11 @@
-<kirby-card>
-  <kirby-card-header title="Titel" subtitle="Subtitel"></kirby-card-header>  
+<kirby-card [hasPadding]="hasPadding" [class.show-size]="showSize">
+  <kirby-card-header *ngIf="hasHeader" [title]="title" [subtitle]="subtitle" [class.bg-color]="hasHeaderFooterBgColor"></kirby-card-header>
 
   <!-- Card content example: -->
   <div class="card-content">
-    Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus ab veniam repellendus doloremque culpa quam libero, est quo accusamus cumque, in quia itaque cupiditate ratione repellat!
+    <p><b>Example content (with background color)</b></p>
+    <p>Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus ab veniam repellendus doloremque culpa quam libero, est quo accusamus cumque, in quia itaque cupiditate ratione repellat!</p>
   </div>
 
-  <kirby-card-footer></kirby-card-footer>
-</kirby-card>
-
-<kirby-card [hasPadding]="true">
-  <kirby-card-header title="Padding" subtitle="Card with padding"></kirby-card-header>  
-
-  <!-- Card content example: -->
-  <div>
-    Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus ab veniam repellendus doloremque culpa quam libero, est quo accusamus cumque, in quia itaque cupiditate ratione repellat!
-  </div>
-
-  <kirby-card-footer></kirby-card-footer>
+  <kirby-card-footer *ngIf="hasFooter" [class.bg-color]="hasHeaderFooterBgColor">Footer</kirby-card-footer>
 </kirby-card>

--- a/src/app/examples/card-example/card-example.component.html
+++ b/src/app/examples/card-example/card-example.component.html
@@ -9,8 +9,8 @@
   <kirby-card-footer></kirby-card-footer>
 </kirby-card>
 
-<kirby-card [hasPadding]="false">
-  <kirby-card-header title="Padding" subtitle="Card without padding"></kirby-card-header>  
+<kirby-card [hasPadding]="true">
+  <kirby-card-header title="Padding" subtitle="Card with padding"></kirby-card-header>  
 
   <!-- Card content example: -->
   <div>

--- a/src/app/examples/card-example/card-example.component.scss
+++ b/src/app/examples/card-example/card-example.component.scss
@@ -6,14 +6,29 @@ kirby-card {
 }
 
 kirby-card-header {
-  padding-bottom: 0;
+  &:not(.bg-color) {
+    padding-bottom: 0;
+  }
+
+  &.bg-color {
+    color: get-color('dark-contrast');
+    background-color: get-color('dark');
+  }
+}
+
+kirby-card-footer {
+  &.bg-color {
+    color: get-color('dark-contrast');
+    background-color: get-color('dark');
+  }
 }
 
 .card-content {
   padding: size("s");
+  background-color: get-color('light');
 }
 
-kirby-card {
+kirby-card.show-size {
   &::before {
       background-color: #ccc;
       color: white;

--- a/src/app/examples/card-example/card-example.component.scss
+++ b/src/app/examples/card-example/card-example.component.scss
@@ -1,4 +1,4 @@
-@import '../../../kirby/scss/web-imports';
+@import 'web-imports';
 
 kirby-card {
   position: relative;
@@ -7,6 +7,10 @@ kirby-card {
 
 kirby-card-header {
   padding-bottom: 0;
+}
+
+.card-content {
+  padding: size("s");
 }
 
 kirby-card {

--- a/src/app/examples/card-example/card-example.component.tns.html
+++ b/src/app/examples/card-example/card-example.component.tns.html
@@ -1,65 +1,62 @@
 <ScrollView>
   <StackLayout class="background">
+    <Label text="Card" class="h1"></Label>
+
     <Label text="Elevation" class="h2"></Label>
   
-    <kirby-card mode="flat">
+    <kirby-card [hasPadding]="true" mode="flat">
       <kirby-card-header title="Flat" subtitle='mode="flat"'></kirby-card-header>  
-      <StackLayout class="card-content">
-        <Label text='mode="flat" sets the elevation of the z-axis to 0.'></Label>"
+      <Label text='mode="flat" sets the elevation of the z-axis to 0.'></Label>"
+    </kirby-card>
+    
+    <kirby-card [hasPadding]="true">
+      <kirby-card-header title="Default" subtitle=" "></kirby-card-header>  
+      <Label text="The default elevation of the card on the z-axis is 2."></Label>"
+    </kirby-card>
+
+    <kirby-card [hasPadding]="true" mode="highlighted">
+      <kirby-card-header title="Highlighted" subtitle='mode="highlighted"'></kirby-card-header>  
+      <Label text='mode="highlighted" sets the elevation of the z-axis to 4.'></Label>"
+    </kirby-card>
+
+    <label text="Padding" class="h2"></label>
+
+    <kirby-card [hasPadding]="false">
+      <kirby-card-header title="Card without padding" subtitle="(default)"></kirby-card-header>
+      <StackLayout class="card-content-background-color bottom-rounded">
+        <Label text="Example content (with background color)" style="font-weight: bold"></Label>
+        <Label text="Lorem ipsum dolor sit amet consectetur adipisicing elit. Qui quas quibusdam eligendi, debitis nemo fuga quia accusamus doloremque sit reprehenderit!" textWrap="true"></Label>
       </StackLayout>
     </kirby-card>
     
-    <kirby-card>
-      <kirby-card-header title="Default" subtitle=" "></kirby-card-header>  
-      <StackLayout class="card-content">
-        <Label text="The default elevation of the card on the z-axis is 2."></Label>"
-      </StackLayout>
-    </kirby-card>
-
-    <kirby-card mode="highlighted">
-      <kirby-card-header title="Highlighted" subtitle='mode="highlighted"'></kirby-card-header>  
-      <StackLayout class="card-content">
-        <Label text='mode="highlighted" sets the elevation of the z-axis to 4.'></Label>"
-      </StackLayout>
-    </kirby-card>
-
-    <label text="Styling" class="h2"></label>
-
-    <kirby-card themeColor="primary" [hasPadding]="true">
-      <kirby-card-header title="Card with padding" subtitle='themeColor="primary"'></kirby-card-header>
-      <StackLayout>
+    <kirby-card [hasPadding]="true">
+      <kirby-card-header title="Card with padding" subtitle='hasPadding="true"'></kirby-card-header>
+      <StackLayout class="card-content-background-color">
+        <Label text="Example content (with background color)" style="font-weight: bold"></Label>
         <Label text="Lorem ipsum dolor sit amet consectetur adipisicing elit. Qui quas quibusdam eligendi, debitis nemo fuga quia accusamus doloremque sit reprehenderit!" textWrap="true"></Label>
       </StackLayout>
     </kirby-card>
 
     <Label text="Colors" class="h2"></Label>
 
-    <kirby-card>
+    <kirby-card [hasPadding]="true">
       <kirby-card-header title="Default" subtitle="Default Card Color"></kirby-card-header>
-      <StackLayout class="card-content">
-        <Label text="Lorem ipsum dolor sit amet consectetur adipisicing elit. Qui quas quibusdam eligendi, debitis nemo fuga quia accusamus doloremque sit reprehenderit!" textWrap="true"></Label>
-      </StackLayout>
+      <Label text="Lorem ipsum dolor sit amet consectetur adipisicing elit. Qui quas quibusdam eligendi, debitis nemo fuga quia accusamus doloremque sit reprehenderit!" textWrap="true"></Label>
     </kirby-card>
 
-    <kirby-card themeColor="primary">
+    <kirby-card [hasPadding]="true" themeColor="primary">
       <kirby-card-header title="Primary" subtitle='themeColor="primary"'></kirby-card-header>
-      <StackLayout class="card-content">
-        <Label text="Lorem ipsum dolor sit amet consectetur adipisicing elit. Qui quas quibusdam eligendi, debitis nemo fuga quia accusamus doloremque sit reprehenderit!" textWrap="true"></Label>
-      </StackLayout>
+      <Label text="Lorem ipsum dolor sit amet consectetur adipisicing elit. Qui quas quibusdam eligendi, debitis nemo fuga quia accusamus doloremque sit reprehenderit!" textWrap="true"></Label>
     </kirby-card>
 
-    <kirby-card themeColor="secondary">
+    <kirby-card [hasPadding]="true" themeColor="secondary">
       <kirby-card-header title="Secondary" subtitle='themeColor="secondary"'></kirby-card-header>
-      <StackLayout class="card-content">
-        <Label text="Lorem ipsum dolor sit amet consectetur adipisicing elit. Qui quas quibusdam eligendi, debitis nemo fuga quia accusamus doloremque sit reprehenderit!" textWrap="true"></Label>
-      </StackLayout>
+      <Label text="Lorem ipsum dolor sit amet consectetur adipisicing elit. Qui quas quibusdam eligendi, debitis nemo fuga quia accusamus doloremque sit reprehenderit!" textWrap="true"></Label>
     </kirby-card>
 
-    <kirby-card themeColor="warning">
+    <kirby-card [hasPadding]="true" themeColor="warning">
       <kirby-card-header title="Warning" subtitle='themeColor="warning"'></kirby-card-header>
-      <StackLayout class="card-content">
-        <Label text="Lorem ipsum dolor sit amet consectetur adipisicing elit. Qui quas quibusdam eligendi, debitis nemo fuga quia accusamus doloremque sit reprehenderit!" textWrap="true"></Label>
-      </StackLayout>
+      <Label text="Lorem ipsum dolor sit amet consectetur adipisicing elit. Qui quas quibusdam eligendi, debitis nemo fuga quia accusamus doloremque sit reprehenderit!" textWrap="true"></Label>
     </kirby-card>   
   </StackLayout>
 </ScrollView>

--- a/src/app/examples/card-example/card-example.component.tns.html
+++ b/src/app/examples/card-example/card-example.component.tns.html
@@ -25,8 +25,8 @@
 
     <label text="Styling" class="h2"></label>
 
-    <kirby-card themeColor="primary" [hasPadding]="false">
-      <kirby-card-header title="Card without padding" subtitle='themeColor="primary"'></kirby-card-header>
+    <kirby-card themeColor="primary" [hasPadding]="true">
+      <kirby-card-header title="Card with padding" subtitle='themeColor="primary"'></kirby-card-header>
       <StackLayout>
         <Label text="Lorem ipsum dolor sit amet consectetur adipisicing elit. Qui quas quibusdam eligendi, debitis nemo fuga quia accusamus doloremque sit reprehenderit!" textWrap="true"></Label>
       </StackLayout>

--- a/src/app/examples/card-example/card-example.component.tns.scss
+++ b/src/app/examples/card-example/card-example.component.tns.scss
@@ -3,8 +3,8 @@
 .background {
   background-color: get-color('background-color');
   padding: size('s');
-  // add vertical spacing of 'xs' between each card
-  * {
+  // add vertical spacing of 'xxs' between each card
+  > * {
     margin-bottom: size('xxs');
   }
 }
@@ -14,6 +14,12 @@ Label.h2 {
     margin-top: size('s');
 }
 
-.card-content {
-  padding: 0 size("m") size("m");
+.card-content-background-color {
+  padding: size('s');
+  background-color: get-color('light');
+}
+
+.bottom-rounded {
+  border-bottom-left-radius: $border-radius;
+  border-bottom-right-radius: $border-radius;
 }

--- a/src/app/examples/card-example/card-example.component.ts
+++ b/src/app/examples/card-example/card-example.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 
 import { DynamicComponent } from '../../../kirby/components/shared/dynamic-component';
 
@@ -8,5 +8,12 @@ import { DynamicComponent } from '../../../kirby/components/shared/dynamic-compo
   styleUrls: ['./card-example.component.scss'],
 })
 export class CardExampleComponent implements DynamicComponent {
+  @Input() title = 'Title';
+  @Input() subtitle = 'Subtitle';
+  @Input() showSize = true;
+  @Input() hasPadding = true;
+  @Input() hasHeader = true;
+  @Input() hasFooter = false;
+  @Input() hasHeaderFooterBgColor = false;
   data: any;
 }

--- a/src/app/examples/card/card-elevations-example/card-elevations-example.component.html
+++ b/src/app/examples/card/card-elevations-example/card-elevations-example.component.html
@@ -1,7 +1,7 @@
 <kirby-card mode="flat">
   <kirby-card-header title="Flat" subtitle='mode="flat"'></kirby-card-header>  
   <div class="card-content">
-    <p>Setting<code>mode="flat"</code> sets the elevation of the z-axis to 0.</p>
+    <p>Setting <code>mode="flat"</code> sets the elevation of the z-axis to 0.</p>
   </div>
 </kirby-card>
 

--- a/src/app/examples/card/card-themecolor-example/card-themecolor-example.component.html
+++ b/src/app/examples/card/card-themecolor-example/card-themecolor-example.component.html
@@ -1,60 +1,60 @@
-<kirby-card hasPadding="true"themeColor="primary">
+<kirby-card [hasPadding]="true" themeColor="primary">
   <kirby-card-header title="Primary" subtitle='themeColor="primary"'></kirby-card-header>  
   <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.
   </div>
 </kirby-card>
 
-<kirby-card hasPadding="true"themeColor="secondary">
+<kirby-card [hasPadding]="true" themeColor="secondary">
   <kirby-card-header title="Secondary" subtitle='themeColor="secondary"'></kirby-card-header>  
   <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.
   </div>
 </kirby-card>
 
-<kirby-card hasPadding="true"themeColor="tertiary">
+<kirby-card [hasPadding]="true" themeColor="tertiary">
   <kirby-card-header title="Tertiary" subtitle='themeColor="tertiary"'></kirby-card-header>  
   <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.
   </div>
 </kirby-card>
 
-<kirby-card hasPadding="true"themeColor="success">
+<kirby-card [hasPadding]="true" themeColor="success">
   <kirby-card-header title="Success" subtitle='themeColor="success"'></kirby-card-header>  
   <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.
   </div>
 </kirby-card>
 
-<kirby-card hasPadding="true"themeColor="warning">
+<kirby-card [hasPadding]="true" themeColor="warning">
   <kirby-card-header title="Warning" subtitle='themeColor="warning"'></kirby-card-header>  
   <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.
   </div>
 </kirby-card>
 
-<kirby-card hasPadding="true"themeColor="danger">
+<kirby-card [hasPadding]="true" themeColor="danger">
   <kirby-card-header title="Danger" subtitle='themeColor="danger"'></kirby-card-header>  
   <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.
   </div>
 </kirby-card>
 
-<kirby-card hasPadding="true"themeColor="light">
+<kirby-card [hasPadding]="true" themeColor="light">
   <kirby-card-header title="Light" subtitle='themeColor="light"'></kirby-card-header>  
   <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.
   </div>
 </kirby-card>
 
-<kirby-card hasPadding="true"themeColor="medium">
+<kirby-card [hasPadding]="true" themeColor="medium">
   <kirby-card-header title="Medium" subtitle='themeColor="medium"'></kirby-card-header>  
   <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.
   </div>
 </kirby-card>
 
-<kirby-card hasPadding="true"themeColor="dark">
+<kirby-card [hasPadding]="true" themeColor="dark">
   <kirby-card-header title="Dark" subtitle='themeColor="dark"'></kirby-card-header>  
   <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.

--- a/src/app/examples/card/card-themecolor-example/card-themecolor-example.component.html
+++ b/src/app/examples/card/card-themecolor-example/card-themecolor-example.component.html
@@ -1,62 +1,62 @@
-<kirby-card themeColor="primary">
+<kirby-card hasPadding="true"themeColor="primary">
   <kirby-card-header title="Primary" subtitle='themeColor="primary"'></kirby-card-header>  
-  <div class="card-content">
+  <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.
   </div>
 </kirby-card>
 
-<kirby-card themeColor="secondary">
+<kirby-card hasPadding="true"themeColor="secondary">
   <kirby-card-header title="Secondary" subtitle='themeColor="secondary"'></kirby-card-header>  
-  <div class="card-content">
+  <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.
   </div>
 </kirby-card>
 
-<kirby-card themeColor="tertiary">
+<kirby-card hasPadding="true"themeColor="tertiary">
   <kirby-card-header title="Tertiary" subtitle='themeColor="tertiary"'></kirby-card-header>  
-  <div class="card-content">
+  <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.
   </div>
 </kirby-card>
 
-<kirby-card themeColor="success">
+<kirby-card hasPadding="true"themeColor="success">
   <kirby-card-header title="Success" subtitle='themeColor="success"'></kirby-card-header>  
-  <div class="card-content">
+  <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.
   </div>
 </kirby-card>
 
-<kirby-card themeColor="warning">
+<kirby-card hasPadding="true"themeColor="warning">
   <kirby-card-header title="Warning" subtitle='themeColor="warning"'></kirby-card-header>  
-  <div class="card-content">
+  <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.
   </div>
 </kirby-card>
 
-<kirby-card themeColor="danger">
+<kirby-card hasPadding="true"themeColor="danger">
   <kirby-card-header title="Danger" subtitle='themeColor="danger"'></kirby-card-header>  
-  <div class="card-content">
+  <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.
   </div>
 </kirby-card>
 
-<kirby-card themeColor="light">
+<kirby-card hasPadding="true"themeColor="light">
   <kirby-card-header title="Light" subtitle='themeColor="light"'></kirby-card-header>  
-  <div class="card-content">
+  <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.
   </div>
 </kirby-card>
 
-<kirby-card themeColor="medium">
+<kirby-card hasPadding="true"themeColor="medium">
   <kirby-card-header title="Medium" subtitle='themeColor="medium"'></kirby-card-header>  
-  <div class="card-content">
+  <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.
   </div>
 </kirby-card>
 
-<kirby-card themeColor="dark">
+<kirby-card hasPadding="true"themeColor="dark">
   <kirby-card-header title="Dark" subtitle='themeColor="dark"'></kirby-card-header>  
-  <div class="card-content">
+  <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae necessitatibus.
   </div>
 </kirby-card>

--- a/src/app/examples/card/card-themecolor-example/card-themecolor-example.component.scss
+++ b/src/app/examples/card/card-themecolor-example/card-themecolor-example.component.scss
@@ -9,7 +9,3 @@
         grid-template-columns: repeat(3, 1fr);
     }
 }
-
-.card-content {
-    padding: size("s");
-}

--- a/src/app/showcase/card-showcase/card-showcase.component.html
+++ b/src/app/showcase/card-showcase/card-showcase.component.html
@@ -1,5 +1,10 @@
 <div class="example">
-  <kirby-card-example></kirby-card-example>
+  <div class="card-grid">
+      <kirby-card-example [showSize]="false" [hasPadding]="false" title="Default Card"></kirby-card-example>
+      <kirby-card-example [showSize]="false" title="Card with padding" subtitle='HTML: hasPadding="true"'></kirby-card-example>
+      <kirby-card-example [showSize]="false" [hasPadding]="false" [hasHeaderFooterBgColor]="true" title="Card with header background" subtitle="CSS: kirby-card-header { background-color: #000}"></kirby-card-example>        
+      <kirby-card-example [showSize]="false" [hasPadding]="false" [hasFooter]="true" [hasHeaderFooterBgColor]="true" title="Card with header and footer" subtitle=""></kirby-card-example>        
+  </div>
   <kirby-code-viewer [html]="exampleHtml"></kirby-code-viewer>
   <h4>Properties:</h4>
   <kirby-showcase-properties [properties]="properties"></kirby-showcase-properties> 

--- a/src/app/showcase/card-showcase/card-showcase.component.scss
+++ b/src/app/showcase/card-showcase/card-showcase.component.scss
@@ -3,3 +3,14 @@
 h4 {
     padding-top: size("s");
 }
+
+
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(1, 1fr);
+    grid-gap: size("s");
+
+    @include media(">=medium") {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}

--- a/src/kirby/components/card/card-header/card-header.component.tns.scss
+++ b/src/kirby/components/card/card-header/card-header.component.tns.scss
@@ -1,7 +1,9 @@
 @import '../../../scss/native-imports';
 
 .header {
-  margin: size("s");
+  padding: size("s");
+  border-top-left-radius: $border-radius;
+  border-top-right-radius: $border-radius;
 }
 
 .title {

--- a/src/kirby/components/card/card.component.html
+++ b/src/kirby/components/card/card.component.html
@@ -1,3 +1,5 @@
 <ng-content select="kirby-card-header"></ng-content>
-<ng-content></ng-content>
+<div class="content-wrapper" [class.padding]="hasPadding">
+    <ng-content></ng-content>
+</div>
 <ng-content select="kirby-card-footer"></ng-content>

--- a/src/kirby/components/card/card.component.scss
+++ b/src/kirby/components/card/card.component.scss
@@ -22,10 +22,12 @@ $min-card-width: 304px;
   min-width: $min-card-width;
   overflow: hidden;
 
-  &.padding {
-    padding: size('s');
-    @include media("<small") {
-      padding: size('xxs');
+  .content-wrapper {
+    &.padding {
+        padding: size('s');
+        @include media("<small") {
+          padding: size('xxs');
+        }
     }
   }
 

--- a/src/kirby/components/card/card.component.tns.html
+++ b/src/kirby/components/card/card.component.tns.html
@@ -3,12 +3,13 @@
                [ngClass]="cardSizeClass"
                [kirbyElevation]="elevation">
     <FlexboxLayout class="container"
-                   [class.padding]="hasPadding"
                    [ngClass]="themeColor"
                    [class.elevation-2]="elevation === 2"
                    [class.elevation-4]="elevation === 4">
         <ng-content select="kirby-card-header"></ng-content>
-        <ng-content></ng-content>
+        <FlexboxLayout class="content-wrapper" [class.padding]="hasPadding">
+            <ng-content></ng-content>
+        </FlexboxLayout>
         <ng-content select="kirby-card-footer"></ng-content>
     </FlexboxLayout>
 </FlexboxLayout>

--- a/src/kirby/components/card/card.component.tns.scss
+++ b/src/kirby/components/card/card.component.tns.scss
@@ -22,8 +22,10 @@
     border-radius: $border-radius;
     background-color: get-color('white');
 
-    &.padding {
-        padding: size('s');
+    .content-wrapper {
+        &.padding {
+            padding: size('s');
+        }
     }
 
     @each $color-name, $color-value in $main-colors {

--- a/src/kirby/components/card/card.component.tns.ts
+++ b/src/kirby/components/card/card.component.tns.ts
@@ -23,7 +23,7 @@ export class CardComponent extends ContentView implements CardCommon {
   @Input() title: string;
   @Input() subtitle: string;
   @Input() themeColor?: ThemeColor;
-  @Input() hasPadding?: boolean = true;
+  @Input() hasPadding?: boolean;
 
   DEFAULT_ELEVATION = 2;
   elevation: number = this.DEFAULT_ELEVATION;

--- a/src/kirby/components/card/card.component.ts
+++ b/src/kirby/components/card/card.component.ts
@@ -21,9 +21,8 @@ export class CardComponent implements OnInit, OnDestroy, CardCommon {
   @Input() title: string;
   @Input() subtitle: string;
 
-  @HostBinding('class.padding')
   @Input()
-  hasPadding: boolean = true;
+  hasPadding: boolean;
 
   private sizesSortedByBreakpoint = this.sortSizesByBreakpoint({
     small: 360,


### PR DESCRIPTION
Closes #531
Only apply padding for card content and don't make padding default

Native:
![image](https://user-images.githubusercontent.com/9210691/63275689-420ab800-c2a2-11e9-86b6-ac65e48c97f7.png)


Web:
![image](https://user-images.githubusercontent.com/9210691/63275626-27384380-c2a2-11e9-9f6d-0c027f6bb403.png)
