### PR TITLE
optional ViewContainerRef and RxJS-operators modal support added

### DIFF
--- a/src/app/examples/action-sheet-example/action-sheet-example.component.html
+++ b/src/app/examples/action-sheet-example/action-sheet-example.component.html
@@ -1,1 +1,2 @@
 <button kirby-button (click)="showActionSheet()">Show action sheet</button>
+<button kirby-button (click)="showReactiveActionSheet()">Show reactive action sheet</button>

--- a/src/app/examples/action-sheet-example/action-sheet-example.component.ts
+++ b/src/app/examples/action-sheet-example/action-sheet-example.component.ts
@@ -1,31 +1,57 @@
-import { Component, ViewContainerRef } from '@angular/core';
+import { Component } from '@angular/core';
+import { of } from 'rxjs';
+import { delay, map, tap } from 'rxjs/operators';
 
-import { ModalController } from '@kirbydesign/designsystem/modal';
-import { ActionSheetConfig } from '@kirbydesign/designsystem/modal';
-import { ActionSheetItem } from '@kirbydesign/designsystem/modal';
+import {
+  ActionSheetConfig,
+  ActionSheetItem,
+  ModalController,
+} from '@kirbydesign/designsystem/modal';
 
 @Component({
   selector: 'kirby-action-sheet-example',
   templateUrl: './action-sheet-example.component.html',
 })
 export class ActionSheetExampleComponent {
-  constructor(private modalController: ModalController, private vcRef: ViewContainerRef) {}
+  private config: ActionSheetConfig = {
+    header: 'Your action sheet header',
+    subheader: 'Your action sheet subheader',
+    items: [
+      { id: '1', text: 'Option 1' },
+      { id: '2', text: 'Option 2' },
+      { id: '3', text: 'Option 3' },
+    ],
+    cancelButtonText: 'Custom cancel',
+  };
+
+  constructor(private modalController: ModalController) {}
 
   showActionSheet() {
-    const config: ActionSheetConfig = {
-      header: 'Your action sheet header',
-      subheader: 'Your action sheet subheader',
-      items: [
-        { id: '1', text: 'Option 1' },
-        { id: '2', text: 'Option 2' },
-        { id: '3', text: 'Option 3' },
-      ],
-      cancelButtonText: 'Custom cancel',
-    };
-    this.modalController.showActionSheet(config, this.vcRef, this.onActionSelected);
+    this.modalController.showActionSheet(this.config, null, this.onActionSelected);
+  }
+
+  showReactiveActionSheet() {
+    this.delayData(['John', 'Paul', 'Ringo', 'George'])
+      .pipe(
+        map((names) => {
+          return names.map((name) => ({ id: name, text: name }));
+        }),
+        this.modalController.operators.showActionSheet(this.config)
+      )
+      .subscribe((response) =>
+        console.log('Response from action sheet (in observable) was:', response)
+      );
   }
 
   private onActionSelected(selection: ActionSheetItem) {
     console.log(`Action sheet selection: ${JSON.stringify(selection)}`);
+  }
+
+  private delayData(data: string[]) {
+    const delayInSeconds = 2;
+    return of(data).pipe(
+      tap(() => console.log(`Delaying for ${delayInSeconds} seconds`)),
+      delay(delayInSeconds * 1000)
+    );
   }
 }

--- a/src/app/examples/alert-example/alert-example.component.html
+++ b/src/app/examples/alert-example/alert-example.component.html
@@ -1,1 +1,2 @@
 <button kirby-button (click)="showAlert()">Show alert</button>
+<button kirby-button (click)="showReactiveAlert()">Show reactive alert</button>

--- a/src/app/examples/alert-example/alert-example.component.ts
+++ b/src/app/examples/alert-example/alert-example.component.ts
@@ -2,25 +2,41 @@ import { Component, ViewContainerRef } from '@angular/core';
 
 import { ModalController } from '@kirbydesign/designsystem/modal';
 import { AlertConfig } from '@kirbydesign/designsystem/modal';
+import { of } from 'rxjs';
+import { delay, map, tap } from 'rxjs/operators';
 
 @Component({
   selector: 'kirby-alert-example',
   templateUrl: './alert-example.component.html',
 })
 export class AlertExampleComponent {
+  private config: AlertConfig = {
+    title: 'Your alert',
+    message: 'Your alert message',
+    okBtnText: 'Ok',
+    cancelBtnText: 'Cancel',
+  };
+
   constructor(private modalController: ModalController, private vcRef: ViewContainerRef) {}
 
   showAlert() {
-    const config: AlertConfig = {
-      title: 'Your alert',
-      message: 'Your alert message',
-      okBtnText: 'Ok',
-      cancelBtnText: 'Cancel',
-    };
-    this.modalController.showAlert(config, this.onAlertClosed);
+    this.modalController.showAlert(this.config, this.onAlertClosed);
+  }
+
+  showReactiveAlert() {
+    this.delay(2)
+      .pipe(this.modalController.operators.showAlert(this.config))
+      .subscribe((response) => console.log('Response from alert (in observable) was:', response));
   }
 
   private onAlertClosed(selection: boolean) {
     console.log(`Alert selection: ${selection}`);
+  }
+
+  private delay(delayInSeconds = 2) {
+    return of(null).pipe(
+      tap(() => console.log(`Delaying for ${delayInSeconds} seconds`)),
+      delay(delayInSeconds * 1000)
+    );
   }
 }

--- a/src/app/examples/alert-example/alert-example.component.ts
+++ b/src/app/examples/alert-example/alert-example.component.ts
@@ -1,9 +1,8 @@
 import { Component, ViewContainerRef } from '@angular/core';
-
-import { ModalController } from '@kirbydesign/designsystem/modal';
-import { AlertConfig } from '@kirbydesign/designsystem/modal';
 import { of } from 'rxjs';
-import { delay, map, tap } from 'rxjs/operators';
+import { delay, tap } from 'rxjs/operators';
+
+import { AlertConfig, ModalController } from '@kirbydesign/designsystem/modal';
 
 @Component({
   selector: 'kirby-alert-example',

--- a/src/app/examples/modal-example/modal-example.component.html
+++ b/src/app/examples/modal-example/modal-example.component.html
@@ -1,3 +1,6 @@
 <button kirby-button (click)="showModal()">Show modal</button>
 <button kirby-button (click)="showDrawer()">Show drawer</button>
+<button kirby-button (click)="showReactiveModal()">Show reactive modal</button>
+<button kirby-button (click)="showReactiveDrawer()">Show reactive drawer</button>
+
 <a href="/home/showcase/modal#multipleModalsFromSameView"><span class="note">*</span> Launching multiple modals from the same view</a>

--- a/src/app/examples/modal-example/modal-example.component.ts
+++ b/src/app/examples/modal-example/modal-example.component.ts
@@ -1,4 +1,6 @@
 import { Component, ViewContainerRef } from '@angular/core';
+import { of } from 'rxjs';
+import { delay, map, tap } from 'rxjs/operators';
 
 import { ModalConfig } from '@kirbydesign/designsystem/modal';
 import { ModalController } from '@kirbydesign/designsystem/modal';
@@ -10,34 +12,52 @@ import { FirstEmbeddedModalExampleComponent } from './first-embedded-modal-examp
   styleUrls: ['./modal-example.component.scss'],
 })
 export class ModalExampleComponent {
+  private modalConfig: ModalConfig = {
+    title: 'My Modal Title',
+    flavor: 'modal',
+    component: FirstEmbeddedModalExampleComponent,
+    componentProps: {
+      prop1: 'value1',
+      prop2: 'value2',
+    },
+  };
+
+  private drawerConfig: ModalConfig = {
+    title: 'My Drawer Title',
+    flavor: 'drawer',
+    component: FirstEmbeddedModalExampleComponent,
+    componentProps: {
+      prop1: 'value1',
+      prop2: 'value2',
+    },
+  };
+
   constructor(private modalController: ModalController, private vcRef: ViewContainerRef) {}
 
   showModal() {
-    const config: ModalConfig = {
-      title: 'My Modal Title',
-      flavor: 'modal',
-      component: FirstEmbeddedModalExampleComponent,
-      componentProps: {
-        prop1: 'value1',
-        prop2: 'value2',
-      },
-    };
+    this.modalController.showModal(this.modalConfig, this.vcRef, this.onModalClose);
+  }
 
-    this.modalController.showModal(config, this.vcRef, this.onModalClose);
+  showReactiveModal() {
+    this.delayData('Some Data')
+      .pipe(
+        map((data) => ({ prop1: data })),
+        this.modalController.operators.showModal(this.modalConfig)
+      )
+      .subscribe((response) => console.log('Response from modal (in observable) was:', response));
   }
 
   showDrawer() {
-    const config: ModalConfig = {
-      title: 'My Drawer Title',
-      flavor: 'drawer',
-      component: FirstEmbeddedModalExampleComponent,
-      componentProps: {
-        prop1: 'value1',
-        prop2: 'value2',
-      },
-    };
+    this.modalController.showModal(this.drawerConfig, this.vcRef, this.onDrawerClose);
+  }
 
-    this.modalController.showModal(config, this.vcRef, this.onDrawerClose);
+  showReactiveDrawer() {
+    this.delayData('Some Data')
+      .pipe(
+        map((data) => ({ prop1: data })),
+        this.modalController.operators.showModal(this.drawerConfig)
+      )
+      .subscribe((response) => console.log('Response from drawer (in observable) was:', response));
   }
 
   onModalClose(data: any): void {
@@ -48,5 +68,13 @@ export class ModalExampleComponent {
   onDrawerClose(data: any): void {
     console.log('Callback from Embedded Drawer:');
     console.log(`Data received: ${JSON.stringify(data)}`);
+  }
+
+  private delayData(data: string) {
+    const delayInSeconds = 2;
+    return of(data).pipe(
+      tap(() => console.log(`Delaying for ${delayInSeconds} seconds`)),
+      delay(delayInSeconds * 1000)
+    );
   }
 }

--- a/src/app/showcase/action-sheet-showcase/action-sheet-showcase.component.html
+++ b/src/app/showcase/action-sheet-showcase/action-sheet-showcase.component.html
@@ -24,6 +24,20 @@ this.modalController.showActionSheet(config, this.vcRef);</kirby-code-viewer>
         We can use <code>modalController.hideTopmost</code> to hide (and destroy its component) the topmost action sheet.
         We can pass an optional result parameter to it, which is then going to be available inside the callback
     </p>
+
+    <h4>Showing a ActionSheet from an RxJs Observable</h4>
+    <p>When using a action sheet, it would some times be useful to use it in an <code>Observable</code> stream (one example hereof would be using it in conjunction
+        with a state-management library, such as <b>NgRx</b>).
+    </p>
+    <p>To facilitate that, an operator is created, that can be put in the "pipe" of an <code>Observable</code>:</p>
+    <kirby-code-viewer language="ts"><![CDATA[const obs$ = ... // some observable is constructed.
+obs$.pipe(
+    map((value) => { ... }), // map to an array of ActionSheetItems
+    modalController.operators.showActionSheet(config)
+)
+.subscribe((res) => console.log('The response from the action sheet is:', res);]]></kirby-code-viewer>
+    <br>
+
     <h4>Action sheet properties:</h4>
     <kirby-showcase-properties [properties]="properties"></kirby-showcase-properties>
 </div>

--- a/src/app/showcase/alert-showcase/alert-showcase.component.html
+++ b/src/app/showcase/alert-showcase/alert-showcase.component.html
@@ -18,6 +18,19 @@ this.modalController.showAlert(config);</kirby-code-viewer>
     ...
 {{ '}' }}</kirby-code-viewer>
     </p>
+
+    <h4>Showing an Alert from an RxJs Observable</h4>
+    <p>When using an alert, it would some times be useful to use it in an <code>Observable</code> stream (one example hereof would be using it in conjunction
+        with a state-management library, such as <b>NgRx</b>).
+    </p>
+    <p>To facilitate that, an operator is created, that can be put in the "pipe" of an <code>Observable</code>:</p>
+    <kirby-code-viewer language="ts"><![CDATA[const obs$ = ... // some observable is constructed.
+obs$.pipe(
+    modalController.operators.showAlert(config)
+)
+.subscribe((res) => console.log('The response from the alert is:', res);]]></kirby-code-viewer>
+    <br>
+
     <h4>Alert config properties:</h4>
     <kirby-showcase-properties [properties]="properties"></kirby-showcase-properties>
 </div>

--- a/src/app/showcase/modal-showcase/modal-showcase.component.html
+++ b/src/app/showcase/modal-showcase/modal-showcase.component.html
@@ -90,6 +90,20 @@ this.modalController.hideTopmost(returnData);</kirby-code-viewer>
     <p>Conclusion must be: If you want to open a second modal - let the first modal do it - just like the example above shows.</p>
     <p>To see the problem in action: <a href="https://play.nativescript.org/?template=play-ng&id=J3Gjbm&v=3">See Playground Example</a></p>
 
+    <h4>Showing a Modal from an RxJs Observable</h4>
+    <p>When using a modal, it would some times be useful to use it in an <code>Observable</code> stream (one example hereof would be using it in conjunction
+        with a state-management library, such as <b>NgRx</b>).
+    </p>
+    <p>To facilitate that, an operator is created, that can be put in the "pipe" of an <code>Observable</code>:</p>
+    <kirby-code-viewer language="ts"><![CDATA[const obs$ = ... // some observable is constructed.
+obs$.pipe(
+    // Map "value" to ComponentProps
+    map((value) => ({ data: value })),
+    // Displays and awaits interaction (modal is hidden / discarded)
+    modalController.operators.showModal(config)
+)
+.subscribe((res) => console.log('Modal response is:', res);]]></kirby-code-viewer>
+    <br>
 
     <h4>ModalConfig properties:</h4>
     <kirby-showcase-properties [properties]="properties"></kirby-showcase-properties>

--- a/src/kirby/components/modal/modal-wrapper/config/modal-config.ts
+++ b/src/kirby/components/modal/modal-wrapper/config/modal-config.ts
@@ -2,12 +2,14 @@ import { ModalConfigHelper } from './modal-config.helper';
 
 import { DrawerSupplementaryAction } from './drawer-supplementary-action';
 
+export type ComponentProps = { [key: string]: any };
+
 export class ModalConfig {
   title: string;
   component: any;
   flavor: 'modal' | 'drawer' = 'modal'; // TODO: also add 'alert' in the future
   dim?: number = ModalConfigHelper.defaultDim;
-  componentProps?: { [key: string]: any };
+  componentProps?: ComponentProps;
   // the supplementary action is only available in the drawer
   drawerSupplementaryAction?: DrawerSupplementaryAction;
 }

--- a/src/kirby/components/modal/services/modal.controller.spec.ts
+++ b/src/kirby/components/modal/services/modal.controller.spec.ts
@@ -1,7 +1,18 @@
+import any = jasmine.any;
+import { of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
 import { ModalController } from './modal.controller';
+import {
+  ActionSheetConfig,
+  ActionSheetItem,
+  AlertConfig,
+  ModalConfig,
+} from '@kirbydesign/designsystem/modal';
+import { ListComponent } from '@kirbydesign/designsystem/list';
 
 describe('modalController', () => {
-  const modalWindowHelperSpy = jasmine.createSpyObj('ModalWindowHelper', ['showModal']);
+  const modalWindowHelperSpy = jasmine.createSpyObj('ModalWindowHelper', ['showModalWindow']);
   const actionSheetHelperSpy = jasmine.createSpyObj('ActionSheetHelper', ['showActionSheet']);
   const alertHelperSpy = jasmine.createSpyObj('AlertHelper', ['showAlert']);
   let modalController: ModalController;
@@ -11,6 +22,10 @@ describe('modalController', () => {
   };
 
   beforeEach(() => {
+    modalWindowHelperSpy.showModalWindow.and.returnValue(Promise.resolve());
+    actionSheetHelperSpy.showActionSheet.and.returnValue(Promise.resolve());
+    alertHelperSpy.showAlert.and.returnValue(Promise.resolve());
+
     modalController = new ModalController(
       modalWindowHelperSpy,
       actionSheetHelperSpy,
@@ -30,6 +45,182 @@ describe('modalController', () => {
       expect(() => {
         modalController.hideTopmost();
       }).not.toThrow();
+    });
+  });
+
+  describe('operators', () => {
+    beforeEach(() => {
+      modalController.register({ close: mockCallback });
+    });
+
+    afterEach(() => {
+      // The callback won't trigger, until the modal is closed (hence the Observable never emits anything nor completes)
+      modalController.hideAll();
+    });
+
+    describe('showModal', () => {
+      const config: Readonly<ModalConfig> = {
+        flavor: 'modal',
+        component: ListComponent,
+        title: 'Foo',
+      };
+
+      beforeEach(() => {
+        spyOn(modalController, 'showModal').and.callThrough();
+      });
+
+      it('should be able to open a modal based on a configuration as an ModalConfig-object', (done) => {
+        of(1)
+          .pipe(
+            map((value) => ({ data: value })),
+            modalController.operators.showModal(config)
+          )
+          .subscribe(() => {
+            expect(modalController.showModal).toHaveBeenCalledWith(
+              { ...config, componentProps: { data: 1 } },
+              null,
+              any(Function)
+            );
+            done();
+          });
+      });
+
+      it('should be able to open a modal based on a configuration as an Observable with a ModalConfig-object', (done) => {
+        const config$ = of(config);
+
+        of(1)
+          .pipe(
+            map((value) => ({ data: value })),
+            modalController.operators.showModal(config$)
+          )
+          .subscribe(() => {
+            expect(modalController.showModal).toHaveBeenCalledWith(
+              { ...config, componentProps: { data: 1 } },
+              null,
+              any(Function)
+            );
+            done();
+          });
+      });
+
+      it('should complete the output Observable, when the modal is closed / hidden', (done) => {
+        const noOp = () => {};
+        of(1)
+          .pipe(
+            map((value) => ({ data: value })),
+            modalController.operators.showModal(config)
+          )
+          .subscribe(noOp, noOp, done);
+      });
+    });
+
+    describe('showActionSheet', () => {
+      const config: Readonly<ActionSheetConfig> = {
+        header: 'Header',
+        subheader: 'Sub-header',
+        items: [],
+        cancelButtonText: 'Nooooo!',
+      };
+
+      function asItem(value: number): ActionSheetItem {
+        return { id: value.toString(), text: `Item #${value}` };
+      }
+
+      beforeEach(() => {
+        spyOn(modalController, 'showActionSheet').and.callThrough();
+      });
+
+      it('should be able to open an action sheet based on a configuration as an ActionSheetConfig-object', (done) => {
+        const values = [1, 2, 3];
+        const items = values.map(asItem);
+
+        of(values)
+          .pipe(
+            map((value) => value.map(asItem)),
+            modalController.operators.showActionSheet(config)
+          )
+          .subscribe(() => {
+            expect(modalController.showActionSheet).toHaveBeenCalledWith(
+              { ...config, items },
+              null,
+              any(Function)
+            );
+            done();
+          });
+      });
+
+      it('should be able to open a modal based on a configuration as an Observable with a ActionSheetConfig-object', (done) => {
+        const values = [1, 2, 3];
+        const items = values.map(asItem);
+        const config$ = of(config);
+
+        of(values)
+          .pipe(
+            map((value) => value.map(asItem)),
+            modalController.operators.showActionSheet(config$)
+          )
+          .subscribe(() => {
+            expect(modalController.showActionSheet).toHaveBeenCalledWith(
+              { ...config, items },
+              null,
+              any(Function)
+            );
+            done();
+          });
+      });
+
+      it('should complete the output Observable, when the action sheet is closed / hidden', (done) => {
+        const noOp = () => {};
+        const values = [1, 2, 3];
+
+        of(values)
+          .pipe(
+            map((value) => value.map(asItem)),
+            modalController.operators.showActionSheet(config)
+          )
+          .subscribe(noOp, noOp, done);
+      });
+    });
+
+    describe('showAlert', () => {
+      const config: Readonly<AlertConfig> = {
+        title: 'Foo',
+        message: 'Bar',
+        cancelBtnText: 'Nope',
+        okBtnText: 'Yep',
+      };
+
+      beforeEach(() => {
+        spyOn(modalController, 'showAlert').and.callThrough();
+      });
+
+      it('should be able to display an alert based on a configuration as an AlertConfig-object', (done) => {
+        of(null)
+          .pipe(modalController.operators.showAlert(config))
+          .subscribe(() => {
+            expect(modalController.showAlert).toHaveBeenCalledWith(config, any(Function));
+            done();
+          });
+      });
+
+      it('should be able to open a modal based on a configuration as an Observable with a AlertConfig-object', (done) => {
+        const config$ = of(config);
+
+        of(null)
+          .pipe(modalController.operators.showAlert(config$))
+          .subscribe(() => {
+            expect(modalController.showAlert).toHaveBeenCalledWith(config, any(Function));
+            done();
+          });
+      });
+
+      it('should complete the output Observable, when the alert is closed / hidden', (done) => {
+        const noOp = () => {};
+
+        of(null)
+          .pipe(modalController.operators.showAlert(config))
+          .subscribe(noOp, noOp, done);
+      });
     });
   });
 });

--- a/src/kirby/components/modal/services/modal.controller.ts
+++ b/src/kirby/components/modal/services/modal.controller.ts
@@ -103,7 +103,7 @@ export class ModalController implements IModalController {
      *  .subscribe((res) => console.log('The response from the modal is:', res);
      * ```
      *
-     * @param config the configuration (or Observable of configuration) to pass to the modal, controlling behaviour and content of modal
+     * @param config the configuration (or Observable of configuration) to pass to the modal
      */
     showModal: (config: ModalConfig | Observable<ModalConfig>) => (
       source: Observable<ComponentProps>
@@ -136,7 +136,7 @@ export class ModalController implements IModalController {
      *
      * - It determines the actions to display, based on the input of [ActionItem]s (array)
      * - It outputs based on the response (callback) from the action sheet (based on the selected action)
-     * - It completes the output Observable, when the user has made a selection (or discarded the)
+     * - It completes the output Observable, when the user has made a selection (or discarded the) action sheet
      *
      * Example usage:
      * ```ts
@@ -148,7 +148,7 @@ export class ModalController implements IModalController {
      *  .subscribe((res) => console.log('The response from the action sheet is:', res);
      * ```
      *
-     * @param config the configuration (or Observable of configuration) to pass to the action sheet, controlling behaviour and content of action sheet
+     * @param config the configuration (or Observable of configuration) to pass to the action sheet
      */
     showActionSheet: (config: ActionSheetConfig | Observable<ActionSheetConfig>) => (
       source: Observable<ActionSheetItem[]>
@@ -176,6 +176,23 @@ export class ModalController implements IModalController {
       });
     },
 
+    /**
+     * An RxJs-operator that can display an alert.
+     *
+     * - It outputs based on the response (callback) from the action sheet (based on the selected action)
+     * - It completes the output Observable, when the user has made a selection (or discarded the) alert
+     *
+     * Example usage:
+     * ```ts
+     * const obs$ = ... // some observable is constructed.
+     * obs$.pipe(
+     *     modalController.operators.showAlert(config)
+     *  )
+     *  .subscribe((res) => console.log('The response from the alert is:', res);
+     * ```
+     *
+     * @param config the configuration (or Observable of configuration) to pass to the alert
+     */
     showAlert: (config: AlertConfig | Observable<AlertConfig>) => (source: Observable<any>) => {
       const controller = this;
 

--- a/src/kirby/components/modal/services/modal.controller.ts
+++ b/src/kirby/components/modal/services/modal.controller.ts
@@ -1,12 +1,15 @@
 import { Injectable, ViewContainerRef } from '@angular/core';
+import { isObservable, Observable, of } from 'rxjs';
+import { withLatestFrom } from 'rxjs/operators';
 
 import { IModalController } from './modal.controller.interface';
 import { ModalHelper } from './modal.helper';
 import { AlertHelper } from './alert.helper';
 import { ActionSheetHelper } from './action-sheet.helper';
-import { ModalConfig } from '../modal-wrapper/config/modal-config';
+import { ComponentProps, ModalConfig } from '../modal-wrapper/config/modal-config';
 import { ActionSheetConfig } from '../action-sheet/config/action-sheet-config';
 import { AlertConfig } from '../alert/config/alert-config';
+import { ActionSheetItem } from '@kirbydesign/designsystem/modal';
 
 @Injectable()
 export class ModalController implements IModalController {
@@ -20,7 +23,7 @@ export class ModalController implements IModalController {
 
   public showModal(
     config: ModalConfig,
-    vcRef: ViewContainerRef,
+    vcRef: ViewContainerRef = null,
     onCloseModal?: (data?: any) => void
   ): void {
     const modalCloseEvent: Promise<any> = this.modalHelper.showModalWindow(
@@ -40,7 +43,7 @@ export class ModalController implements IModalController {
 
   public showActionSheet(
     config: ActionSheetConfig,
-    vcRef: ViewContainerRef,
+    vcRef: ViewContainerRef = null,
     onCloseModal?: (data?: any) => void
   ): void {
     this.actionSheetHelper.showActionSheet(config, vcRef, this.register.bind(this)).then((data) => {
@@ -50,7 +53,8 @@ export class ModalController implements IModalController {
       }
     });
   }
-  showAlert(config: AlertConfig, onCloseModal?: (result?: boolean) => void) {
+
+  public showAlert(config: AlertConfig, onCloseModal?: (result?: boolean) => void) {
     this.alertHelper.showAlert(config).then((result) => {
       if (onCloseModal) {
         onCloseModal(result);
@@ -77,4 +81,121 @@ export class ModalController implements IModalController {
   public hideAll(): void {
     this.modals.forEach((modal) => modal.close());
   }
+
+  /**
+   * Exposes RxJs-operators to work with modals, drawers and alerts from Observables.
+   */
+  public operators = {
+    /**
+     * An RxJs-operator that can display a modal, or a drawer (depending upon configuration)
+     *
+     * - It passes the input of pipe to [ComponentProps] of the modal
+     * - It outputs based on the response (callback) from the modal (based on user interaction)
+     * - It completes the output Observable, when the user interacted with (discarded the) modal
+     *
+     * Example usage:
+     * ```ts
+     * const obs$ = ... // some observable is constructed.
+     * obs$.pipe(
+     *     map((value) => ({ data: value })),
+     *     modalController.operators.showModal(config)
+     *  )
+     *  .subscribe((res) => console.log('The response from the modal is:', res);
+     * ```
+     *
+     * @param config the configuration (or Observable of configuration) to pass to the modal, controlling behaviour and content of modal
+     */
+    showModal: (config: ModalConfig | Observable<ModalConfig>) => (
+      source: Observable<ComponentProps>
+    ) => {
+      const controller = this;
+
+      const config$ = isObservable(config) ? config : of(config);
+      return new Observable((observer) => {
+        return source.pipe(withLatestFrom(config$)).subscribe({
+          next([componentProps, config]) {
+            const clonedConfig = { ...config };
+            clonedConfig.componentProps = { ...config.componentProps, ...componentProps };
+            controller.showModal(clonedConfig, null, (data) => {
+              observer.next(data);
+              observer.complete();
+            });
+          },
+          error(err) {
+            observer.error(err);
+          },
+          complete() {
+            // Intentionally left empty, closing the modal also completes the stream
+          },
+        });
+      });
+    },
+
+    /**
+     * An RxJs-operator that can display an action sheet.
+     *
+     * - It determines the actions to display, based on the input of [ActionItem]s (array)
+     * - It outputs based on the response (callback) from the action sheet (based on the selected action)
+     * - It completes the output Observable, when the user has made a selection (or discarded the)
+     *
+     * Example usage:
+     * ```ts
+     * const obs$ = ... // some observable is constructed.
+     * obs$.pipe(
+     *     map((value) => { ... }), // map to an array of ActionSheetItems
+     *     modalController.operators.showActionSheet(config)
+     *  )
+     *  .subscribe((res) => console.log('The response from the action sheet is:', res);
+     * ```
+     *
+     * @param config the configuration (or Observable of configuration) to pass to the action sheet, controlling behaviour and content of action sheet
+     */
+    showActionSheet: (config: ActionSheetConfig | Observable<ActionSheetConfig>) => (
+      source: Observable<ActionSheetItem[]>
+    ) => {
+      const controller = this;
+
+      const config$ = isObservable(config) ? config : of(config);
+      return new Observable((observer) => {
+        return source.pipe(withLatestFrom(config$)).subscribe({
+          next([items, config]) {
+            const clonedConfig = { ...config, items: [] };
+            clonedConfig.items = [...config.items, ...items];
+            controller.showActionSheet(clonedConfig, null, (data) => {
+              observer.next(data);
+              observer.complete();
+            });
+          },
+          error(err) {
+            observer.error(err);
+          },
+          complete() {
+            // Intentionally left empty, closing the action sheet also completes the stream
+          },
+        });
+      });
+    },
+
+    showAlert: (config: AlertConfig | Observable<AlertConfig>) => (source: Observable<any>) => {
+      const controller = this;
+
+      const config$ = isObservable(config) ? config : of(config);
+      return new Observable((observer) => {
+        return source.pipe(withLatestFrom(config$)).subscribe({
+          next([_, config]) {
+            controller.showAlert(config, (data) => {
+              observer.next(data);
+              observer.complete();
+            });
+          },
+          error(err) {
+            observer.error(err);
+          },
+          complete() {
+            // Intentionally left empty, closing the alert also completes the stream
+          },
+        });
+      });
+    },
+  };
 }


### PR DESCRIPTION
:children_crossing: Since ViewContainerRef was not needed anymore, passing it to the ModalController is now optional (will be removed in later version of Kirby). Made operators (to be used with RxJs) to use modals, alerts and action sheets in a reactive manor.