### PR TITLE
:bug: Removing unused ViewContainerRef from ModalController.

### DIFF
--- a/src/kirby/components/modal/services/action-sheet.helper.ts
+++ b/src/kirby/components/modal/services/action-sheet.helper.ts
@@ -10,7 +10,6 @@ export class ActionSheetHelper {
 
   public async showActionSheet(
     config: ActionSheetConfig,
-    vcRef: ViewContainerRef,
     registerModal: (modal: { close: (data?: any) => {} }) => void
   ): Promise<any> {
     const modal = await this.ionicModalController.create({

--- a/src/kirby/components/modal/services/modal.controller.ts
+++ b/src/kirby/components/modal/services/modal.controller.ts
@@ -20,12 +20,11 @@ export class ModalController implements IModalController {
 
   public showModal(
     config: ModalConfig,
-    vcRef: ViewContainerRef,
+    vcRef?: ViewContainerRef,
     onCloseModal?: (data?: any) => void
   ): void {
     const modalCloseEvent: Promise<any> = this.modalHelper.showModalWindow(
       config,
-      vcRef,
       this.register.bind(this)
     );
     modalCloseEvent.then((data) => {
@@ -40,10 +39,10 @@ export class ModalController implements IModalController {
 
   public showActionSheet(
     config: ActionSheetConfig,
-    vcRef: ViewContainerRef,
+    vcRef?: ViewContainerRef,
     onCloseModal?: (data?: any) => void
   ): void {
-    this.actionSheetHelper.showActionSheet(config, vcRef, this.register.bind(this)).then((data) => {
+    this.actionSheetHelper.showActionSheet(config, this.register.bind(this)).then((data) => {
       this.forgetTopmost();
       if (onCloseModal) {
         onCloseModal(typeof data === 'object' && 'data' in data ? data.data : data);

--- a/src/kirby/components/modal/services/modal.helper.ts
+++ b/src/kirby/components/modal/services/modal.helper.ts
@@ -1,4 +1,4 @@
-import { Injectable, ViewContainerRef } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { ModalController as IonicModalController } from '@ionic/angular';
 import { Animation } from '@ionic/core';
 
@@ -11,7 +11,6 @@ export class ModalHelper {
 
   public async showModalWindow(
     config: ModalConfig,
-    _vcRef: ViewContainerRef,
     registerModal: (modal: { close: (data?: any) => {} }) => void
   ): Promise<any> {
     const modal = await this.ionicModalController.create({


### PR DESCRIPTION
Removed `ViewContainerRef` (well, made it optional for now) from `ModalController`, to avoid leaking memory, when displaying modals from Effects.

When dependant code has removed the usage of the `ViewContainerRef`, the API of kirby can delete the argument completely (doing it this way to minimize the impact of this optimization).