### PR TITLE
[Clean up] Remove ViewContainerRef

### DIFF
--- a/src/app/examples/action-sheet-example/action-sheet-example.component.ts
+++ b/src/app/examples/action-sheet-example/action-sheet-example.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewContainerRef } from '@angular/core';
+import { Component } from '@angular/core';
 
 import { ModalController } from '@kirbydesign/designsystem/modal';
 import { ActionSheetConfig } from '@kirbydesign/designsystem/modal';
@@ -9,7 +9,7 @@ import { ActionSheetItem } from '@kirbydesign/designsystem/modal';
   templateUrl: './action-sheet-example.component.html',
 })
 export class ActionSheetExampleComponent {
-  constructor(private modalController: ModalController, private vcRef: ViewContainerRef) {}
+  constructor(private modalController: ModalController) {}
 
   showActionSheet() {
     const config: ActionSheetConfig = {
@@ -22,7 +22,7 @@ export class ActionSheetExampleComponent {
       ],
       cancelButtonText: 'Custom cancel',
     };
-    this.modalController.showActionSheet(config, this.vcRef, this.onActionSelected);
+    this.modalController.showActionSheet(config, this.onActionSelected);
   }
 
   private onActionSelected(selection: ActionSheetItem) {

--- a/src/app/examples/alert-example/alert-example.component.ts
+++ b/src/app/examples/alert-example/alert-example.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewContainerRef } from '@angular/core';
+import { Component } from '@angular/core';
 
 import { ModalController } from '@kirbydesign/designsystem/modal';
 import { AlertConfig } from '@kirbydesign/designsystem/modal';
@@ -8,7 +8,7 @@ import { AlertConfig } from '@kirbydesign/designsystem/modal';
   templateUrl: './alert-example.component.html',
 })
 export class AlertExampleComponent {
-  constructor(private modalController: ModalController, private vcRef: ViewContainerRef) {}
+  constructor(private modalController: ModalController) {}
 
   showAlert() {
     const config: AlertConfig = {

--- a/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.ts
+++ b/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, ViewContainerRef } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 
 import { ModalController } from '@kirbydesign/designsystem/modal';
 import { ModalConfig } from '@kirbydesign/designsystem/modal';
@@ -14,7 +14,6 @@ export class FirstEmbeddedModalExampleComponent {
   constructor(
     @Inject(COMPONENT_PROPS) private componentProps,
     private modalController: ModalController,
-    private vcRef: ViewContainerRef
   ) {
     this.props = componentProps;
   }
@@ -27,7 +26,7 @@ export class FirstEmbeddedModalExampleComponent {
     };
 
     // supposing no callback needed for the second component
-    this.modalController.showModal(config, this.vcRef);
+    this.modalController.showModal(config);
   }
 
   async showNestedDrawer() {
@@ -42,7 +41,7 @@ export class FirstEmbeddedModalExampleComponent {
     };
 
     // supposing no callback needed for the second component
-    this.modalController.showModal(config, this.vcRef);
+    this.modalController.showModal(config);
   }
 
   onHideFirst() {

--- a/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.ts
+++ b/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.ts
@@ -13,7 +13,7 @@ export class FirstEmbeddedModalExampleComponent {
 
   constructor(
     @Inject(COMPONENT_PROPS) private componentProps,
-    private modalController: ModalController,
+    private modalController: ModalController
   ) {
     this.props = componentProps;
   }

--- a/src/app/examples/modal-example/modal-example.component.ts
+++ b/src/app/examples/modal-example/modal-example.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewContainerRef } from '@angular/core';
+import { Component } from '@angular/core';
 
 import { ModalConfig } from '@kirbydesign/designsystem/modal';
 import { ModalController } from '@kirbydesign/designsystem/modal';
@@ -10,7 +10,7 @@ import { FirstEmbeddedModalExampleComponent } from './first-embedded-modal-examp
   styleUrls: ['./modal-example.component.scss'],
 })
 export class ModalExampleComponent {
-  constructor(private modalController: ModalController, private vcRef: ViewContainerRef) {}
+  constructor(private modalController: ModalController) {}
 
   showModal() {
     const config: ModalConfig = {
@@ -23,7 +23,7 @@ export class ModalExampleComponent {
       },
     };
 
-    this.modalController.showModal(config, this.vcRef, this.onModalClose);
+    this.modalController.showModal(config, this.onModalClose);
   }
 
   showDrawer() {
@@ -37,7 +37,7 @@ export class ModalExampleComponent {
       },
     };
 
-    this.modalController.showModal(config, this.vcRef, this.onDrawerClose);
+    this.modalController.showModal(config, this.onDrawerClose);
   }
 
   onModalClose(data: any): void {

--- a/src/kirby/components/modal/services/action-sheet.helper.ts
+++ b/src/kirby/components/modal/services/action-sheet.helper.ts
@@ -1,4 +1,4 @@
-import { Injectable, ViewContainerRef, ComponentFactoryResolver } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { ModalController as IonicModalController } from '@ionic/angular';
 
 import { ActionSheetConfig } from '../action-sheet/config/action-sheet-config';

--- a/src/kirby/components/modal/services/modal.controller.interface.ts
+++ b/src/kirby/components/modal/services/modal.controller.interface.ts
@@ -1,20 +1,10 @@
-import { ViewContainerRef } from '@angular/core';
-
 import { ModalConfig } from '../modal-wrapper/config/modal-config';
 import { ActionSheetConfig } from '../action-sheet/config/action-sheet-config';
 import { AlertConfig } from '../alert/config/alert-config';
 
 export abstract class IModalController {
-  abstract showModal(
-    config: ModalConfig,
-    vcRef: ViewContainerRef,
-    onCloseModal?: (data?: any) => any
-  ): void;
-  abstract showActionSheet(
-    config: ActionSheetConfig,
-    vcRef: ViewContainerRef,
-    onCloseModal?: (data?: any) => any
-  ): void;
+  abstract showModal(config: ModalConfig, onCloseModal?: (data?: any) => any): void;
+  abstract showActionSheet(config: ActionSheetConfig, onCloseModal?: (data?: any) => any): void;
   abstract showAlert(config: AlertConfig, onCloseModal?: (result?: boolean) => boolean);
   abstract hideTopmost(data?: any): void;
   abstract register(modal: { close: (data?: any) => {} }): void;

--- a/src/kirby/components/modal/services/modal.controller.ts
+++ b/src/kirby/components/modal/services/modal.controller.ts
@@ -1,4 +1,4 @@
-import { Injectable, ViewContainerRef } from '@angular/core';
+import { Injectable } from '@angular/core';
 
 import { IModalController } from './modal.controller.interface';
 import { ModalHelper } from './modal.helper';
@@ -18,11 +18,7 @@ export class ModalController implements IModalController {
     private alertHelper: AlertHelper
   ) {}
 
-  public showModal(
-    config: ModalConfig,
-    vcRef?: ViewContainerRef,
-    onCloseModal?: (data?: any) => void
-  ): void {
+  public showModal(config: ModalConfig, onCloseModal?: (data?: any) => void): void {
     const modalCloseEvent: Promise<any> = this.modalHelper.showModalWindow(
       config,
       this.register.bind(this)
@@ -37,11 +33,7 @@ export class ModalController implements IModalController {
     });
   }
 
-  public showActionSheet(
-    config: ActionSheetConfig,
-    vcRef?: ViewContainerRef,
-    onCloseModal?: (data?: any) => void
-  ): void {
+  public showActionSheet(config: ActionSheetConfig, onCloseModal?: (data?: any) => void): void {
     this.actionSheetHelper.showActionSheet(config, this.register.bind(this)).then((data) => {
       this.forgetTopmost();
       if (onCloseModal) {
@@ -49,7 +41,8 @@ export class ModalController implements IModalController {
       }
     });
   }
-  showAlert(config: AlertConfig, onCloseModal?: (result?: boolean) => void) {
+
+  public showAlert(config: AlertConfig, onCloseModal?: (result?: boolean) => void) {
     this.alertHelper.showAlert(config).then((result) => {
       if (onCloseModal) {
         onCloseModal(result);

--- a/src/kirby/components/shared/component-loader.directive.ts
+++ b/src/kirby/components/shared/component-loader.directive.ts
@@ -1,10 +1,10 @@
 import {
   Directive,
-  ViewContainerRef,
   Input,
   ComponentFactoryResolver,
   OnInit,
   Renderer2,
+  ViewContainerRef,
 } from '@angular/core';
 
 import { ComponentConfiguration } from './component-configuration';


### PR DESCRIPTION
Removes `ViewContainerRef` from modals, action sheets and alerts completely (was previously an optional 2nd parameter).