### PR TITLE
KirbyTestingModule can leak state

### DIFF
--- a/src/kirby/testing/kirby-testing.module.ts
+++ b/src/kirby/testing/kirby-testing.module.ts
@@ -168,6 +168,27 @@ const MOCK_DIRECTIVES = MockDirectives(
   ListItemColorDirective
 );
 
+function modalControllerFactory() {
+  return createSpyObj('ModalController', [
+    'showModal',
+    'showActionSheet',
+    'showAlert',
+    'register',
+    'hideTopmost',
+  ]);
+}
+
+function toastControllerFactory() {
+  return createSpyObj('ToastController', ['showToast']);
+}
+
+function loadingOverlayServiceFactory() {
+  return createSpyObj<LoadingOverlayService>('LoadingOverlayService', [
+    'showLoadingOverlay',
+    'hideLoadingOverlay',
+  ]);
+}
+
 @NgModule({
   imports: [CommonModule],
   declarations: [NON_MOCKED_COMPONENTS, MOCK_COMPONENTS, MOCK_DIRECTIVES],
@@ -175,24 +196,15 @@ const MOCK_DIRECTIVES = MockDirectives(
   providers: [
     {
       provide: ModalController,
-      useValue: createSpyObj('ModalController', [
-        'showModal',
-        'showActionSheet',
-        'showAlert',
-        'register',
-        'hideTopmost',
-      ]),
+      useFactory: modalControllerFactory,
     },
     {
       provide: ToastController,
-      useValue: createSpyObj('ToastController', ['showToast']),
+      useFactory: toastControllerFactory,
     },
     {
       provide: LoadingOverlayService,
-      useValue: createSpyObj<LoadingOverlayService>('LoadingOverlayService', [
-        'showLoadingOverlay',
-        'hideLoadingOverlay',
-      ]),
+      useFactory: loadingOverlayServiceFactory,
     },
   ],
 })


### PR DESCRIPTION
:bug: Jasmine mocks in KirbyTestingModule had the potential to leak state (since mocks were created once, and being able to share state between test-case executions).

This fixes the issue by providing a factory for the module... hence, providing a new instance of the mock(s), for every TestBed that imports the `KirbyTestingModule`.