### PR TITLE
fix/list-assignment-based-on-output

### DIFF
--- a/src/kirby/components/list/list.component.spec.ts
+++ b/src/kirby/components/list/list.component.spec.ts
@@ -158,9 +158,9 @@ describe('ListComponent', () => {
 
   describe('function: ngOnInit', () => {
     it('should enable load more, if there is a subscriber to the loadMore event emitter', () => {
-      component.loadOnDemand.subscribe((loadMoreEvent: LoadOnDemandEvent) => {});
+      component.loadOnDemand.subscribe((_: LoadOnDemandEvent) => {});
 
-      runNgOnChanges();
+      component.ngOnInit();
 
       expect(component.isLoadOnDemandEnabled).toBeTruthy();
     });

--- a/src/kirby/components/list/list.component.ts
+++ b/src/kirby/components/list/list.component.ts
@@ -10,7 +10,6 @@ import {
   TemplateRef,
   ViewChild,
   TrackByFunction,
-  SimpleChanges,
 } from '@angular/core';
 
 import {

--- a/src/kirby/components/list/list.component.ts
+++ b/src/kirby/components/list/list.component.ts
@@ -10,6 +10,7 @@ import {
   TemplateRef,
   ViewChild,
   TrackByFunction,
+  SimpleChanges,
 } from '@angular/core';
 
 import {
@@ -135,6 +136,8 @@ export class ListComponent implements OnInit, OnChanges {
 
   ngOnInit() {
     this.initialzeSwipeActions();
+    this.isSelectable = this.itemSelect.observers.length > 0;
+    this.isLoadOnDemandEnabled = this.loadOnDemand.observers.length > 0;
   }
 
   ngOnChanges(): void {
@@ -146,8 +149,6 @@ export class ListComponent implements OnInit, OnChanges {
       this.groupedItems = null;
       this.orderMap = null;
     }
-    this.isSelectable = this.itemSelect.observers.length > 0;
-    this.isLoadOnDemandEnabled = this.loadOnDemand.observers.length > 0;
   }
 
   isFirstItem(item: any, index: number) {


### PR DESCRIPTION
The list is looking on `Output` properties in its `ngOnChange` function.

This ruins the load on demand functionality as the property `isLoadOnDemandEnabled` is reassigned  on every change. So if is disable load on demand, but make a change to the list, it will be enabled again. This will hide the `noMoreItemsText`.

I have fixed this by moving the usage of the `Output` properties to the `ngOnInit` function.