### PR TITLE
Fix/padding-to-follow-card-design

### DIFF
--- a/src/kirby/components/list/list.component.scss
+++ b/src/kirby/components/list/list.component.scss
@@ -5,6 +5,31 @@ $background-color-hover: get-color('background-color');
 $shadow: get-elevation(2);
 $item-height: size('xxxl');
 
+ion-list, .list-items {
+  > ion-item {
+    &:first-of-type {
+      --padding-top: #{size('s')};
+    }
+  
+    &:last-of-type {
+      --padding-bottom: #{size('s')};
+    }
+  }
+
+  ion-item-sliding {
+    &:first-of-type {
+      ion-item {
+        --padding-top: #{size('s')};
+      }
+    }
+    &:last-of-type {
+      ion-item {
+        --padding-bottom: #{size('s')};
+      }
+    }
+  }
+}
+
 ion-list {
   box-shadow: $shadow;
   background: transparent;
@@ -63,8 +88,6 @@ ion-list-header {
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  
-
 }
 
 :host(.has-sections) {
@@ -172,6 +195,7 @@ ion-item-divider {
 ion-item {
   display: flex;
   width: 100%;
+  --ion-safe-area-right: 0;
   --padding-top: #{size('xxs')};
   --padding-bottom: #{size('xxs')};
   --padding-start: #{size('s')};
@@ -185,7 +209,7 @@ ion-item {
 
 .section-header {
   background-color: transparent;
-  padding: size('m');
+  padding: size('m') size('s') 0 size('s');
 }
 
 .no-more-items, .loading {


### PR DESCRIPTION
I have tried to align the styling of the list with the card design. 
That means that i have set the top/bottom padding of the first/last `ion-item` in the list.

I have also aligned the padding of the section header to follow the design. 

![image](https://user-images.githubusercontent.com/46445487/66649840-727e2b00-ec2f-11e9-9fea-410eb368eb46.png)
