### PR TITLE
bug/list-load-on-demand-in-kirby-page

### DIFF
--- a/src/kirby/components/page/page.component.html
+++ b/src/kirby/components/page/page.component.html
@@ -15,7 +15,7 @@
     </ion-toolbar>
 </ion-header>
 
-<ion-content>
+<ion-content scrollEvents="true">
 
     <div class="content-inner">
         <div *ngIf="hasPageTitle" class="page-title" [class.has-actions]="hasActionsInPage" [ngClass]="{'text-center': titleAlignment === 'center', 'text-right': titleAlignment === 'right'}" #pageTitle>


### PR DESCRIPTION
The `infinite-scroll` directive now take into account, that it can be used inside an `kirby-page` and have to listen to scroll on `ion-content` and not the window. 