### PR TITLE
fix(page): wrap title and toolbar actions inside div

### DIFF
--- a/src/kirby/components/page/page.component.html
+++ b/src/kirby/components/page/page.component.html
@@ -3,14 +3,20 @@
         <ion-buttons slot="start">
             <ion-back-button text="" [defaultHref]="defaultBackHref" icon="assets/kirby/icons/svg/arrow-back.svg"></ion-back-button>
         </ion-buttons>
-        <ion-title [@visibility]="toolbarTitleVisibility">
-            <ng-container *ngTemplateOutlet="toolbarTitleTemplate"></ng-container>
+        <ion-title>
+            <div [@visibility]="toolbarTitleVisibility">
+                <ng-container *ngTemplateOutlet="toolbarTitleTemplate"></ng-container>
+            </div>
         </ion-title>
-        <ion-buttons *ngIf="stickyActionsTemplate" slot="primary" [@visibility]="toolbarStickyActionsVisibility" #stickyToolbarButtons>
-            <ng-container *ngTemplateOutlet="stickyActionsTemplate"></ng-container>
+        <ion-buttons *ngIf="stickyActionsTemplate" slot="primary" #stickyToolbarButtons>
+            <div [@visibility]="toolbarStickyActionsVisibility">
+                <ng-container *ngTemplateOutlet="stickyActionsTemplate"></ng-container>
+            </div>
         </ion-buttons>
-        <ion-buttons *ngIf="fixedActionsTemplate" slot="secondary" [@visibility]="toolbarFixedActionsVisibility" #fixedToolbarButtons>
-            <ng-container *ngTemplateOutlet="fixedActionsTemplate"></ng-container>
+        <ion-buttons *ngIf="fixedActionsTemplate" slot="secondary" #fixedToolbarButtons>
+            <div [@visibility]="toolbarFixedActionsVisibility">
+                <ng-container *ngTemplateOutlet="fixedActionsTemplate"></ng-container>
+            </div>
         </ion-buttons>
     </ion-toolbar>
 </ion-header>


### PR DESCRIPTION
Wrapping title and toolbar actions because Ionic otherwise will conflict with our own transitions.