### PR TITLE
fix(form-field): add web-appearance: none, to make box-shadow on form…

### DIFF
--- a/src/kirby/components/form-field/_form-field-inputs.shared.scss
+++ b/src/kirby/components/form-field/_form-field-inputs.shared.scss
@@ -19,6 +19,7 @@
   outline: none;
   padding: size('s');
   width: 100%;
+  -webkit-appearance: none;
 
   &:disabled {
     background-color: get-color('light-tint');


### PR DESCRIPTION
Add **web-appearance: none**, to make box-shadow on form-field work on iOS
closes #716 