### PR TITLE
Divider without color

### DIFF
--- a/src/kirby/components/divider/divider.component.scss
+++ b/src/kirby/components/divider/divider.component.scss
@@ -1,14 +1,10 @@
 @import '../../scss/utils';
 
-:host-context(.default),
-:host-context(.kirby-color-brightness-white) {
-  --kirby-divider-color: #{get-color('background-color')};
-}
 :host-context(.kirby-color-brightness-light) {
   --kirby-divider-color: #{get-color('medium')};
 }
 
 hr {
-  border: 0px;
-  border-top: 1px solid var(--kirby-divider-color);
+  border: 0;
+  border-top: 1px solid var(--kirby-divider-color, get-color('background-color'));
 }


### PR DESCRIPTION
:bug: Divider didn't have a default color (unless placed in element with parent having class set to `.default`).