### PR TITLE
Divider color on background

### DIFF
--- a/src/app/examples/divider-example/divider-example.component.html
+++ b/src/app/examples/divider-example/divider-example.component.html
@@ -1,5 +1,9 @@
+<h1>Divider on background</h1>
+<kirby-divider></kirby-divider>
+<p>Some text below divider</p>
+
 <kirby-card [hasPadding]="true" [themeColor]="themeColor">
-  <h1>Above divider</h1>
+  <h1>Divider on card</h1>
   <kirby-divider></kirby-divider>
-  <p>Below divider</p>
+  <p>Some text below divider</p>
 </kirby-card>

--- a/src/kirby/components/divider/divider.component.scss
+++ b/src/kirby/components/divider/divider.component.scss
@@ -1,10 +1,18 @@
 @import '../../scss/utils';
 
+:host-context(kirby-card) {
+  --kirby-divider-color: #{get-color('background-color')};
+}
+
+:host-context(.kirby-color-brightness-white) {
+  --kirby-divider-color: #{get-color('background-color')};
+}
+
 :host-context(.kirby-color-brightness-light) {
   --kirby-divider-color: #{get-color('medium')};
 }
 
 hr {
   border: 0;
-  border-top: 1px solid var(--kirby-divider-color, get-color('background-color'));
+  border-top: 1px solid var(--kirby-divider-color, get-color('medium'));
 }

--- a/src/kirby/components/divider/divider.component.scss
+++ b/src/kirby/components/divider/divider.component.scss
@@ -1,9 +1,6 @@
 @import '../../scss/utils';
 
-:host-context(kirby-card) {
-  --kirby-divider-color: #{get-color('background-color')};
-}
-
+:host-context(kirby-card),
 :host-context(.kirby-color-brightness-white) {
   --kirby-divider-color: #{get-color('background-color')};
 }


### PR DESCRIPTION
When the divider was added to a modal or something else with `background-color` as background color, it would be invisible (also have `background-color` as color).

Now it will have `background-color` as color when in Card, unless the card has either `white` or `light` theme color. If not in card it will have `medium` as color.