### PR TITLE
fix/empty-state-icon-color

### DIFF
--- a/src/kirby/components/empty-state/empty-state.component.scss
+++ b/src/kirby/components/empty-state/empty-state.component.scss
@@ -19,8 +19,12 @@ article {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  border: 3px solid var(--kirby-medium);
+  border: 3px solid get-color('medium');
   border-radius: 50%;
+}
+
+kirby-icon {
+  color: get-color('medium');
 }
 
 h3.title {


### PR DESCRIPTION
Closes #624 

I also use the `get-color` mixin instead of referring the `--kirby-medium` variable directly.