### PR TITLE
fix/Remove-inner-padding-item-devider

### DIFF
--- a/src/kirby/components/list/list.component.scss
+++ b/src/kirby/components/list/list.component.scss
@@ -106,6 +106,7 @@ ion-item-group {
 }
 
 ion-item-divider {
+  --inner-padding-end: 0;
   --color: unset;
   background-color: transparent;
   border-color: transparent;


### PR DESCRIPTION
`ion-item-devider` has per default a right padding on 8px. This creates misalignment on the right side of the section heder, if using a custom `kirbyListSectionHeader` containing right aligned content.

Look at the text `Saldo: 26.292,78`. 

Before the change:
![image](https://user-images.githubusercontent.com/46445487/70612267-ed030100-1c06-11ea-9fa4-b1cc4a4217dd.png)

After the change:
![image](https://user-images.githubusercontent.com/46445487/70612285-f4c2a580-1c06-11ea-80d1-4c0e2f06bc45.png)
