### PR TITLE
fix(button): styling of button in context of page

### DIFF
--- a/src/kirby/components/button/button.component.scss
+++ b/src/kirby/components/button/button.component.scss
@@ -197,7 +197,7 @@
   margin-inline-start: size('s');
 }
 
-:host-context(ion-toolbar kirby-page-actions) {
+:host-context(ion-toolbar) {
   &.attention-level1,
   &.attention-level2,
   &.attention-level3,
@@ -208,7 +208,7 @@
   }
 }
 
-:host-context(ion-content kirby-page-actions) {
+:host-context(ion-content) {
   &.attention-level1,
   &.attention-level2,
   &.attention-level3,

--- a/src/kirby/components/button/button.component.scss
+++ b/src/kirby/components/button/button.component.scss
@@ -208,7 +208,7 @@
   }
 }
 
-:host-context(ion-content) {
+:host-context(.page-title) {
   &.attention-level1,
   &.attention-level2,
   &.attention-level3,


### PR DESCRIPTION
Fix wrong styling of buttons in context of page. Buttons should now be styled correctly inside of an page toolbar and page header.
**Can be tested by running ng serve --prod**