### PR TITLE
fix/kirby-list-infinite-scroll-ion-content

### DIFF
--- a/src/kirby/components/list/directives/infinite-scroll.directive.spec.ts
+++ b/src/kirby/components/list/directives/infinite-scroll.directive.spec.ts
@@ -15,6 +15,7 @@ describe('InfiniteScrollDirective', () => {
     const viewHeight = 0;
 
     nativeElement.getBoundingClientRect.and.returnValue({ height, bottom });
+    nativeElement.closest.and.returnValue(null);
     document.getElementsByTagName.and.returnValue([]);
 
     const directive = new InfiniteScrollDirective(
@@ -28,7 +29,7 @@ describe('InfiniteScrollDirective', () => {
   };
 
   beforeEach(() => {
-    nativeElement = jasmine.createSpyObj('nativeElement', ['getBoundingClientRect']);
+    nativeElement = jasmine.createSpyObj('nativeElement', ['getBoundingClientRect', 'closest']);
     document = jasmine.createSpyObj('document', ['getElementsByTagName']);
   });
 

--- a/src/kirby/components/list/directives/infinite-scroll.directive.ts
+++ b/src/kirby/components/list/directives/infinite-scroll.directive.ts
@@ -1,3 +1,4 @@
+import { IonContent } from '@ionic/angular';
 import {
   Directive,
   AfterViewInit,
@@ -76,26 +77,27 @@ export class InfiniteScrollDirective implements AfterViewInit, OnDestroy {
         this.scrollEnd.emit();
       });
 
-    const allIonContents = this.windowRef.nativeWindow.document.getElementsByTagName('ion-content');
-    if (allIonContents && allIonContents.length > 0) {
-      const closetsIonContent = allIonContents[allIonContents.length - 1];
-      fromEvent<any>(closetsIonContent, 'ionScroll')
-        .pipe(
-          takeUntil(this.ngUnsubscribe$),
-          debounceTime(INFINITE_SCROLL_DEBOUNCE),
-          filter(() => !this.disabled),
-          map(() => this.getScroll()),
-          filter((scroll) => {
-            return (
-              scroll.elementHeight * (1 - this.offset) >=
-              scroll.distanceToViewBottom - scroll.viewHeight
-            );
-          })
-        )
-        .subscribe(() => {
-          this.scrollEnd.emit();
-        });
-    }
+    setTimeout(() => {
+      const ionContent = this.elementRef.nativeElement.closest('ion-content');
+      if (ionContent) {
+        fromEvent<any>(ionContent, 'ionScroll')
+          .pipe(
+            takeUntil(this.ngUnsubscribe$),
+            debounceTime(INFINITE_SCROLL_DEBOUNCE),
+            filter(() => !this.disabled),
+            map(() => this.getScroll()),
+            filter((scroll) => {
+              return (
+                scroll.elementHeight * (1 - this.offset) >=
+                scroll.distanceToViewBottom - scroll.viewHeight
+              );
+            })
+          )
+          .subscribe(() => {
+            this.scrollEnd.emit();
+          });
+      }
+    });
   }
 
   /**

--- a/src/kirby/components/list/directives/infinite-scroll.directive.ts
+++ b/src/kirby/components/list/directives/infinite-scroll.directive.ts
@@ -1,4 +1,3 @@
-import { IonContent } from '@ionic/angular';
 import {
   Directive,
   AfterViewInit,


### PR DESCRIPTION
Before we took the last of all `IonContent`. This could happen not to be the `IonContent` that the `kirby-list` was in. An example being a modal with an `IonContent` not being removed from the DOM, as the directive was initialized.

So not we get the closest ancestor for the element with the directive attached. For this to work, i hade to wrap the check in a `setTimeout `.