### PR TITLE
:lipstick: :bug: Only style buttons inside kirby-page-actions

### DIFF
--- a/src/kirby/components/button/button.component.scss
+++ b/src/kirby/components/button/button.component.scss
@@ -208,7 +208,7 @@
   }
 }
 
-:host-context(.page-title) {
+:host-context(kirby-page-actions) {
   &.attention-level1,
   &.attention-level2,
   &.attention-level3,


### PR DESCRIPTION
Fixes an issue where buttons inside page titles are styled like page actions

*Wrong:*
![image](https://user-images.githubusercontent.com/9556693/71014224-e2a6a280-20f1-11ea-8b69-e5bd9ecdad10.png)

*Correct:*
![image](https://user-images.githubusercontent.com/9556693/71014268-f8b46300-20f1-11ea-914f-593b68f3fe53.png)
