### PR TITLE
863/item-corners-on-swipe-safari

### DIFF
--- a/src/kirby/components/list/list.component.scss
+++ b/src/kirby/components/list/list.component.scss
@@ -79,6 +79,14 @@ ion-item {
 }
 
 ion-item-sliding {
+  //  https://stackoverflow.com/a/16681137
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  -moz-backface-visibility: hidden;
+  transform: translate3d(0, 0, 0);
+  -webkit-transform: translate3d(0, 0, 0);
+  -moz-transform: translate3d(0, 0, 0);
+
   $list-colors: ('light'); // add supported list item theme colors here
   @each $color-name, $color-value in $list-colors {
     &.#{$color-name} {

--- a/src/kirby/components/list/list.component.scss
+++ b/src/kirby/components/list/list.component.scss
@@ -79,7 +79,7 @@ ion-item {
 }
 
 ion-item-sliding {
-  //  https://stackoverflow.com/a/16681137
+  // backface-visibility and transform, to fix clipping issue on iOS see https://stackoverflow.com/a/16681137 and https://github.com/kirbydesign/designsystem/issues/863
   backface-visibility: hidden;
   -webkit-backface-visibility: hidden;
   -moz-backface-visibility: hidden;

--- a/src/kirby/components/list/list.component.scss
+++ b/src/kirby/components/list/list.component.scss
@@ -81,11 +81,7 @@ ion-item {
 ion-item-sliding {
   // backface-visibility and transform, to fix clipping issue on iOS see https://stackoverflow.com/a/16681137 and https://github.com/kirbydesign/designsystem/issues/863
   backface-visibility: hidden;
-  -webkit-backface-visibility: hidden;
-  -moz-backface-visibility: hidden;
   transform: translate3d(0, 0, 0);
-  -webkit-transform: translate3d(0, 0, 0);
-  -moz-transform: translate3d(0, 0, 0);
 
   $list-colors: ('light'); // add supported list item theme colors here
   @each $color-name, $color-value in $list-colors {


### PR DESCRIPTION
Closes #863 

The bug is a known issue on safari when combining use of `overflow`, `border-radius` and `transform`.

Fixed by setting the `backface-visibility` and `transform` on the parent element with the `border-radius`.

### Safari Before
![image](https://user-images.githubusercontent.com/46445487/72261727-a9d8eb00-3615-11ea-8099-6f4d87ee7d91.png)


### Safari After
![image](https://user-images.githubusercontent.com/46445487/72261520-49e24480-3615-11ea-91a3-931a8b9f4bd8.png)
