### PR TITLE
Perf/performance update to kirby list

### DIFF
--- a/src/kirby/components/list/directives/infinite-scroll.directive.spec.ts
+++ b/src/kirby/components/list/directives/infinite-scroll.directive.spec.ts
@@ -1,4 +1,4 @@
-import { ElementRef } from '@angular/core';
+import { ElementRef, NgZone } from '@angular/core';
 import { fakeAsync, tick } from '@angular/core/testing';
 import { SpyObject } from '@ngneat/spectator';
 
@@ -18,9 +18,18 @@ describe('InfiniteScrollDirective', () => {
     nativeElement.closest.and.returnValue(null);
     document.getElementsByTagName.and.returnValue([]);
 
+    const mockNgZone: SpyObject<NgZone> = jasmine.createSpyObj('ngZone', [
+      'runOutsideAngular',
+      'run',
+    ]);
+
+    mockNgZone.run.and.callFake((fn) => fn());
+    mockNgZone.runOutsideAngular.and.callFake((fn) => fn());
+
     const directive = new InfiniteScrollDirective(
       { nativeElement } as ElementRef,
-      { nativeWindow: { innerHeight: viewHeight, document: document as Document } } as WindowRef
+      { nativeWindow: { innerHeight: viewHeight, document: document as Document } } as WindowRef,
+      mockNgZone
     );
     spyOn(directive.scrollEnd, 'emit');
     directive.ngAfterViewInit();

--- a/src/kirby/components/list/list.component.html
+++ b/src/kirby/components/list/list.component.html
@@ -30,7 +30,7 @@
 </div>
 
 <ng-template #groupedListTemplate>
-  <ion-item-group *ngFor="let section of groupedItems; trackBy: defaultTrackBy">
+  <ion-item-group *ngFor="let section of groupedItems; trackBy: sectionTrackBy">
     <ion-item-divider>
       <ng-container
         *ngTemplateOutlet="sectionHeaderTemplate; context: { $implicit: section.name }"

--- a/src/kirby/components/list/list.component.ts
+++ b/src/kirby/components/list/list.component.ts
@@ -181,6 +181,10 @@ export class ListComponent implements OnInit, AfterViewInit, OnChanges {
     return index;
   }
 
+  sectionTrackBy(_: number, section: { name: string }): string {
+    return section.name;
+  }
+
   getSwipeActionsSide(side: 'left' | 'right', item: any): ListSwipeAction[] {
     if (!Array.isArray(this.swipeActions)) {
       return [];


### PR DESCRIPTION
This a 2 part performance update but both are about cutting down on change detections runs.

The first change is in regard to the `trackBy` on sections in the list. It was set to the default `trackBy` that uses the `index`. I have changed this to use the `name` property of the sections, as this is a know property. This cut down the change detection runs, if you made changes to the items in list, for example use`loadOnDemand`.

The second change is in regard to the `InfiniteScroll` directive.  Based on this [blog post](https://netbasal.com/optimizing-angular-change-detection-triggered-by-dom-events-d2a3b2e11d87), i have made so, that we listen for `ionScroll` event outside the angular context, again to cut down on runs of the change detection.