### PR TITLE
Segmented control accessibility

### DIFF
--- a/src/app/examples/segmented-control-example/segmented-control-example.component.ts
+++ b/src/app/examples/segmented-control-example/segmented-control-example.component.ts
@@ -48,6 +48,7 @@ export class SegmentedControlExampleComponent implements OnInit, OnChanges {
         id: 'first',
         badge: {
           content: '4',
+          description: '4 unread messages',
           themeColor: 'warning',
         },
       });

--- a/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
+++ b/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
@@ -17,12 +17,12 @@
 
   <div class="badge-note">
     <p>
-      <sup>*</sup> If you want a badge on the segment-item then you add a badge object in the
-      SegmentItem array. Note that badges are only applied when the mode is 'default'.See the
-      interface
+      <sup>*</sup> If you want a badge on the SegmentItem then you add a badge object in the
+      SegmentItem array. The description of the badge is used as aria-label. Note that badges are
+      only applied when the mode is 'default'.
       <a
         href="https://github.com/kirbydesign/designsystem/blob/master/src/kirby/components/segmented-control/segment-item.ts"
-        >here</a
+        >See the interface for SegmentItem</a
       >.
     </p>
   </div>

--- a/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.ts
+++ b/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.ts
@@ -25,7 +25,7 @@ export class SegmentedControlShowcaseComponent implements OnInit {
       description: 'Array of SegmentItem controls',
       defaultValue: '',
       inputValues: [
-        '[{ text: string, id: string, checked: boolean, badge?: {content: string, themeColor: ThemeColor}}]',
+        '[{ text: string, id: string, checked: boolean, badge?: {content: string, description?: string, themeColor: ThemeColor}}]',
       ],
     },
   ];

--- a/src/kirby/components/segmented-control/segment-item.ts
+++ b/src/kirby/components/segmented-control/segment-item.ts
@@ -6,6 +6,7 @@ export interface SegmentItem {
   checked?: boolean;
   badge?: {
     content: string;
+    description?: string;
     themeColor: ThemeColor;
   };
 }

--- a/src/kirby/components/segmented-control/segmented-control.component.html
+++ b/src/kirby/components/segmented-control/segmented-control.component.html
@@ -8,9 +8,13 @@
     >
       {{ item.text }}
     </ion-segment-button>
-    <span *ngIf="item.badge" role="text" [attr.aria-label]="item.badge.description">
-      <kirby-badge [themeColor]="item.badge.themeColor">{{ item.badge.content }}</kirby-badge>
-    </span>
+    <kirby-badge
+      *ngIf="item.badge"
+      role="text"
+      [attr.aria-label]="item.badge.description"
+      [themeColor]="item.badge.themeColor"
+      >{{ item.badge.content }}</kirby-badge
+    >
   </div>
 </ion-segment>
 

--- a/src/kirby/components/segmented-control/segmented-control.component.html
+++ b/src/kirby/components/segmented-control/segmented-control.component.html
@@ -1,8 +1,5 @@
 <ion-segment mode="ios" *ngIf="isDefaultMode">
-  <div class="segment-btn-wrapper" *ngFor="let item of items">
-    <kirby-badge *ngIf="item.badge" [themeColor]="item.badge.themeColor">{{
-      item.badge.content
-    }}</kirby-badge>
+  <div class="segment-btn-wrapper" *ngFor="let item of items" role="group">
     <ion-segment-button
       [value]="item"
       class="kirby-text-small"
@@ -11,14 +8,21 @@
     >
       {{ item.text }}
     </ion-segment-button>
+    <span role="text" [attr.aria-label]="item.badge.description">
+      <kirby-badge *ngIf="item.badge" [themeColor]="item.badge.themeColor">{{
+        item.badge.content
+      }}</kirby-badge>
+    </span>
   </div>
 </ion-segment>
 
-<div class="scrollable" *ngIf="isChipMode">
+<div class="scrollable" role="group" *ngIf="isChipMode">
   <kirby-chip
     [text]="item.text"
     [isSelected]="item.checked"
+    [attr.aria-selected]="item.checked"
     (click)="onSegmentSelect(item)"
     *ngFor="let item of items"
+    role="button"
   ></kirby-chip>
 </div>

--- a/src/kirby/components/segmented-control/segmented-control.component.html
+++ b/src/kirby/components/segmented-control/segmented-control.component.html
@@ -8,10 +8,8 @@
     >
       {{ item.text }}
     </ion-segment-button>
-    <span role="text" [attr.aria-label]="item.badge.description">
-      <kirby-badge *ngIf="item.badge" [themeColor]="item.badge.themeColor">{{
-        item.badge.content
-      }}</kirby-badge>
+    <span *ngIf="item.badge" role="text" [attr.aria-label]="item.badge.description">
+      <kirby-badge [themeColor]="item.badge.themeColor">{{ item.badge.content }}</kirby-badge>
     </span>
   </div>
 </ion-segment>


### PR DESCRIPTION
SegmentedControl is now more accessible by people with low vision. 

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [x] Other... Please describe: Accessibility improvements

## What is the current behavior?

When a screen reader reads a segmented control it does the following:
- For default mode, the badge is read a text **before** the button
- For chip mode, every chip is read as text

## What is the new behavior?

When a screen reader reads a segmented control it does the following:
- For default mode, the badge is read a text **after** the button, and the `description` of the badge is read instead of the text in the badge
- For chip mode, every chip is read as a button

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
