### PR TITLE
Makes it possible to toggle scroll Y of modals

### DIFF
--- a/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.html
+++ b/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.html
@@ -7,6 +7,7 @@
   <button kirby-button (click)="showNestedModal()">Show nested modal</button>
   <button kirby-button (click)="showNestedDrawer()">Show nested drawer</button>
   <button kirby-button (click)="scrollToBottom()">Scroll to bottom</button>
+  <button kirby-button (click)="toggleScrollY()">Toggle ScrollY</button>
   <div>
     <h4>The standard Lorem Ipsum passage, used since the 1500s</h4>
     <p>

--- a/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.ts
@@ -54,6 +54,10 @@ export class FirstEmbeddedModalExampleComponent {
     this.modalController.scrollToTop(KirbyAnimation.Duration.LONG);
   }
 
+  toggleScrollY() {
+    this.modalController.toggleScrollY();
+  }
+
   onHideFirst() {
     let someTestData: number = Math.PI;
     this.modalController.hideTopmost(someTestData);

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
@@ -71,7 +71,7 @@ myCallback(dataReturnedByModal: any) {{ '{' }}
     The <code>ModalController</code> support scrolling to the top and bottom of the modal using the
     methods <code>scrollToTop</code> and <code>scrollToBottom</code>. They accept
     <code>KirbyAnimation.Duration</code> as optional param. If not provided the scrolling will
-    happen instantaneously.
+    happen instantaneously.You can also disable / enable scrollY with <code>toggleScrollY</code>
   </p>
   <br />
 
@@ -88,6 +88,14 @@ myCallback(dataReturnedByModal: any) {{ '{' }}
     <cookbook-code-viewer language="ts">this.modalController.scrollToBottom();</cookbook-code-viewer>
   </p>
   <br />
+
+  <p>
+    <code>toggleScrollY</code> example:
+    <!-- prettier-ignore -->
+    <cookbook-code-viewer language="ts">this.modalController.toggleScrollY();</cookbook-code-viewer>
+  </p>
+  <br />
+
   <h3>Inside the embedded component:</h3>
   <p>To create a embedded component, ensure:</p>
   <ol>
@@ -112,6 +120,7 @@ myCallback(dataReturnedByModal: any) {{ '{' }}
 ) {{ '{' }}
     this.props = componentProps;
 {{ '}' }}</cookbook-code-viewer
+
 
   ><br />
   <p>

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
@@ -35,6 +35,11 @@ export class ModalWrapperComponent {
   private registerScrolling(modal: Modal) {
     modal.scrollToTop = this.scrollToTop.bind(this);
     modal.scrollToBottom = this.scrollToBottom.bind(this);
+    modal.toggleScrollY = this.toggleScrollY.bind(this);
+  }
+
+  private toggleScrollY() {
+    this.ionContent.scrollY = !this.ionContent.scrollY;
   }
 
   private scrollToTop(scrollDuration?: KirbyAnimation.Duration) {

--- a/libs/designsystem/src/lib/components/modal/services/modal.controller.interface.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal.controller.interface.ts
@@ -7,6 +7,7 @@ import { Modal } from './modal.model';
 export abstract class IModalController {
   abstract scrollToTop: (duration?: KirbyAnimation.Duration) => void;
   abstract scrollToBottom: (duration?: KirbyAnimation.Duration) => void;
+  abstract toggleScrollY: () => void;
   abstract showModal(config: ModalConfig, onCloseModal?: (data?: any) => any): void;
   abstract showActionSheet(config: ActionSheetConfig, onCloseModal?: (data?: any) => any): void;
   abstract showAlert(config: AlertConfig, onCloseModal?: (result?: boolean) => boolean);

--- a/libs/designsystem/src/lib/components/modal/services/modal.controller.spec.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal.controller.spec.ts
@@ -30,6 +30,7 @@ describe('modalController', () => {
         close: mockCallback,
         scrollToTop: () => {},
         scrollToBottom: () => {},
+        toggleScrollY: () => {},
       });
       expect(() => {
         modalController.hideTopmost();
@@ -54,6 +55,14 @@ describe('modalController', () => {
       it('should throw an error when scrolling to bottom, when no modals have been opened', () => {
         expect(() => {
           modalController.scrollToBottom();
+        }).toThrow(expectedError);
+      });
+    });
+
+    describe('toggleScrollY', () => {
+      it('should throw an error when toggle scrollY, when no modals have been opened', () => {
+        expect(() => {
+          modalController.toggleScrollY();
         }).toThrow(expectedError);
       });
     });

--- a/libs/designsystem/src/lib/components/modal/services/modal.controller.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal.controller.ts
@@ -94,6 +94,14 @@ export class ModalController implements IModalController {
     modal.scrollToBottom(duration);
   }
 
+  public toggleScrollY() {
+    const modal = this.modals[this.modals.length - 1];
+    if (!modal) {
+      throw new Error(this.noModalRegisteredErrorMessage);
+    }
+    modal.toggleScrollY();
+  }
+
   private forgetTopmost(): void {
     this.modals.pop();
   }

--- a/libs/designsystem/src/lib/components/modal/services/modal.helper.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal.helper.ts
@@ -21,6 +21,7 @@ export class ModalHelper {
       close: (data?: any) => null,
       scrollToTop: () => null,
       scrollToBottom: () => null,
+      toggleScrollY: () => null,
     };
     const mergedConfig = this.mergeDefaultConfig(config);
     mergedConfig.modal = modal;

--- a/libs/designsystem/src/lib/components/modal/services/modal.model.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal.model.ts
@@ -4,4 +4,5 @@ export interface Modal {
   close: (data?: any) => void;
   scrollToTop: (scrollDuration?: KirbyAnimation.Duration) => void;
   scrollToBottom: (scrollDuration?: KirbyAnimation.Duration) => void;
+  toggleScrollY: () => void;
 }


### PR DESCRIPTION
This PR closes # NaN

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Right now you not able to disable scrolling of modals without doing ugly stuff.

Issue Number: N/A

## What is the new behavior?
Now you can toggle scroll y by using `this.modalController.toggleScrollY()` just like you would use scroll to top or bottom.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information