### PR TITLE
fix: fix reorder list rounded corners for ios

### DIFF
--- a/libs/designsystem/src/lib/components/reorder-list/reorder-list.component.scss
+++ b/libs/designsystem/src/lib/components/reorder-list/reorder-list.component.scss
@@ -73,7 +73,7 @@ kirby-card {
   }
 
   @include slotted('div:first-child>kirby-item') {
-    border-radius: $border-radius $border-radius 0 0;
+    border-radius: $border-radius;
     overflow: hidden;
   }
 

--- a/libs/designsystem/src/lib/components/reorder-list/reorder-list.component.scss
+++ b/libs/designsystem/src/lib/components/reorder-list/reorder-list.component.scss
@@ -68,8 +68,12 @@ kirby-card {
     overflow: hidden;
   }
 
+  @include slotted('div>kirby-item') {
+    z-index: 1; // for showing rounded corners on ios devices
+  }
+
   @include slotted('div:first-child>kirby-item') {
-    border-radius: $border-radius;
+    border-radius: $border-radius 0;
     overflow: hidden;
   }
 

--- a/libs/designsystem/src/lib/components/reorder-list/reorder-list.component.scss
+++ b/libs/designsystem/src/lib/components/reorder-list/reorder-list.component.scss
@@ -73,7 +73,7 @@ kirby-card {
   }
 
   @include slotted('div:first-child>kirby-item') {
-    border-radius: $border-radius 0;
+    border-radius: $border-radius $border-radius 0 0;
     overflow: hidden;
   }
 

--- a/libs/designsystem/src/lib/components/reorder-list/reorder-list.component.scss
+++ b/libs/designsystem/src/lib/components/reorder-list/reorder-list.component.scss
@@ -68,7 +68,7 @@ kirby-card {
     overflow: hidden;
   }
 
-  @include slotted('div>kirby-item') {
+  @include slotted('div kirby-item') {
     z-index: 1; // for showing rounded corners on ios devices
   }
 


### PR DESCRIPTION
This PR closes # (reference issue number here)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
No rounded corners on reorder list Kirby items
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
![image](https://user-images.githubusercontent.com/9210691/78018519-53469780-734e-11ea-94e3-47b1c8c31185.png)
Round corners for items in reorder list.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
