### PR TITLE
Fix/segmented control

### DIFF
--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
@@ -23,8 +23,8 @@
 <div class="scrollable" role="group" *ngIf="isChipMode">
   <kirby-chip
     [text]="item.text"
-    [isSelected]="item.checked"
-    [attr.aria-selected]="item.checked"
+    [isSelected]="item.id === activeSegment?.id"
+    [attr.aria-selected]="item.id === activeSegment?.id"
     (click)="onSegmentSelect(item)"
     *ngFor="let item of items"
     role="button"

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.spec.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.spec.ts
@@ -118,8 +118,7 @@ describe('SegmentedControlComponent', () => {
 
   describe('chip mode', () => {
     beforeEach(() => {
-      component.mode = 'chip';
-      spectator.detectChanges();
+      spectator.setInput('mode', 'chip');
     });
 
     it("should have a 'chip' mode when created", () => {

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.spec.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.spec.ts
@@ -63,10 +63,6 @@ describe('SegmentedControlComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should not emit segmentSelect when created', () => {
-    expect(onSegmentSelectSpy).not.toHaveBeenCalled();
-  });
-
   it('should have checked item as activeSegment when created', () => {
     expect(component.activeSegment).toBe(items[1]);
   });

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
@@ -6,6 +6,7 @@ import {
   HostBinding,
   SimpleChanges,
   OnChanges,
+  AfterViewChecked,
 } from '@angular/core';
 
 import { SegmentItem } from './segment-item';
@@ -15,7 +16,7 @@ import { SegmentItem } from './segment-item';
   templateUrl: './segmented-control.component.html',
   styleUrls: ['./segmented-control.component.scss'],
 })
-export class SegmentedControlComponent implements OnChanges {
+export class SegmentedControlComponent implements OnChanges, AfterViewChecked {
   @Output() segmentSelect: EventEmitter<SegmentItem> = new EventEmitter();
 
   @HostBinding('class.default-mode')
@@ -33,15 +34,25 @@ export class SegmentedControlComponent implements OnChanges {
 
   activeSegment: SegmentItem;
 
+  private isInitializing = false;
+
   onSegmentSelect(item: SegmentItem) {
-    this.activeSegment = item;
-    this.items.forEach((segment) => (segment.checked = this.activeSegment.id === segment.id));
-    this.segmentSelect.emit(this.activeSegment);
+    if (!this.isInitializing) {
+      this.activeSegment = item;
+      this.segmentSelect.emit(this.activeSegment);
+    }
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.items) {
-      this.activeSegment = this.items.find((item) => item.checked);
+      // Flag to prevent emitting onSegmentSelect event if previous items exists
+      // Is cleared in ngAfterViewChecked
+      this.isInitializing = true;
+      this.activeSegment = (this.items || []).find((item) => item.checked);
     }
+  }
+
+  ngAfterViewChecked(): void {
+    this.isInitializing = false;
   }
 }


### PR DESCRIPTION
This PR closes # (reference issue number here)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Segment Control emits the `onSegmentSelect` change event if items are updated.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
This fix ensures the `onSegmentSelect` change event is only fired when selecting a new segment by clicking/tapping/sliding.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
