### PR TITLE
:bug: Fix modal close button

### DIFF
--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.html
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.html
@@ -1,4 +1,4 @@
-<ion-header (touchstart)="blurActiveElement()">
+<ion-header (touchstart)="onHeaderTouchStart($event)">
   <ion-toolbar>
     <ion-title>{{ config.title }}</ion-title>
     <ion-buttons slot="start" *ngIf="config.flavor === 'drawer'">

--- a/libs/designsystem/testing-base/src/lib/components/mock.calendar.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.calendar.component.ts
@@ -15,14 +15,16 @@ import { CalendarComponent } from '@kirbydesign/designsystem';
 })
 export class MockCalendarComponent {
   @Output() dateChange = new EventEmitter<Date>();
+  @Input() timezone: 'local' | 'UTC';
   @Input() disableWeekends: boolean;
   @Input() disablePastDates: boolean;
   @Input() disableFutureDates: boolean;
-  @Input() disabledDates: Date[];
-  @Input() minDate: Date;
-  @Input() maxDate: Date;
   @Input() alwaysEnableToday: boolean;
   @Input() selectedDate: Date;
+  @Input() disabledDates: Date[];
+  @Input() todayDate: Date;
+  @Input() minDate: Date;
+  @Input() maxDate: Date;
 }
 
 // #endregion


### PR DESCRIPTION
This PR fixes a transient modal bug that was introduced with #1003
* Sometimes the blurring of an active element in the touchstart event handler prevents the tap/click handler to fire on toolbar buttons. This in turn prevents the modal from being closed on first click.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No