### PR TITLE
feat(modal): add scrollDisabled property, to toggle scrollY

### DIFF
--- a/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.html
+++ b/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.html
@@ -9,6 +9,8 @@
   <button kirby-button (click)="showNestedAlert()">Show nested alert</button>
   <button kirby-button (click)="showNestedActionSheet()">Show nested action sheet</button>
   <button kirby-button (click)="scrollToBottom()">Scroll to bottom</button>
+  <button kirby-button (click)="disableScroll()">Disable scroll</button>
+  <button kirby-button (click)="enableScroll()">Enable scroll</button>
   <div>
     <h4>The standard Lorem Ipsum passage, used since the 1500s</h4>
     <p>

--- a/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.ts
@@ -82,6 +82,14 @@ export class FirstEmbeddedModalExampleComponent {
     this.modal.scrollToTop(KirbyAnimation.Duration.LONG);
   }
 
+  disableScroll() {
+    this.modal.scrollDisabled = true;
+  }
+
+  enableScroll() {
+    this.modal.scrollDisabled = false;
+  }
+
   close() {
     let someTestData: number = Math.PI;
     this.modal.close(someTestData);

--- a/apps/cookbook/src/app/examples/modal-example/modal-example.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example.component.ts
@@ -78,6 +78,14 @@ this.modal?.scrollToTop(KirbyAnimation.Duration.LONG);
 
 // scrollToBottom example:
 this.modal?.scrollToBottom();`,
+
+  disableScrollingCodeSnippet: `import { KirbyAnimation, Modal } from '@kirbydesign/designsystem';
+...
+constructor(@Optional() @SkipSelf() private modal: Modal) {}
+
+// Disable scroll Y
+this.modal?.scrollDisabled = true;`,
+
   didPresentCodeSnippet: `constructor(@Optional() @SkipSelf() private modal: Modal) {}
 
 @ViewChild('nameInput', { static: false, read: ElementRef }) private nameInputElement: ElementRef<HTMLInputElement>;
@@ -138,6 +146,7 @@ export class ModalExampleComponent {
   didPresentCodeSnippet = config.didPresentCodeSnippet;
   willCloseCodeSnippet = config.willCloseCodeSnippet;
   scrollingCodeSnippet = config.scrollingCodeSnippet;
+  disableScrollingCodeSnippet = config.disableScrollingCodeSnippet;
   embeddedCodeSnippet = config.embeddedCodeSnippet;
   closeModalCodeSnippet = config.closeModalCodeSnippet;
 

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
@@ -28,6 +28,9 @@
         the parent/caller component
       </li>
       <li>Support for <a href="#" (click)="scrollTo(scrolling)">scrolling</a></li>
+      <li>
+        Support for <a href="#" (click)="scrollTo(disableScrolling)">disabling of scrolling</a>
+      </li>
       <li>(Optional) <a href="#" (click)="scrollTo(footer)">Fixed footer</a></li>
     </ul>
     <h2><span class="desktop">Desktop:</span><span class="mobile">Mobile:</span></h2>
@@ -132,6 +135,13 @@
   instantaneously.
 </p>
 <cookbook-code-viewer [ts]="example.scrollingCodeSnippet"></cookbook-code-viewer>
+
+<h3 #disableScrolling>Disable scrolling</h3>
+<p>
+  The <code>Modal</code> supports disabling of scrolling Y by setting the property
+  <code>scrollDisabled = true</code>
+</p>
+<cookbook-code-viewer [ts]="example.disableScrollingCodeSnippet"></cookbook-code-viewer>
 
 <h2 #footer>Footer</h2>
 <p>

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
@@ -150,8 +150,10 @@
 </p>
 <cookbook-code-viewer [html]="example.footerTemplate"></cookbook-code-viewer>
 
-<h2>Properties:</h2>
-<h3><code>ModalConfig</code></h3>
+<h2>Modal config:</h2>
+<cookbook-showcase-properties [properties]="configProperties"></cookbook-showcase-properties>
+
+<h2>Modal properties:</h2>
 <cookbook-showcase-properties [properties]="properties"></cookbook-showcase-properties>
 
 <h2>Events:</h2>

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
@@ -26,7 +26,7 @@ export class ModalShowcaseComponent implements AfterViewInit {
     return false;
   }
 
-  properties: ShowcaseProperty[] = [
+  configProperties: ShowcaseProperty[] = [
     {
       name: 'title',
       description: 'The header of the modal',
@@ -58,6 +58,15 @@ export class ModalShowcaseComponent implements AfterViewInit {
       description: 'The data to pass to the modal component.',
       defaultValue: '',
       inputValues: ['undefined | { [key: string]: any; }'],
+    },
+  ];
+
+  properties: ShowcaseProperty[] = [
+    {
+      name: 'scrollDisabled',
+      description: 'Disable scrolling of the modal',
+      inputValues: ['true', 'false'],
+      defaultValue: 'false',
     },
   ];
 

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/compact/modal-compact-wrapper.component.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/compact/modal-compact-wrapper.component.ts
@@ -21,6 +21,7 @@ import { Modal } from '../../services/modal.interfaces';
 })
 export class ModalCompactWrapperComponent implements Modal, OnInit {
   scrollY: number = Math.abs(window.scrollY);
+  scrollDisabled = false;
   @Input() config: ModalConfig;
   componentPropsInjector: Injector;
 

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.spec.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.spec.ts
@@ -198,6 +198,14 @@ describe('ModalWrapperComponent', () => {
     });
   });
 
+  describe('disable scroll Y', () => {
+    it('should disable scroll Y', () => {
+      const ionContent: IonContent = spectator.query(IonContent);
+      spectator.component.scrollDisabled = true;
+      expect(ionContent.scrollY).toBeFalse;
+    });
+  });
+
   describe('with embedded component with static footer', () => {
     beforeEach(() => {
       spectator = createComponent({

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
@@ -34,6 +34,10 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
   static readonly KEYBOARD_HIDE_DELAY_IN_MS = 100;
 
   scrollY: number = Math.abs(window.scrollY);
+  set scrollDisabled(disabled: boolean) {
+    this.ionContent.scrollY = !disabled;
+  }
+
   @Input() config: ModalConfig;
   componentPropsInjector: Injector;
 
@@ -51,7 +55,6 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
   private delayedCloseTimeoutId;
   private initialViewportHeight: number;
   private viewportResized = false;
-
   private ionModalElement: HTMLIonModalElement;
   private readonly ionModalDidPresent = new Subject<void>();
   readonly didPresent = this.ionModalDidPresent.toPromise();

--- a/libs/designsystem/src/lib/components/modal/services/modal.interfaces.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal.interfaces.ts
@@ -11,10 +11,10 @@ export interface Overlay {
 }
 
 export abstract class Modal {
-  scrollDisabled: boolean;
   didPresent: Promise<void>;
   willClose: Promise<void>;
   close: (data?: any) => Promise<void>;
   scrollToTop: (scrollDuration?: KirbyAnimation.Duration) => void;
   scrollToBottom: (scrollDuration?: KirbyAnimation.Duration) => void;
+  scrollDisabled: boolean;
 }

--- a/libs/designsystem/src/lib/components/modal/services/modal.interfaces.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal.interfaces.ts
@@ -11,6 +11,7 @@ export interface Overlay {
 }
 
 export abstract class Modal {
+  scrollDisabled: boolean;
   didPresent: Promise<void>;
   willClose: Promise<void>;
   close: (data?: any) => Promise<void>;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
With the current behaviour you can't disable scrolling of a modal

## What is the new behavior?
You can now toggle scrolling of a modal by setting scrollDisabled=true|false

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No