### PR TITLE
kirby item is now correctly rendered behind the kirby card

### DIFF
--- a/apps/cookbook/src/app/examples/item-example/examples/card.ts
+++ b/apps/cookbook/src/app/examples/item-example/examples/card.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+
+const config = {
+  selector: 'cookbook-item-example-card',
+  template: `<kirby-card>
+  <kirby-item selectable="true">
+    <h3>Title</h3>
+    <kirby-toggle slot="end"></kirby-toggle>
+  </kirby-item>
+</kirby-card>`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+})
+export class ItemExampleCardComponent {
+  template: string = config.template;
+}

--- a/apps/cookbook/src/app/examples/item-example/item-example.component.html
+++ b/apps/cookbook/src/app/examples/item-example/item-example.component.html
@@ -35,3 +35,6 @@
 
 <h2>Button</h2>
 <cookbook-item-example-button></cookbook-item-example-button>
+
+<h2>Card</h2>
+<cookbook-item-example-card></cookbook-item-example-card>

--- a/apps/cookbook/src/app/examples/item-example/item-example.module.ts
+++ b/apps/cookbook/src/app/examples/item-example/item-example.module.ts
@@ -25,6 +25,7 @@ import { ItemExampleButtonComponent } from './examples/button';
 import { ItemExampleSimpleMediumComponent } from './examples/simple/default-md';
 import { ItemExampleSimpleSmallComponent } from './examples/simple/default-sm';
 import { ItemExampleSimpleExtraSmallComponent } from './examples/simple/default-xs';
+import { ItemExampleCardComponent } from './examples/card';
 
 const COMPONENT_DECLARATIONS = [
   ItemExampleSimpleComponent,
@@ -50,6 +51,7 @@ const COMPONENT_DECLARATIONS = [
   ItemExampleAvatarFlaggedThreeLinesComponent,
   ItemExampleButtonComponent,
   ItemExampleHorizontalComponent,
+  ItemExampleCardComponent,
 ];
 
 @NgModule({

--- a/apps/cookbook/src/app/showcase/item-showcase/item-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/item-showcase/item-showcase.component.html
@@ -200,3 +200,8 @@
 <cookbook-example-viewer [html]="buttonExample.template">
   <cookbook-item-example-button #buttonExample></cookbook-item-example-button>
 </cookbook-example-viewer>
+
+<h2>Card with item</h2>
+<cookbook-example-viewer [html]="cardExample.template">
+  <cookbook-item-example-card #cardExample></cookbook-item-example-card>
+</cookbook-example-viewer>

--- a/libs/designsystem/src/lib/components/card/card.component.scss
+++ b/libs/designsystem/src/lib/components/card/card.component.scss
@@ -16,6 +16,7 @@
   flex-direction: column;
   justify-content: space-between;
   overflow: hidden;
+  z-index: 1;
 
   .content-wrapper {
     &.padding {

--- a/libs/designsystem/src/lib/components/card/card.component.scss
+++ b/libs/designsystem/src/lib/components/card/card.component.scss
@@ -16,7 +16,8 @@
   flex-direction: column;
   justify-content: space-between;
   overflow: hidden;
-  z-index: 1;
+  position: relative;
+  z-index: z('default');
 
   .content-wrapper {
     &.padding {


### PR DESCRIPTION
closes #1052

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 1052

## What is the new behavior?
The kirby-card is no longer sqaure if it includes a kirby-item.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
