### PR TITLE
Bugfix: Modal fixed footer failed to follow keyboard

### DIFF
--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
@@ -255,8 +255,10 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
             (node) => node.nodeName === 'KIRBY-MODAL-FOOTER'
           );
         })[0];
-      this.embeddedFooterElement = <HTMLElement>addedFooter;
-      this.moveEmbeddedFooter();
+      if (addedFooter) {
+        this.embeddedFooterElement = <HTMLElement>addedFooter;
+        this.moveEmbeddedFooter();
+      }
     };
     this.mutationObserver = new MutationObserver(callback);
     this.mutationObserver.observe(embeddedComponentElement, {


### PR DESCRIPTION
It seems like I managed to break the functionality during the previous PR cleanup.

The problem: observeEmbeddedFooter() would be triggered as the footer appeared,
then triggered again as the footer disappeared (as a direct result of it being moved).
In both cases, a reference was stored to the element, but as the element was (re)moved,
the reference was effectively lost. Thus, any subsequent attempt to set --keyboard-offset
would skip setting it on the footer.

TL;DR: duh!

Fixed by reintroducing the check that made logic run only for the footer being added.

This PR closes # (reference issue number here)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
