### PR TITLE
Fix/avatar default bg

### DIFF
--- a/apps/cookbook/src/app/examples/avatar-example/examples/badge.scss
+++ b/apps/cookbook/src/app/examples/avatar-example/examples/badge.scss
@@ -1,6 +1,5 @@
 @import './avatar-examples.shared.scss';
 
 :host {
-  background-color: get-color('white');
   padding: size('l');
 }

--- a/libs/designsystem/src/lib/components/avatar/avatar.component.scss
+++ b/libs/designsystem/src/lib/components/avatar/avatar.component.scss
@@ -37,7 +37,7 @@ $badge-diameter: $avatar-badge-size;
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: get-color('light');
+  background-color: get-color('white');
   color: get-color('light-contrast');
 
   //default to icon size 'sm'

--- a/libs/designsystem/src/lib/components/avatar/avatar.component.spec.ts
+++ b/libs/designsystem/src/lib/components/avatar/avatar.component.spec.ts
@@ -42,7 +42,7 @@ describe('AvatarComponent', () => {
 
     const avatar = spectator.queryHost<HTMLElement>('.avatar');
     expect(avatar).toHaveComputedStyle({
-      'background-color': getColor('light'),
+      'background-color': getColor('white'),
       color: getColor('light', 'contrast'),
     });
   });


### PR DESCRIPTION
This PR changes the default background-color of the avatar from light -> white

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been updated (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Avatar default background-color is light

Issue Number: N/A

## What is the new behavior?
Avatar default background-color is white

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
White background-color of avatar-with-badge example has also been removed. 
This change has been requested by @bommariusser 