### PR TITLE
Added explicit default padding to input field

### DIFF
--- a/libs/designsystem/src/lib/components/form-field/_form-field-inputs.shared.scss
+++ b/libs/designsystem/src/lib/components/form-field/_form-field-inputs.shared.scss
@@ -31,6 +31,7 @@ $form-field-label-height: 24px;
   line-height: line-height('n');
   outline: none;
   margin: 0;
+  padding: 0;
   -webkit-appearance: none;
 
   &:not(.borderless) {
@@ -58,6 +59,6 @@ $form-field-label-height: 24px;
 :host-context(kirby-item) {
   border-radius: 0 !important;
   box-shadow: none !important;
-  padding: 1px 2px !important;
+  padding: 0 !important;
   width: auto !important;
 }

--- a/libs/designsystem/src/lib/components/form-field/input/input.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/form-field/input/input.component.integration.spec.ts
@@ -22,9 +22,9 @@ describe('InputComponent in Item', () => {
     element = spectator.element as HTMLInputElement;
   });
 
-  it('should render with default padding', () => {
+  it('should render with correct padding', () => {
     expect(element).toHaveComputedStyle({
-      padding: '1px 2px',
+      padding: '0px',
     });
   });
 

--- a/libs/designsystem/src/lib/components/form-field/input/input.component.spec.ts
+++ b/libs/designsystem/src/lib/components/form-field/input/input.component.spec.ts
@@ -90,12 +90,11 @@ describe('InputComponent', () => {
       spectator.detectChanges();
     });
 
-    // TODO: Fails on Jenkins but passes on Travis. Ignore for now investigate later
-    // it('should render with default padding', () => {
-    //   expect(element).toHaveComputedStyle({
-    //     padding: '1px 2px',
-    //   });
-    // });
+    it('should render with correct padding', () => {
+      expect(element).toHaveComputedStyle({
+        padding: '0px',
+      });
+    });
 
     it('should render without border-radius', () => {
       expect(element).toHaveComputedStyle({


### PR DESCRIPTION
This PR closes # (reference issue number here)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
Added explicit default padding to input element of 0px and un-commented a test that previously failed on Jenkins.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
