### PR TITLE
Added xs sized icon support

### DIFF
--- a/libs/designsystem/src/lib/components/icon/_icon.component.shared.scss
+++ b/libs/designsystem/src/lib/components/icon/_icon.component.shared.scss
@@ -1,4 +1,5 @@
 $_icon-font-size-map: (
+  'xs': size('s'),
   'sm': size('m'),
   'md': size('l'),
   'lg': size('xxxl'),

--- a/libs/designsystem/src/lib/components/icon/icon.component.scss
+++ b/libs/designsystem/src/lib/components/icon/icon.component.scss
@@ -15,6 +15,10 @@
   }
 }
 
+:host(.xs) {
+  --kirby-icon-font-size: #{icon-font-size('xs')};
+}
+
 :host(.sm) {
   --kirby-icon-font-size: #{icon-font-size('sm')};
 }


### PR DESCRIPTION
This PR closes # N/A

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Add xs size support for icons

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently icons with size 'xs' are shown in Cookbook - however they are displayed with the same size as icons having size 's'. 

Issue Number: N/A

## What is the new behavior?

When specifying size xs on an icon, it is now correctly rendered as font-size('s') ie. 16px

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
