### PR TITLE
:art: Removing max-width for ion-header and ion-toolbar on tablet

### DIFF
--- a/libs/designsystem/src/lib/components/page/page.component.scss
+++ b/libs/designsystem/src/lib/components/page/page.component.scss
@@ -6,8 +6,13 @@
 ion-header,
 ion-toolbar {
   --background: #{get-color('background-color')};
-  max-width: 768px;
   margin: 0 auto;
+
+  @include media('>=large') {
+    @include not-touch {
+      max-width: 768px;
+    }
+  }
 }
 
 ion-toolbar {


### PR DESCRIPTION
This PR closes # (reference issue number here)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently the page toolbar is capped at 768px max-width.

See: https://github.com/kirbydesign/designsystem/issues/965
Issue Number: 965

## What is the new behavior?
max-width is only enforced if toolbar is displayed on a large non-touch device. This way the toolbar will be full width as is expected on native devices.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
