### PR TITLE
fix(list): ensure round corners at iOS, before round corners could disappear when rotating an iPad in special scenarios

### DIFF
--- a/libs/designsystem/src/lib/components/list/list.component.scss
+++ b/libs/designsystem/src/lib/components/list/list.component.scss
@@ -178,6 +178,10 @@ ion-item-options[side='end'] {
   ion-list-header {
     border-top-left-radius: $border-radius;
     border-top-right-radius: $border-radius;
+    -webkit-mask-image: -webkit-radial-gradient(
+      white,
+      black
+    ); // Solves issues with round borders at iOS in certain scenarios
   }
 
   ion-list ion-item-sliding > ion-item,
@@ -192,6 +196,10 @@ ion-item-options[side='end'] {
   .footer {
     border-bottom-left-radius: $border-radius;
     border-bottom-right-radius: $border-radius;
+    -webkit-mask-image: -webkit-radial-gradient(
+      white,
+      black
+    ); // Solves issues with round borders at iOS in certain scenarios
   }
 
   ion-list ion-item-sliding > ion-item,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
In some scenarios at iOS the round corners are overflowed and therefore disappear 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Adding following at ion-item-sliding ensures that doesn't happen:
`-webkit-mask-image: -webkit-radial-gradient(
      white,
      black
    );`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
