### PR TITLE
Modal footer snap to keyboard optional

### DIFF
--- a/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.html
+++ b/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.html
@@ -76,9 +76,20 @@
   </div>
   <button *ngIf="!showFooter" kirby-button (click)="scrollToTop()">Scroll to top</button>
 </div>
-<kirby-modal-footer *ngIf="showFooter">
-  <button attentionLevel="3" style="flex-grow: 1;" kirby-button (click)="scrollToTop()">
-    To top
-  </button>
-  <button style="flex-grow: 1;" kirby-button (click)="close()">Close</button>
+<kirby-modal-footer *ngIf="showFooter" [snapToKeyboard]="snapFooterToKeyboard">
+  <div>
+    <div>
+      <button attentionLevel="3" style="flex-grow: 1;" kirby-button (click)="scrollToTop()">
+        To top
+      </button>
+      <button style="flex-grow: 1;" kirby-button (click)="close()">Close</button>
+    </div>
+    <div>
+      <kirby-checkbox
+        checked="false"
+        (checkedChange)="onSnapFooterToKeyboardCheckbox($event)"
+      ></kirby-checkbox
+      ><label>Snap footer to keyboard</label>
+    </div>
+  </div>
 </kirby-modal-footer>

--- a/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.scss
+++ b/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.scss
@@ -1,0 +1,8 @@
+@import './libs/designsystem/src/lib/scss/utils';
+
+kirby-modal-footer label {
+  font-size: font-size('xs');
+  position: relative;
+  top: -4px;
+  padding-left: 10px;
+}

--- a/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.ts
@@ -10,10 +10,12 @@ import { SecondEmbeddedModalExampleComponent } from '../second-embedded-modal-ex
 @Component({
   selector: 'cookbook-first-embedded-modal-example',
   templateUrl: './first-embedded-modal-example.component.html',
+  styleUrls: ['./first-embedded-modal-example.component.scss'],
 })
 export class FirstEmbeddedModalExampleComponent {
   props: { [key: string]: any };
-  showFooter: boolean = true;
+  showFooter = true;
+  snapFooterToKeyboard = false;
 
   constructor(
     @Inject(COMPONENT_PROPS) componentProps,
@@ -107,6 +109,10 @@ export class FirstEmbeddedModalExampleComponent {
       durationInMs: 1500,
     };
     this.toastController.showToast(config);
+  }
+
+  onSnapFooterToKeyboardCheckbox(checked: boolean) {
+    this.snapFooterToKeyboard = checked;
   }
 
   onAlertClose(result?: boolean): void {

--- a/apps/cookbook/src/app/examples/modal-example/modal-example.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example.component.ts
@@ -13,7 +13,7 @@ const config = {
 <button kirby-button (click)="showModalWithFooter()">Show modal with footer</button>`,
   footerTemplate: `<p>Some content of the embedded component</p>
 ...
-<kirby-modal-footer [snapToKeyboard]="false">
+<kirby-modal-footer>
   <button kirby-button (click)="scrollToBottom()">Scroll to bottom</button>
 </kirby-modal-footer>`,
   defaultCodeSnippet: `constructor(private modalController: ModalController) {}

--- a/apps/cookbook/src/app/examples/modal-example/modal-example.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 
 import { ModalConfig, ModalController } from '@kirbydesign/designsystem';
+
 import { FirstEmbeddedModalExampleComponent } from './first-embedded-modal-example/first-embedded-modal-example.component';
 import { ModalCompactExampleComponent } from './compact-example/modal-compact-example.component';
 
@@ -12,7 +13,7 @@ const config = {
 <button kirby-button (click)="showModalWithFooter()">Show modal with footer</button>`,
   footerTemplate: `<p>Some content of the embedded component</p>
 ...
-<kirby-modal-footer>
+<kirby-modal-footer [snapToKeyboard]="false">
   <button kirby-button (click)="scrollToBottom()">Scroll to bottom</button>
 </kirby-modal-footer>`,
   defaultCodeSnippet: `constructor(private modalController: ModalController) {}

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
@@ -150,6 +150,12 @@
 </p>
 <cookbook-code-viewer [html]="example.footerTemplate"></cookbook-code-viewer>
 
+<p>
+  If the <code>snapToKeyboard</code> attribute is set to true, the modal footer will slide upwards
+  with the soft keyboard on mobile devices to make it stay visible. If omitted, or if explicitly set
+  to false, the modal footer will stay at the bottom and the keyboard will slide in on top of it.
+</p>
+
 <h2>Modal config:</h2>
 <cookbook-showcase-properties [properties]="configProperties"></cookbook-showcase-properties>
 

--- a/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.scss
+++ b/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.scss
@@ -7,6 +7,6 @@ ion-footer {
   align-items: center;
   background-color: get-color('white');
   padding: size('s');
-  padding-bottom: calc(#{size('s')} + var(--keyboard-offset, 0px));
+  padding-bottom: calc(#{size('s')} + var(--keyboard-offset, 0px) * var(--snap-to-keyboard, 0));
   transition: padding-bottom $soft-keyboard-transition;
 }

--- a/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.scss
+++ b/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.scss
@@ -7,10 +7,9 @@ ion-footer {
   align-items: center;
   background-color: get-color('white');
   padding: size('s');
-  padding-bottom: size('s');
-  transition: padding-bottom $soft-keyboard-transition;
 }
 
 :host(.snap-to-keyboard) ion-footer {
   padding-bottom: calc(#{size('s')} + var(--keyboard-offset, 0px));
+  transition: padding-bottom $soft-keyboard-transition;
 }

--- a/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.scss
+++ b/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.scss
@@ -7,6 +7,10 @@ ion-footer {
   align-items: center;
   background-color: get-color('white');
   padding: size('s');
-  padding-bottom: calc(#{size('s')} + var(--keyboard-offset, 0px) * var(--snap-to-keyboard, 0));
+  padding-bottom: size('s');
   transition: padding-bottom $soft-keyboard-transition;
+}
+
+:host(.snap-to-keyboard) ion-footer {
+  padding-bottom: calc(#{size('s')} + var(--keyboard-offset, 0px));
 }

--- a/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.spec.ts
+++ b/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.spec.ts
@@ -1,0 +1,81 @@
+import { Component } from '@angular/core';
+import { IonFooter } from '@ionic/angular';
+import { MockComponents } from 'ng-mocks';
+import { createComponentFactory, Spectator } from '@ngneat/spectator';
+
+import { TestHelper } from '../../../testing/test-helper';
+import { ModalFooterComponent } from '../footer/modal-footer.component';
+
+@Component({
+  template: '<kirby-modal-footer [snapToKeyboard]="snapToKeyboard"></kirby-modal-footer>',
+})
+class TestHostComponent {
+  snapToKeyboard = false;
+}
+
+describe('ModalWrapperComponent', () => {
+  let spectator: Spectator<TestHostComponent>;
+  let modalFooterElement: HTMLElement;
+  let ionFooterElement: HTMLIonFooterElement;
+
+  const createComponent = createComponentFactory({
+    component: TestHostComponent,
+    entryComponents: [],
+    declarations: [TestHostComponent, ModalFooterComponent, MockComponents(IonFooter)],
+  });
+
+  beforeEach(() => {
+    spectator = createComponent();
+    modalFooterElement = spectator.element.querySelector('kirby-modal-footer');
+    ionFooterElement = spectator.element.querySelector('ion-footer');
+  });
+
+  it('should create', () => {
+    expect(spectator.component).toBeTruthy();
+  });
+
+  describe('Snap to keyboard', () => {
+    describe('when snapToKeyboard is true', () => {
+      beforeEach(() => spectator.setInput('snapToKeyboard', true));
+
+      it('should follow the keyboard up', () => {
+        keyboardSlideIn();
+        expectPaddingBottom().toEqual(PADDING_BOTTOM_PUSHED_BY_KEYBOARD);
+      });
+
+      it('should follow the keyboard down', () => {
+        keyboardSlideOut();
+        expectPaddingBottom().toEqual(PADDING_BOTTOM_NOT_PUSHED_BY_KEYBOARD);
+      });
+    });
+
+    describe('when snapToKeyboard is false', () => {
+      beforeEach(() => spectator.setInput('snapToKeyboard', false));
+
+      it('should not follow the keyboard up', () => {
+        keyboardSlideIn();
+        expectPaddingBottom().toEqual(PADDING_BOTTOM_NOT_PUSHED_BY_KEYBOARD);
+      });
+    });
+  });
+
+  // utility constants and functions
+
+  const KEYBOARD_HEIGHT_PX = 216; // sample value, depends upon device
+  const BASE_PADDING_PX = 16;
+
+  const PADDING_BOTTOM_NOT_PUSHED_BY_KEYBOARD = BASE_PADDING_PX + 'px';
+  const PADDING_BOTTOM_PUSHED_BY_KEYBOARD = BASE_PADDING_PX + KEYBOARD_HEIGHT_PX + 'px';
+
+  function keyboardSlideIn() {
+    modalFooterElement.style.setProperty('--keyboard-offset', KEYBOARD_HEIGHT_PX + 'px');
+  }
+
+  function keyboardSlideOut() {
+    modalFooterElement.style.setProperty('--keyboard-offset', '0px');
+  }
+
+  function expectPaddingBottom() {
+    return expect(TestHelper.getCssProperty(ionFooterElement, 'padding-bottom'));
+  }
+});

--- a/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.ts
+++ b/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.ts
@@ -6,5 +6,7 @@ import { Component, Input, HostBinding } from '@angular/core';
   styleUrls: ['./modal-footer.component.scss'],
 })
 export class ModalFooterComponent {
-  @HostBinding('class.snap-to-keyboard') @Input() snapToKeyboard = false;
+  @HostBinding('class.snap-to-keyboard')
+  @Input()
+  snapToKeyboard = false;
 }

--- a/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.ts
+++ b/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.ts
@@ -1,32 +1,12 @@
-import { Component, Input, OnInit, ElementRef, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, Input, HostBinding } from '@angular/core';
 
 @Component({
   selector: 'kirby-modal-footer',
   templateUrl: './modal-footer.component.html',
   styleUrls: ['./modal-footer.component.scss'],
 })
-export class ModalFooterComponent implements OnInit, OnChanges {
-  @Input() snapToKeyboard = false;
+export class ModalFooterComponent {
+  @HostBinding('class.snap-to-keyboard') @Input() snapToKeyboard = false;
 
-  private kirbyModalFooterElement: HTMLElement;
-
-  constructor(private elementRef: ElementRef<HTMLElement>) {}
-
-  ngOnInit() {
-    this.kirbyModalFooterElement = this.elementRef.nativeElement;
-
-    this.setSnapToKeyboard(this.snapToKeyboard);
-  }
-
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes.snapToKeyboard && this.kirbyModalFooterElement) {
-      this.setSnapToKeyboard(changes.snapToKeyboard.currentValue);
-    }
-  }
-
-  private setSnapToKeyboard(value: boolean) {
-    if (this.kirbyModalFooterElement) {
-      this.kirbyModalFooterElement.style.setProperty('--snap-to-keyboard', value ? '1' : '0');
-    }
-  }
+  constructor() {}
 }

--- a/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.ts
+++ b/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.ts
@@ -1,8 +1,30 @@
-import { Component } from '@angular/core';
+import { Component, Input, OnInit, ElementRef, OnChanges, SimpleChanges } from '@angular/core';
 
 @Component({
   selector: 'kirby-modal-footer',
   templateUrl: './modal-footer.component.html',
   styleUrls: ['./modal-footer.component.scss'],
 })
-export class ModalFooterComponent {}
+export class ModalFooterComponent implements OnInit, OnChanges {
+  @Input() snapToKeyboard = false;
+
+  private kirbyModalFooterElement: HTMLElement;
+
+  constructor(private elementRef: ElementRef<HTMLElement>) {}
+
+  ngOnInit() {
+    this.kirbyModalFooterElement = this.elementRef.nativeElement.closest('ion-modal');
+
+    this.setSnapToKeyboard(this.snapToKeyboard);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.snapToKeyboard && this.kirbyModalFooterElement) {
+      this.setSnapToKeyboard(changes.snapToKeyboard.currentValue);
+    }
+  }
+
+  private setSnapToKeyboard(value: boolean) {
+    this.kirbyModalFooterElement.style.setProperty('--snap-to-keyboard', value ? '1' : '0');
+  }
+}

--- a/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.ts
+++ b/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.ts
@@ -13,7 +13,7 @@ export class ModalFooterComponent implements OnInit, OnChanges {
   constructor(private elementRef: ElementRef<HTMLElement>) {}
 
   ngOnInit() {
-    this.kirbyModalFooterElement = this.elementRef.nativeElement; //.nativeElement.closest('ion-footer');
+    this.kirbyModalFooterElement = this.elementRef.nativeElement;
 
     this.setSnapToKeyboard(this.snapToKeyboard);
   }

--- a/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.ts
+++ b/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.ts
@@ -13,7 +13,7 @@ export class ModalFooterComponent implements OnInit, OnChanges {
   constructor(private elementRef: ElementRef<HTMLElement>) {}
 
   ngOnInit() {
-    this.kirbyModalFooterElement = this.elementRef.nativeElement.closest('ion-modal');
+    this.kirbyModalFooterElement = this.elementRef.nativeElement; //.nativeElement.closest('ion-footer');
 
     this.setSnapToKeyboard(this.snapToKeyboard);
   }
@@ -25,6 +25,8 @@ export class ModalFooterComponent implements OnInit, OnChanges {
   }
 
   private setSnapToKeyboard(value: boolean) {
-    this.kirbyModalFooterElement.style.setProperty('--snap-to-keyboard', value ? '1' : '0');
+    if (this.kirbyModalFooterElement) {
+      this.kirbyModalFooterElement.style.setProperty('--snap-to-keyboard', value ? '1' : '0');
+    }
   }
 }

--- a/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.ts
+++ b/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.ts
@@ -7,6 +7,4 @@ import { Component, Input, HostBinding } from '@angular/core';
 })
 export class ModalFooterComponent {
   @HostBinding('class.snap-to-keyboard') @Input() snapToKeyboard = false;
-
-  constructor() {}
 }

--- a/libs/designsystem/testing-base/src/lib/components/mock.modal-footer.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.modal-footer.component.ts
@@ -13,6 +13,8 @@ import { ModalFooterComponent } from '@kirbydesign/designsystem';
     },
   ],
 })
-export class MockModalFooterComponent {}
+export class MockModalFooterComponent {
+  @Input() snapToKeyboard: boolean;
+}
 
 // #endregion

--- a/libs/designsystem/testing-base/src/lib/components/mock.modal-footer.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.modal-footer.component.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Component } from '@angular/core';
+import { forwardRef, Component, Input } from '@angular/core';
 
 import { ModalFooterComponent } from '@kirbydesign/designsystem';
 


### PR DESCRIPTION
This PR closes # (reference issue number here)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The kirby modal footer always slides in with the soft keyboard on devices.

Issue Number: N/A

## What is the new behavior?
A flag to control if the modal footer should stay fixed to the bottom or if it should slide in with ("snap to") the keyboard.

The flag has been named `snapToKeyboard` and is defined as an attribute on the `<kirby-modal-footer>` element. If omitted, it will default to false.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
This requires existing usages (there is just one) to define the flag to true to stay the same. We should make a separate bump of Kirby in DRB, fixing this as part of the bump.

## Other information
The main design decisions were made in collaboration with @jakobe prior to the summer holidays.