### PR TITLE
Bugfix: weekday labels were off when using some locales

### DIFF
--- a/libs/designsystem/src/lib/components/calendar/calendar.component.spec.ts
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.spec.ts
@@ -1,6 +1,7 @@
 import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
 import moment from 'moment';
 import { MockComponent } from 'ng-mocks';
+import { LOCALE_ID } from '@angular/core';
 
 import { CalendarComponent, IconComponent } from '..';
 
@@ -14,6 +15,13 @@ describe('CalendarComponent', () => {
   const createHost = createHostFactory({
     component: CalendarComponent,
     declarations: [CalendarComponent, MockComponent(IconComponent)],
+    providers: [
+      {
+        provide: LOCALE_ID,
+        // i.e. en-US. The week should start on Monday regardlessly
+        useValue: 'en',
+      },
+    ],
   });
 
   beforeEach(() => {
@@ -205,6 +213,15 @@ describe('CalendarComponent', () => {
     expect(spectator.component.disabledDates).toEqual(localDates);
     spectator.setInput('disabledDates', utcDates);
     expect(spectator.component.disabledDates).toEqual(localDates);
+  });
+
+  it('should render days from Monday to Sunday', () => {
+    expect(
+      spectator
+        .queryAll('.calendar-table-header th')
+        .map((_) => _.textContent)
+        .join(' ')
+    ).toEqual('M T W T F S S');
   });
 
   // constants and utility functions

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.ts
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.ts
@@ -108,9 +108,6 @@ export class CalendarComponent implements OnInit, AfterViewInit, OnChanges {
   }
 
   constructor(private calendarHelper: CalendarHelper, @Inject(LOCALE_ID) private locale: string) {
-    if (this.locale === 'en-US') {
-      this.locale = 'en-GB';
-    }
     moment.locale(this.locale);
     moment().format('YYYY-MM-DD');
   }
@@ -192,9 +189,9 @@ export class CalendarComponent implements OnInit, AfterViewInit, OnChanges {
   }
 
   private getWeekDays(): string[] {
-    return [0, 1, 2, 3, 4, 5, 6].map((index) =>
+    return [1, 2, 3, 4, 5, 6, 7].map((index) =>
       moment()
-        .weekday(index)
+        .isoWeekday(index)
         .format('dd')
         .substr(0, 1)
         .toUpperCase()


### PR DESCRIPTION
Specifically, when using locale in which weeks don't start on a Monday, such as "en-US" or "en", but presumably also a host of other locales around the globe.

This PR closes #1123

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 1123

## What is the new behavior?
Labels for weekdays are rendered Monday .. Sunday regardless of locale. This matched the dates rendered below.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
