### PR TITLE
Fix/icon component warnings

### DIFF
--- a/libs/designsystem/src/lib/components/icon/icon-registry.service.spec.ts
+++ b/libs/designsystem/src/lib/components/icon/icon-registry.service.spec.ts
@@ -1,7 +1,7 @@
 import { IconRegistryService } from './icon-registry.service';
 import { Icon, IconSettings } from './icon-settings';
 
-fdescribe('KirbyIconRegistryService', () => {
+describe('KirbyIconRegistryService', () => {
   let service: IconRegistryService;
 
   beforeEach(() => {

--- a/libs/designsystem/src/lib/components/icon/icon-registry.service.spec.ts
+++ b/libs/designsystem/src/lib/components/icon/icon-registry.service.spec.ts
@@ -1,5 +1,5 @@
 import { IconRegistryService } from './icon-registry.service';
-import { Icon, IconSettings } from './icon-settings';
+import { IconSettings } from './icon-settings';
 
 describe('KirbyIconRegistryService', () => {
   let service: IconRegistryService;
@@ -57,12 +57,47 @@ describe('KirbyIconRegistryService', () => {
       service.addIcons(icons);
       expect(service.getIcons()).toEqual(icons);
     });
+  });
+
+  describe('addIcon', () => {
+    it('should add the icon to the regitry', () => {
+      service.addIcon('name1', 'svg1');
+      expect(service.getIcons()).toEqual([{ name: 'name1', svg: 'svg1' }]);
+    });
     it('should only add distinct icon names', () => {
-      const icon1 = [{ name: 'name1', svg: 'svg1' }];
-      const icon2 = [{ name: 'name1', svg: 'svg2' }];
-      service.addIcons(icon1);
-      service.addIcons(icon2);
-      expect(service.getIcons()).toEqual(icon1);
+      service.addIcon('name1', 'svg1');
+      service.addIcon('name1', 'svg2');
+      expect(service.getIcons()).toEqual([{ name: 'name1', svg: 'svg1' }]);
+    });
+    it('should warn when overwriting existing icon name', () => {
+      spyOn(console, 'warn');
+      service.addIcon('name1', 'svg1');
+      service.addIcon('name1', 'svg2');
+      expect(console.warn).toHaveBeenCalledWith('Icon with name: "name1" already exists');
+    });
+  });
+
+  describe('addIcons', () => {
+    const icon1 = { name: 'name1', svg: 'svg1' };
+    const icon2 = { name: 'name1', svg: 'svg2' };
+    const icon3 = { name: 'name3', svg: 'svg3' };
+    const expectedIcons = [icon1, icon3];
+
+    it('should only add distinct icon names from same set', () => {
+      service.addIcons([icon1, icon2, icon3]);
+      expect(service.getIcons()).toEqual(expectedIcons);
+    });
+
+    it('should only add distinct icon names from different sets', () => {
+      service.addIcons([icon1]);
+      service.addIcons([icon2, icon3]);
+      expect(service.getIcons()).toEqual(expectedIcons);
+    });
+
+    it('should warn when overwriting existing icon name', () => {
+      spyOn(console, 'warn');
+      service.addIcons([icon1, icon2, icon3]);
+      expect(console.warn).toHaveBeenCalledWith('Icon with name: "name1" already exists');
     });
   });
 });

--- a/libs/designsystem/src/lib/components/icon/icon-registry.service.spec.ts
+++ b/libs/designsystem/src/lib/components/icon/icon-registry.service.spec.ts
@@ -1,7 +1,7 @@
 import { IconRegistryService } from './icon-registry.service';
 import { Icon, IconSettings } from './icon-settings';
 
-describe('KirbyIconRegistryService', () => {
+fdescribe('KirbyIconRegistryService', () => {
   let service: IconRegistryService;
 
   beforeEach(() => {
@@ -10,6 +10,40 @@ describe('KirbyIconRegistryService', () => {
   it('should create service', () => {
     expect(service).toBeTruthy();
   });
+  it('should register icons if injected', () => {
+    const iconSettings: IconSettings = {
+      icons: [
+        { name: 'name1', svg: 'svg1' },
+        { name: 'name2', svg: 'svg2' },
+      ],
+    };
+    service = new IconRegistryService(iconSettings);
+    expect(service.getIcons()).toEqual(iconSettings.icons);
+  });
+
+  describe('getIcon', () => {
+    it('should return undefined if no icons registered', () => {
+      expect(service.getIcon('test')).toBeUndefined();
+    });
+    it('should return undefined if no icon match name', () => {
+      const icons = [
+        { name: 'name1', svg: 'svg1' },
+        { name: 'name2', svg: 'svg2' },
+      ];
+      service.addIcons(icons);
+      expect(service.getIcon('test')).toBeUndefined();
+    });
+    it('should return icon if name matches registered icon', () => {
+      const icons = [
+        { name: 'name1', svg: 'svg1' },
+        { name: 'name2', svg: 'svg2' },
+      ];
+      service.addIcons(icons);
+      expect(service.getIcon('name1')).toEqual(icons[0]);
+      expect(service.getIcon('name2')).toEqual(icons[1]);
+    });
+  });
+
   describe('getIcons', () => {
     it('should return empty map by default', () => {
       const expectedIcons = [];

--- a/libs/designsystem/src/lib/components/icon/icon-registry.service.ts
+++ b/libs/designsystem/src/lib/components/icon/icon-registry.service.ts
@@ -1,12 +1,18 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
 
-import { Icon } from './icon-settings';
+import { Icon, IconSettings, ICON_SETTINGS } from './icon-settings';
 
 @Injectable({
   providedIn: 'root',
 })
 export class IconRegistryService {
   private iconRegistry = new Map<string, string>();
+
+  constructor(@Optional() @Inject(ICON_SETTINGS) private iconSettings?: IconSettings) {
+    if (this.iconSettings) {
+      this.addIcons(this.iconSettings.icons);
+    }
+  }
 
   addIcon(iconName: string, svgPath: string): void {
     if (!this.iconRegistry.has(iconName)) {
@@ -30,5 +36,10 @@ export class IconRegistryService {
     return [...this.iconRegistry].map(
       (keyValPair) => ({ name: keyValPair[0], svg: keyValPair[1] } as Icon)
     );
+  }
+
+  public getIcon(name: string): Icon {
+    const svg = this.iconRegistry.get(name);
+    return svg ? { name, svg } : undefined;
   }
 }

--- a/libs/designsystem/src/lib/components/icon/icon.component.spec.ts
+++ b/libs/designsystem/src/lib/components/icon/icon.component.spec.ts
@@ -12,7 +12,7 @@ import { IconRegistryService } from './icon-registry.service';
 
 const getColor = DesignTokenHelper.getColor;
 
-fdescribe('IconComponent', () => {
+describe('IconComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
@@ -41,7 +41,7 @@ fdescribe('IconComponent', () => {
   });
 
   describe('icons', () => {
-    fit('should point to the cog icon by default', () => {
+    it('should point to the cog icon by default', () => {
       const fixture = createTestComponent('<kirby-icon></kirby-icon>');
       const component = fixture.debugElement.query(By.directive(IconComponent)).componentInstance;
       expect(component.name).toBe(undefined);

--- a/libs/designsystem/src/lib/components/icon/icon.component.spec.ts
+++ b/libs/designsystem/src/lib/components/icon/icon.component.spec.ts
@@ -12,7 +12,7 @@ import { IconRegistryService } from './icon-registry.service';
 
 const getColor = DesignTokenHelper.getColor;
 
-describe('IconComponent', () => {
+fdescribe('IconComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
@@ -41,7 +41,7 @@ describe('IconComponent', () => {
   });
 
   describe('icons', () => {
-    it('should point to the cog icon by default', () => {
+    fit('should point to the cog icon by default', () => {
       const fixture = createTestComponent('<kirby-icon></kirby-icon>');
       const component = fixture.debugElement.query(By.directive(IconComponent)).componentInstance;
       expect(component.name).toBe(undefined);
@@ -55,17 +55,7 @@ describe('IconComponent', () => {
       expect(component.icon.name).toBe('verify');
     });
 
-    it('should use custom icons from ICON_SETTINGS', () => {
-      const fixture = createTestComponent(
-        `<kirby-icon customName="customIconNameFromIconSettings"></kirby-icon>`
-      );
-      fixture.detectChanges();
-      const component = fixture.debugElement.query(By.directive(IconComponent)).componentInstance;
-      expect(component.icon.name).toBe('customIconNameFromIconSettings');
-      expect(component.icon.svg).toBe('customIconSvgFromIconSettings');
-    });
-
-    it('should use custom icons added with KirbyIconRegistryService', () => {
+    it('should use custom icon from IconRegistryService', () => {
       const fixture = createTestComponent(
         `<kirby-icon customName="customIconNameFromIconRegistry"></kirby-icon>`
       );
@@ -169,10 +159,10 @@ function createTestComponent(template: string): ComponentFixture<TestWrapperComp
         {
           provide: IconRegistryService,
           useValue: createSpyObject(IconRegistryService, {
-            getIcons: () => [
-              { name: 'customIconNameFromIconRegistry', svg: 'customIconSvgFromIconRegistry' },
-              { name: 'customIconNameFromIconSettings', svg: 'customIconSvgFromIconSettings' },
-            ],
+            getIcon: (_) => ({
+              name: 'customIconNameFromIconRegistry',
+              svg: 'customIconSvgFromIconRegistry',
+            }),
           }),
         },
       ],

--- a/libs/designsystem/src/lib/components/icon/icon.component.spec.ts
+++ b/libs/designsystem/src/lib/components/icon/icon.component.spec.ts
@@ -1,9 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockComponent } from 'ng-mocks';
-import * as ionic from '@ionic/angular';
+import { IonIcon } from '@ionic/angular';
 import { By } from '@angular/platform-browser';
-import { Component, OnInit } from '@angular/core';
-import { createSpyObject } from '@ngneat/spectator';
+import { Component } from '@angular/core';
+import { mockProvider, SpyObject } from '@ngneat/spectator';
 
 import { ThemeColorDirective } from '../../directives/theme-color/theme-color.directive';
 import { DesignTokenHelper } from '../../helpers/design-token-helper';
@@ -19,8 +19,9 @@ describe('IconComponent', () => {
         IconComponent,
         ThemeColorDirective,
         TestWrapperComponent,
-        MockComponent(ionic.IonIcon),
+        MockComponent(IonIcon),
       ],
+      providers: [mockProvider(IconRegistryService)],
     });
   }));
 
@@ -41,11 +42,51 @@ describe('IconComponent', () => {
   });
 
   describe('icons', () => {
-    it('should point to the cog icon by default', () => {
+    it('should set default icon by default', () => {
       const fixture = createTestComponent('<kirby-icon></kirby-icon>');
       const component = fixture.debugElement.query(By.directive(IconComponent)).componentInstance;
       expect(component.name).toBe(undefined);
       expect(component.icon.name).toBe(component.defaultIcon.name);
+    });
+
+    it('should set default icon if icon name not found', () => {
+      const noExistingIconName = 'no-existing-icon-name';
+      const fixture = createTestComponent(`<kirby-icon name="${noExistingIconName}"></kirby-icon>`);
+      const component = fixture.debugElement.query(By.directive(IconComponent)).componentInstance;
+      expect(component.name).toBe(noExistingIconName);
+      expect(component.icon.name).toBe(component.defaultIcon.name);
+    });
+
+    it('should warn if icon name not found', () => {
+      spyOn(console, 'warn');
+      const noExistingIconName = 'no-existing-icon-name';
+      const fixture = createTestComponent(`<kirby-icon name="${noExistingIconName}"></kirby-icon>`);
+      fixture.detectChanges();
+      expect(console.warn).toHaveBeenCalledWith(
+        `Icon with name "${noExistingIconName}" was not found.`
+      );
+    });
+
+    it('should set default icon if custom icon name not found', () => {
+      const noExistingIconName = 'no-existing-custom-icon-name';
+      const fixture = createTestComponent(
+        `<kirby-icon customName="${noExistingIconName}"></kirby-icon>`
+      );
+      const component = fixture.debugElement.query(By.directive(IconComponent)).componentInstance;
+      expect(component.customName).toBe(noExistingIconName);
+      expect(component.icon.name).toBe(component.defaultIcon.name);
+    });
+
+    it('should warn if custom icon name not found', () => {
+      spyOn(console, 'warn');
+      const noExistingIconName = 'no-existing-custom-icon-name';
+      const fixture = createTestComponent(
+        `<kirby-icon customName="${noExistingIconName}"></kirby-icon>`
+      );
+      fixture.detectChanges();
+      expect(console.warn).toHaveBeenCalledWith(
+        `Icon with name "${noExistingIconName}" was not found.`
+      );
     });
 
     it('should use default icons from Kirby icon settings', () => {
@@ -59,6 +100,11 @@ describe('IconComponent', () => {
       const fixture = createTestComponent(
         `<kirby-icon customName="customIconNameFromIconRegistry"></kirby-icon>`
       );
+      const iconRegistrySpy = TestBed.inject(IconRegistryService) as SpyObject<IconRegistryService>;
+      iconRegistrySpy.getIcon.and.returnValue({
+        name: 'customIconNameFromIconRegistry',
+        svg: 'customIconSvgFromIconRegistry',
+      });
       fixture.detectChanges();
       const component = fixture.debugElement.query(By.directive(IconComponent)).componentInstance;
       expect(component.icon.name).toBe('customIconNameFromIconRegistry');
@@ -141,10 +187,7 @@ describe('IconComponent', () => {
   selector: 'kirby-test-component',
   template: '<span>PlaceHolder HTML to be Replaced</span>',
 })
-export class TestWrapperComponent implements OnInit {
-  constructor() {}
-  ngOnInit() {}
-}
+export class TestWrapperComponent {}
 
 /*
  * Custom Helper function to quickly create a `fixture` instance based on
@@ -155,17 +198,6 @@ function createTestComponent(template: string): ComponentFixture<TestWrapperComp
   return TestBed.overrideComponent(TestWrapperComponent, {
     set: {
       template: template,
-      providers: [
-        {
-          provide: IconRegistryService,
-          useValue: createSpyObject(IconRegistryService, {
-            getIcon: (_) => ({
-              name: 'customIconNameFromIconRegistry',
-              svg: 'customIconSvgFromIconRegistry',
-            }),
-          }),
-        },
-      ],
     },
   }).createComponent(TestWrapperComponent);
 }

--- a/libs/designsystem/src/lib/components/icon/icon.component.ts
+++ b/libs/designsystem/src/lib/components/icon/icon.component.ts
@@ -1,15 +1,7 @@
-import {
-  Component,
-  HostBinding,
-  Inject,
-  Input,
-  OnChanges,
-  Optional,
-  SimpleChanges,
-} from '@angular/core';
+import { Component, HostBinding, Input, OnChanges, SimpleChanges } from '@angular/core';
 
 import { kirbyIconSettings } from './kirby-icon-settings';
-import { ICON_SETTINGS, Icon, IconSettings } from './icon-settings';
+import { Icon } from './icon-settings';
 import { IconRegistryService } from './icon-registry.service';
 
 @Component({
@@ -30,13 +22,6 @@ export class IconComponent implements OnChanges {
   }
 
   set icon(icon: Icon) {
-    // Check if ICON_SETTINGS are configured
-    if (!this.iconSettings && this.customName) {
-      console.warn(
-        'ICON_SETTINGS provider in your module.ts is not set. Read documentation on how to set it up.'
-      );
-    }
-
     // If icon are not found, set default icon
     if (!icon && (this.name || this.customName)) {
       console.warn(`Icon with name "${this.name || this.customName}" was not found.`);
@@ -59,27 +44,13 @@ export class IconComponent implements OnChanges {
    * iconRegistryService: Registry for custom icons.
    * iconSettings: @deprecated Use KirbyIconRegistryService for adding custom icons.
    */
-  constructor(
-    private iconRegistryService: IconRegistryService,
-    @Optional() @Inject(ICON_SETTINGS) private iconSettings?: IconSettings
-  ) {
-    this.mergeIconSettings();
-  }
-
-  private mergeIconSettings() {
-    if (this.iconSettings) {
-      this.iconRegistryService.addIcons(this.iconSettings.icons);
-    }
-  }
+  constructor(private iconRegistryService: IconRegistryService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.name && changes.name.currentValue) {
       this.icon = this.findIcon(kirbyIconSettings.icons, changes.name.currentValue);
     } else if (changes.customName && changes.customName.currentValue) {
-      this.icon = this.findIcon(
-        this.iconRegistryService.getIcons(),
-        changes.customName.currentValue
-      );
+      this.icon = this.iconRegistryService.getIcon(changes.customName.currentValue);
     }
   }
 


### PR DESCRIPTION
Remove warning firing way too much.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Icon component logs warnings for icon overwrites on each instantitation.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
Icon overwrites only logs warnings once (from singleton registry)

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
