### PR TITLE
Enhance/modal full height

### DIFF
--- a/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.html
+++ b/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.html
@@ -57,6 +57,7 @@
         [(showDummyContent)]="showNestedDummyContent"
         [(delayLoadDummyContent)]="delayLoadDummyContent"
         [(loadAdditionalContent)]="loadAdditionalContent"
+        [(openFullHeight)]="openFullHeight"
       ></cookbook-modal-example-configuration>
     </kirby-card>
     <div *ngIf="showDummyContent">

--- a/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.ts
@@ -37,6 +37,7 @@ export class FirstEmbeddedModalExampleComponent implements OnInit {
   delayLoadDummyContent: boolean;
   loadAdditionalContent: boolean;
   disableScroll: boolean = false;
+  openFullHeight: boolean;
 
   isLoading = false;
   isLoadingAdditionalContent = false;
@@ -73,6 +74,7 @@ export class FirstEmbeddedModalExampleComponent implements OnInit {
         action: this.onSupplementaryActionSelect.bind(this),
       },
       component: FirstEmbeddedModalExampleComponent,
+      size: this.openFullHeight ? 'full-height' : null,
       componentProps: {
         title,
         subtitle: 'Hello from second embedded example component!',

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.html
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.html
@@ -51,4 +51,9 @@
     ></kirby-checkbox
     >Delay load additional modal content</label
   >
+  <label
+    *ngIf="openFullHeight !== undefined"
+    (click)="toggleOpenFullHeight((openFullHeight = !openFullHeight))"
+    ><kirby-checkbox [checked]="openFullHeight"></kirby-checkbox>Open in full height</label
+  >
 </fieldset>

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.ts
@@ -26,6 +26,9 @@ export class ModalExampleConfigurationComponent {
   @Input() disableScroll: boolean;
   @Output() disableScrollChange = new EventEmitter<boolean>();
 
+  @Input() openFullHeight: boolean;
+  @Output() openFullHeightChange = new EventEmitter<boolean>();
+
   constructor(private window: WindowRef, zone: NgZone) {}
 
   toggleDummyKeyboard() {
@@ -71,5 +74,10 @@ export class ModalExampleConfigurationComponent {
   toggleDisableScroll(show: boolean) {
     this.disableScroll = show;
     this.disableScrollChange.emit(this.disableScroll);
+  }
+
+  toggleOpenFullHeight(show: boolean) {
+    this.openFullHeight = show;
+    this.openFullHeightChange.emit(this.openFullHeight);
   }
 }

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-default.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-default.component.ts
@@ -17,6 +17,7 @@ const config = {
     [(showDummyContent)]="showDummyContent"
     [(delayLoadDummyContent)]="delayLoadDummyContent"
     [(loadAdditionalContent)]="loadAdditionalContent"
+    [(openFullHeight)]="openFullHeight"
   ></cookbook-modal-example-configuration>`,
   titleTemplate: `<kirby-page-title>My Modal Title</kirby-page-title>
  
@@ -180,6 +181,7 @@ export class ModalExampleDefaultComponent {
   showDummyContent = true;
   delayLoadDummyContent = true;
   loadAdditionalContent = false;
+  openFullHeight = false;
 
   constructor(private modalController: ModalController, private window: WindowRef) {}
 
@@ -188,6 +190,7 @@ export class ModalExampleDefaultComponent {
     const config: ModalConfig = {
       flavor,
       component: FirstEmbeddedModalExampleComponent,
+      size: this.openFullHeight ? 'full-height' : null,
       componentProps: {
         title,
         subtitle: 'Hello from the first embedded example component!',
@@ -203,6 +206,7 @@ export class ModalExampleDefaultComponent {
         delayLoadDummyContent: this.delayLoadDummyContent,
         loadAdditionalContent: this.loadAdditionalContent,
         disableScroll: false,
+        openFullHeight: this.openFullHeight,
       },
     };
     await this.modalController.showModal(config, this.onOverlayClose);

--- a/apps/cookbook/src/app/shared/showcase-properties/showcase-properties.component.html
+++ b/apps/cookbook/src/app/shared/showcase-properties/showcase-properties.component.html
@@ -10,7 +10,7 @@
       <td *ngIf="columns.Name">
         <code>{{ prop.name }}</code>
       </td>
-      <td *ngIf="columns.Description">{{ prop.description }}</td>
+      <td *ngIf="columns.Description" class="description">{{ prop.description }}</td>
       <td *ngIf="columns.Type">
         <ng-container *ngIf="!prop.preserveInputValuesWhitespaces">
           <code>{{ prop.inputValues ? prop.inputValues.join(' | ') : '' }}</code>

--- a/apps/cookbook/src/app/shared/showcase-properties/showcase-properties.component.ts
+++ b/apps/cookbook/src/app/shared/showcase-properties/showcase-properties.component.ts
@@ -5,7 +5,17 @@ import { ShowcaseProperty } from './showcase-property';
 @Component({
   selector: 'cookbook-showcase-properties',
   templateUrl: './showcase-properties.component.html',
-  styles: [':host { display: block; }'],
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+
+      .description {
+        white-space: pre-line;
+      }
+    `,
+  ],
 })
 export class ShowcasePropertiesComponent {
   @Input() properties: ShowcaseProperty[];

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
@@ -28,10 +28,24 @@ export class ModalShowcaseComponent implements AfterViewInit {
 
   configProperties: ShowcaseProperty[] = [
     {
-      name: 'title',
-      description: 'The header of the modal',
-      defaultValue: '',
-      inputValues: ['string'],
+      name: 'flavor',
+      description: `(Optional) The flavor of the modal.
+      
+      Modals with \`modal\` flavor have a close button placed in the top right corner and are full-screen on small screens.
+      
+      Modals with a \`drawer\` flavor slide-up/down and have a arrow-down button placed in the top left corner.
+      
+      Modals with a \`compact\` flavor simply render the specified component, similar to alerts.
+      Please note: As there is no toolbar or close button, you should handle closing the modal yourself.`,
+      defaultValue: 'modal',
+      inputValues: ['undefined', 'modal', 'drawer', 'compact'],
+    },
+    {
+      name: 'size',
+      description: `(Optional) The initial size of the modal before content is loaded.
+        The \`full-height\` option will take up as much vertical space as possible and not resize with content or native keyboard.`,
+      defaultValue: 'medium (modal) | small (drawer)',
+      inputValues: ['undefined', 'small', 'medium', 'large', 'full-height'],
     },
     {
       name: 'component',
@@ -40,24 +54,17 @@ export class ModalShowcaseComponent implements AfterViewInit {
       inputValues: ['Component'],
     },
     {
-      name: 'flavor',
-      description:
-        "The flavor of the modal. Modals with 'modal' flavor fade-in/out and have a close button placed in the top right corner. Modals with a 'compact' flavor simply render the specified component, similar to alerts. As there a toolbar or close button, you should handle closing the modal yourself. Modals with a 'drawer' flavor slide-up/down and have a arrow-down button placed in the top left corner.",
-      defaultValue: 'modal',
-      inputValues: ['modal', 'drawer', 'compact'],
+      name: 'componentProps',
+      description: '(Optional) The data to pass to the modal component.',
+      defaultValue: '',
+      inputValues: ['undefined | { [key: string]: any; }'],
     },
     {
       name: 'drawerSupplementaryAction',
-      description:
-        "(Optional) Allows placing a supplementary button in the top right corner of drawers. Note that this is only available on modals with a 'drawer' flavor",
+      description: `(Optional) Allows placing a supplementary button in the top right corner of drawers.
+      Please note: Only available on modals with a \`drawer\` flavor.`,
       defaultValue: '',
       inputValues: ['{iconName: string, action: Function}'],
-    },
-    {
-      name: 'componentProps',
-      description: 'The data to pass to the modal component.',
-      defaultValue: '',
-      inputValues: ['undefined | { [key: string]: any; }'],
     },
   ];
 

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.html
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.html
@@ -1,8 +1,22 @@
-<ion-checkbox
-  class="checkbox"
-  [ngClass]="classes"
-  [mode]="shape === 'circle' ? undefined : 'md'"
-  [checked]="checked"
-  [disabled]="disabled"
-  (ionChange)="onChecked($event.detail.checked)"
-></ion-checkbox>
+<!-- Since there is a bug in Ionic when binding to the `mode` property of ion-checkbox,
+a switch between templates is used -->
+<ng-container *ngIf="shape === 'circle'; else squareBox">
+  <ion-checkbox
+    class="checkbox"
+    [ngClass]="classes"
+    [checked]="checked"
+    [disabled]="disabled"
+    (ionChange)="onChecked($event.detail.checked)"
+  ></ion-checkbox>
+</ng-container>
+
+<ng-template #squareBox>
+  <ion-checkbox
+    class="checkbox"
+    [ngClass]="classes"
+    mode="md"
+    [checked]="checked"
+    (ionChange)="onChecked($event.detail.checked)"
+  >
+  </ion-checkbox>
+</ng-template>

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/config/modal-config.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/config/modal-config.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import { DrawerSupplementaryAction } from './drawer-supplementary-action';
 
 export type ModalFlavor = 'modal' | 'drawer' | 'compact';
-export type ModalSize = 'small' | 'medium' | 'large';
+export type ModalSize = 'small' | 'medium' | 'large' | 'full-height';
 
 export interface ModalConfig {
   /**

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/config/modal-config.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/config/modal-config.ts
@@ -3,16 +3,19 @@ import { Observable } from 'rxjs';
 
 import { DrawerSupplementaryAction } from './drawer-supplementary-action';
 
+export type ModalFlavor = 'modal' | 'drawer' | 'compact';
+export type ModalSize = 'small' | 'medium' | 'large';
+
 export interface ModalConfig {
   /**
    * @deprecated Will be removed in next major version. Embed a `<kirby-page-title>` element inside the component instead.
    */
   title?: string;
   component: any;
-  size?: 'small' | 'medium' | 'large';
+  size?: ModalSize;
   modalRoute?: ActivatedRoute;
   siblingModalRouteActivated$?: Observable<ActivatedRoute>;
-  flavor?: 'modal' | 'drawer' | 'compact';
+  flavor?: ModalFlavor;
   /**
    * @deprecated Will be removed in next major version.
    */

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.scss
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.scss
@@ -34,16 +34,22 @@
   }
 }
 
-:host {
-  --vh100: var(--vh, 1vh) * 100; /// Fixes an issue with vh units on iOS Safari
-  --header-height: 0px;
-  --footer-height: 0px;
+:host-context(ion-modal:not(.full-height)) {
   @include media('>=medium') {
     @include contain-content();
   }
 
   &.drawer {
     @include contain-content();
+  }
+}
+
+:host {
+  --vh100: var(--vh, 1vh) * 100; /// Fixes an issue with vh units on iOS Safari
+  --header-height: 0px;
+  --footer-height: 0px;
+
+  &.drawer {
     // Prevent iOS safe-area padding-top on drawer flavor
     // as this is already applied on the top-level modal itself
     // in /scss/_global-styles.scss:

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
@@ -74,7 +74,6 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
   readonly didPresent = this.ionModalDidPresent.toPromise();
   private readonly ionModalWillDismiss = new Subject<void>();
   readonly willClose = this.ionModalWillDismiss.toPromise();
-  private readonly defaultSize = 'medium';
   private _mutationObserver: MutationObserver;
   private get mutationObserver(): MutationObserver {
     if (!this._mutationObserver) {
@@ -148,12 +147,6 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
       this.routerOutlet.activateWith(route, this.componentFactoryResolver);
       this.checkForEmbeddedElements();
     });
-  }
-
-  private setInitialModalSize() {
-    if (this.config.flavor !== 'modal') return;
-    if (!this.ionModalElement) return;
-    this.renderer.addClass(this.ionModalElement, this.config.size || this.defaultSize);
   }
 
   private patchScrollElementSize(): void {

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
@@ -122,7 +122,7 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
   }
 
   private initializeSizing() {
-    this.setInitialModalSize();
+    if (this.config.size === 'full-height') return;
     this.patchScrollElementSize();
     this.observeHeaderResize();
     this.observeModalFullHeight();

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
@@ -366,7 +366,7 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
   }
 
   private setViewportHeight() {
-    const vh = this.windowRef.innerHeight * 0.01;
+    const vh = (this.windowRef.innerHeight * 0.01).toFixed(2);
     this.setCssVar(this.elementRef.nativeElement, '--vh', `${vh}px`);
   }
 

--- a/libs/designsystem/src/lib/components/modal/services/modal.helper.spec.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal.helper.spec.ts
@@ -9,7 +9,7 @@ import { WindowRef } from '../../../types/window-ref';
 import { ScreenSize, TestHelper } from '../../../testing/test-helper';
 import { IconComponent } from '../../icon';
 import { ModalFooterComponent } from '../footer/modal-footer.component';
-import { ModalConfig, ModalFlavor } from '../modal-wrapper/config/modal-config';
+import { ModalConfig, ModalFlavor, ModalSize } from '../modal-wrapper/config/modal-config';
 import { ModalWrapperComponent } from '../modal-wrapper/modal-wrapper.component';
 import { ModalCompactWrapperComponent } from '../modal-wrapper/compact/modal-compact-wrapper.component';
 import { ModalHelper } from './modal.helper';
@@ -68,6 +68,9 @@ describe('ModalHelper', () => {
   const defaultBorderRadius = DesignTokenHelper.borderRadius();
   const size = DesignTokenHelper.size;
   const backgroundColor = DesignTokenHelper.backgroundColor();
+  const modalPaddingTopPx = size('xl');
+  const modalPaddingTop = parseInt(modalPaddingTopPx);
+  const modalHeaderHeight = 46;
 
   const createService = createServiceFactory({
     service: ModalHelper,
@@ -126,16 +129,12 @@ describe('ModalHelper', () => {
     expect(modalShadow).toBeTruthy();
   };
 
-  const openModal = async (
-    title: string = 'Modal',
-    component?: any,
-    size?: 'small' | 'medium' | 'large'
-  ) => {
+  const openModal = async (title: string = 'Modal', component?: any, size?: ModalSize) => {
     await openOverlay({ flavor: 'modal', title, component, size });
   };
 
-  const openDrawer = async (title: string = 'Drawer', component?: any) => {
-    await openOverlay({ flavor: 'drawer', title, component });
+  const openDrawer = async (title: string = 'Drawer', component?: any, size?: ModalSize) => {
+    await openOverlay({ flavor: 'drawer', title, component, size });
   };
 
   const expectShadowStyle = () => {
@@ -228,7 +227,7 @@ describe('ModalHelper', () => {
             await overlay.dismiss();
           });
 
-          const expectSize = (size: 'small' | 'medium' | 'large' | undefined) => {
+          const expectSize = (size: ModalSize | undefined) => {
             expect(ionModal.classList.contains('small')).toBe(size === 'small');
             expect(ionModal.classList.contains('medium')).toBe(size === 'medium');
             expect(ionModal.classList.contains('large')).toBe(size === 'large');
@@ -274,7 +273,26 @@ describe('ModalHelper', () => {
             expectSize('large');
           });
 
-          it('should not set sizing class if flavor is `drawer`', async () => {
+          it('modal should be sized `full-height`', async () => {
+            await openModal('Full-height Modal', undefined, 'full-height');
+
+            expectSize('full-height');
+            const expectedHeight = window.innerHeight - modalPaddingTop;
+            expect(ionModalWrapper).toHaveComputedStyle({ '--height': '100%' });
+            expect(ionModalWrapper).toHaveComputedStyle({ height: `${expectedHeight}px` });
+          });
+
+          it('drawer should be sized `full-height`', async () => {
+            await openDrawer('Full-height Drawer', undefined, 'full-height');
+
+            expectSize('full-height');
+            const drawerPaddingTop = modalPaddingTop + modalHeaderHeight / 2;
+            const expectedHeight = window.innerHeight - drawerPaddingTop;
+            expect(ionModalWrapper).toHaveComputedStyle({ '--height': '100%' });
+            expect(ionModalWrapper).toHaveComputedStyle({ height: `${expectedHeight}px` });
+          });
+
+          it('should not set default size class if flavor is `drawer`', async () => {
             await openDrawer();
 
             expectSize(undefined);
@@ -322,7 +340,7 @@ describe('ModalHelper', () => {
           expectModalWrapperStyle();
 
           it('modal should have correct padding-top', () => {
-            expect(ionModal).toHaveComputedStyle({ 'padding-top': size('xl') });
+            expect(ionModal).toHaveComputedStyle({ 'padding-top': modalPaddingTopPx });
           });
 
           it('modal window should not take focus from embedded input after opening', async () => {
@@ -351,9 +369,8 @@ describe('ModalHelper', () => {
           expectDrawerWrapperStyle();
 
           it('modal should have correct padding-top', () => {
-            const headerHeight = 46;
             expect(ionModal).toHaveComputedStyle({
-              'padding-top': `${parseInt(size('xl')) + headerHeight / 2}px`,
+              'padding-top': `${modalPaddingTop + modalHeaderHeight / 2}px`,
             });
           });
         });
@@ -506,6 +523,44 @@ describe('ModalHelper', () => {
             expect(ionToolbar).toHaveComputedStyle({ 'padding-top': '0px' });
             await overlay.dismiss();
           });
+        });
+      });
+
+      describe('sizing', () => {
+        afterEach(async () => {
+          await overlay.dismiss();
+        });
+
+        const expectSize = (size: ModalSize | undefined) => {
+          expect(ionModal.classList.contains('small')).toBe(size === 'small');
+          expect(ionModal.classList.contains('medium')).toBe(size === 'medium');
+          expect(ionModal.classList.contains('large')).toBe(size === 'large');
+        };
+
+        it('modal should be full height', async () => {
+          await openModal();
+
+          expect(ionModalWrapper).toHaveComputedStyle({
+            '--height': '100%',
+          });
+        });
+
+        it('drawer should have min-height', async () => {
+          await openDrawer();
+
+          expect(ionModalWrapper).toHaveComputedStyle({
+            '--min-height': DesignTokenHelper.drawerDefaultHeight,
+          });
+        });
+
+        it('drawer should be sized `full-height`', async () => {
+          await openDrawer('Full-height Drawer', undefined, 'full-height');
+
+          expectSize('full-height');
+          const drawerPaddingTop = parseInt(size('m'));
+          const expectedHeight = window.innerHeight - drawerPaddingTop;
+          expect(ionModalWrapper).toHaveComputedStyle({ '--height': '100%' });
+          expect(ionModalWrapper).toHaveComputedStyle({ height: `${expectedHeight}px` });
         });
       });
 

--- a/libs/designsystem/src/lib/components/modal/services/modal.helper.spec.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal.helper.spec.ts
@@ -9,7 +9,7 @@ import { WindowRef } from '../../../types/window-ref';
 import { ScreenSize, TestHelper } from '../../../testing/test-helper';
 import { IconComponent } from '../../icon';
 import { ModalFooterComponent } from '../footer/modal-footer.component';
-import { ModalConfig } from '../modal-wrapper/config/modal-config';
+import { ModalConfig, ModalFlavor } from '../modal-wrapper/config/modal-config';
 import { ModalWrapperComponent } from '../modal-wrapper/modal-wrapper.component';
 import { ModalCompactWrapperComponent } from '../modal-wrapper/compact/modal-compact-wrapper.component';
 import { ModalHelper } from './modal.helper';
@@ -390,8 +390,7 @@ describe('ModalHelper', () => {
         });
 
         describe(`when modal is opened on top of another modal`, () => {
-          type modalFlavorType = 'modal' | 'drawer' | 'compact';
-          const modalFlavors: modalFlavorType[] = ['modal', 'drawer', 'compact'];
+          const modalFlavors: ModalFlavor[] = ['modal', 'drawer', 'compact'];
           modalFlavors.forEach((firstFlavor) => {
             describe(`when first modal has '${firstFlavor}' flavor`, () => {
               beforeEach(async () => {
@@ -578,8 +577,7 @@ describe('ModalHelper', () => {
       });
 
       describe(`when modal is opened on top of another modal`, () => {
-        type modalFlavorType = 'modal' | 'drawer' | 'compact';
-        const modalFlavors: modalFlavorType[] = ['modal', 'drawer', 'compact'];
+        const modalFlavors: ModalFlavor[] = ['modal', 'drawer', 'compact'];
         modalFlavors.forEach((firstFlavor) => {
           describe(`when first modal has '${firstFlavor}' flavor`, () => {
             beforeEach(async () => {

--- a/libs/designsystem/src/lib/components/modal/services/modal.helper.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal.helper.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ModalController } from '@ionic/angular';
 
-import { ModalConfig, ModalFlavor } from '../modal-wrapper/config/modal-config';
+import { ModalConfig, ModalFlavor, ModalSize } from '../modal-wrapper/config/modal-config';
 import { ModalWrapperComponent } from '../modal-wrapper/modal-wrapper.component';
 import { ModalCompactWrapperComponent } from '../modal-wrapper/compact/modal-compact-wrapper.component';
 import { Overlay } from './modal.interfaces';
@@ -32,6 +32,9 @@ export class ModalHelper {
     const enterAnimation = this.modalAnimationBuilder.enterAnimation(currentBackdrop);
     const leaveAnimation = this.modalAnimationBuilder.leaveAnimation(currentBackdrop);
 
+    const defaultModalSize: ModalSize = config.flavor === 'modal' ? 'medium' : null;
+    const modalSize = config.size || defaultModalSize;
+
     const ionModal = await this.ionicModalController.create({
       component: config.flavor === 'compact' ? ModalCompactWrapperComponent : ModalWrapperComponent,
       cssClass: [
@@ -39,6 +42,7 @@ export class ModalHelper {
         'kirby-modal',
         config.flavor === 'drawer' ? 'kirby-drawer' : null,
         config.flavor === 'compact' ? 'kirby-modal-compact' : null,
+        modalSize,
       ],
       backdropDismiss: config.flavor === 'compact' ? false : true,
       componentProps: { config: config },

--- a/libs/designsystem/src/lib/components/modal/services/modal.helper.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal.helper.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ModalController } from '@ionic/angular';
 
-import { ModalConfig } from '../modal-wrapper/config/modal-config';
+import { ModalConfig, ModalFlavor } from '../modal-wrapper/config/modal-config';
 import { ModalWrapperComponent } from '../modal-wrapper/modal-wrapper.component';
 import { ModalCompactWrapperComponent } from '../modal-wrapper/compact/modal-compact-wrapper.component';
 import { Overlay } from './modal.interfaces';
@@ -62,7 +62,7 @@ export class ModalHelper {
     ModalHelper.presentingElement = element;
   }
 
-  private async getPresentingElement(flavor?: 'modal' | 'drawer' | 'compact') {
+  private async getPresentingElement(flavor?: ModalFlavor) {
     let modalPresentingElement: HTMLElement = undefined;
     if (!flavor || flavor === 'modal') {
       const topMostModal = await this.ionicModalController.getTop();

--- a/libs/designsystem/src/lib/scss/_global-styles.scss
+++ b/libs/designsystem/src/lib/scss/_global-styles.scss
@@ -97,6 +97,10 @@ ion-modal.kirby-overlay {
       }
     }
 
+    &:not(.kirby-modal-compact).full-height {
+      --height: 100%;
+    }
+
     @include media('>=medium') {
       --width: #{$modal-max-width};
       --border-radius: #{$border-radius};
@@ -107,10 +111,6 @@ ion-modal.kirby-overlay {
         --kirby-modal-padding-top-base: #{size('xl')};
         --kirby-modal-padding-top: var(--kirby-modal-padding-top-base);
         padding-top: var(--kirby-modal-padding-top);
-
-        &.full-height {
-          --height: 100%;
-        }
 
         &:not(.kirby-drawer) {
           --min-height: #{$modal-default-height};

--- a/libs/designsystem/src/lib/scss/_global-styles.scss
+++ b/libs/designsystem/src/lib/scss/_global-styles.scss
@@ -108,6 +108,10 @@ ion-modal.kirby-overlay {
         --kirby-modal-padding-top: var(--kirby-modal-padding-top-base);
         padding-top: var(--kirby-modal-padding-top);
 
+        &.full-height {
+          --height: 100%;
+        }
+
         &:not(.kirby-drawer) {
           --min-height: #{$modal-default-height};
           align-items: flex-start;
@@ -122,6 +126,7 @@ ion-modal.kirby-overlay {
             --min-height: #{map-get($modal-heights, 'l')};
           }
 
+          &.full-height .modal-wrapper,
           .modal-wrapper.full-height {
             border-bottom-left-radius: 0;
             border-bottom-right-radius: 0;

--- a/libs/designsystem/src/lib/scss/_global-styles.scss
+++ b/libs/designsystem/src/lib/scss/_global-styles.scss
@@ -71,6 +71,7 @@ ion-modal.kirby-overlay {
     }
 
     &.kirby-drawer {
+      --min-height: #{$drawer-default-height};
       --kirby-modal-padding-top: calc(var(--kirby-safe-area-top, 0px) + #{size('m')});
       padding-top: var(--kirby-modal-padding-top);
       align-items: flex-end;
@@ -135,7 +136,6 @@ ion-modal.kirby-overlay {
       }
 
       &.kirby-drawer {
-        --min-height: #{$drawer-default-height};
         --kirby-modal-padding-top: calc(
           var(--kirby-modal-padding-top-base) + #{get-drawer-additional-padding-top()}
         );

--- a/libs/designsystem/src/lib/scss/_global-styles.scss
+++ b/libs/designsystem/src/lib/scss/_global-styles.scss
@@ -82,6 +82,16 @@ ion-modal.kirby-overlay {
       }
     }
 
+    @include media('<medium') {
+      &:not(.kirby-drawer):not(.kirby-modal-compact) {
+        --height: 100%;
+      }
+    }
+
+    &:not(.kirby-modal-compact).full-height {
+      --height: 100%;
+    }
+
     &.modal-card:not(.kirby-drawer) {
       .modal-wrapper {
         @include media('<medium') {
@@ -96,10 +106,6 @@ ion-modal.kirby-overlay {
           border-radius: $border-radius;
         }
       }
-    }
-
-    &:not(.kirby-modal-compact).full-height {
-      --height: 100%;
     }
 
     @include media('>=medium') {


### PR DESCRIPTION
This PR closes # (reference issue number here)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
If using a view with varying height (e.g. a tabbed view using a segmented control) the drawer will resize with each subview causing a jagged UX.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
This PR adds a `full-height` size option to the modal+drawer, which will open the modal/drawer in full-height and not resize with content/keyboard.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
