### PR TITLE
Fix/checkbox sizing

### DIFF
--- a/apps/cookbook/src/app/examples/checkbox-example/checkbox-example.component.html
+++ b/apps/cookbook/src/app/examples/checkbox-example/checkbox-example.component.html
@@ -10,5 +10,8 @@
 <h2>States</h2>
 <cookbook-checkbox-states-example></cookbook-checkbox-states-example>
 
+<h2>Sizes</h2>
+<cookbook-checkbox-sizes-example></cookbook-checkbox-sizes-example>
+
 <h2>Checked Change Event</h2>
 <cookbook-checkbox-events-example></cookbook-checkbox-events-example>

--- a/apps/cookbook/src/app/examples/checkbox-example/checkbox-example.component.ts
+++ b/apps/cookbook/src/app/examples/checkbox-example/checkbox-example.component.ts
@@ -3,5 +3,6 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'cookbook-checkbox-example',
   templateUrl: './checkbox-example.component.html',
+  styleUrls: ['../_examples.shared.scss'],
 })
 export class CheckboxExampleComponent {}

--- a/apps/cookbook/src/app/examples/checkbox-example/checkbox-example.module.ts
+++ b/apps/cookbook/src/app/examples/checkbox-example/checkbox-example.module.ts
@@ -7,6 +7,7 @@ import { CheckboxDefaultExampleComponent } from './examples/default';
 import { CheckboxListExampleComponent } from './examples/list';
 import { CheckboxConfirmExampleComponent } from './examples/confirm';
 import { CheckboxStatesExampleComponent } from './examples/states';
+import { CheckboxSizesExampleComponent } from './examples/sizes';
 import { CheckboxEventsExampleComponent } from './examples/events';
 
 const COMPONENT_DECLARATIONS = [
@@ -14,6 +15,7 @@ const COMPONENT_DECLARATIONS = [
   CheckboxListExampleComponent,
   CheckboxConfirmExampleComponent,
   CheckboxStatesExampleComponent,
+  CheckboxSizesExampleComponent,
   CheckboxEventsExampleComponent,
 ];
 

--- a/apps/cookbook/src/app/examples/checkbox-example/examples/events.ts
+++ b/apps/cookbook/src/app/examples/checkbox-example/examples/events.ts
@@ -4,9 +4,12 @@ import { ToastConfig, ToastController } from '@kirbydesign/designsystem';
 
 const config = {
   selector: 'cookbook-checkbox-events-example',
-  template: `<kirby-checkbox (checkedChange)="checkedChange($event)" text="Toggle to see 'checkedChange' event in action"></kirby-checkbox>`,
-  checkboxEventCodeSnippet: `checkedChange(checked: boolean) {
-  alert(\`Checkbox checked change: \${checked}\`);
+  template: `<kirby-checkbox
+  (checkedChange)="onCheckedChange($event)"
+  text="Toggle to see 'checkedChange' event in action">
+</kirby-checkbox>`,
+  codeSnippet: `onCheckedChange(checked: boolean) {
+  ...
 }`,
 };
 
@@ -16,11 +19,11 @@ const config = {
 })
 export class CheckboxEventsExampleComponent {
   template: string = config.template;
-  checkboxEventCodeSnippet: string = config.checkboxEventCodeSnippet;
+  codeSnippet: string = config.codeSnippet;
 
   constructor(private toastController: ToastController) {}
 
-  checkedChange(checked: boolean) {
+  onCheckedChange(checked: boolean) {
     const config: ToastConfig = {
       message: `Checkbox changed - checked: ${checked}`,
       messageType: checked ? 'success' : 'warning',

--- a/apps/cookbook/src/app/examples/checkbox-example/examples/events.ts
+++ b/apps/cookbook/src/app/examples/checkbox-example/examples/events.ts
@@ -1,5 +1,7 @@
 import { Component } from '@angular/core';
 
+import { ToastConfig, ToastController } from '@kirbydesign/designsystem';
+
 const config = {
   selector: 'cookbook-checkbox-events-example',
   template: `<kirby-checkbox (checkedChange)="checkedChange($event)" text="Toggle to see 'checkedChange' event in action"></kirby-checkbox>`,
@@ -16,7 +18,14 @@ export class CheckboxEventsExampleComponent {
   template: string = config.template;
   checkboxEventCodeSnippet: string = config.checkboxEventCodeSnippet;
 
+  constructor(private toastController: ToastController) {}
+
   checkedChange(checked: boolean) {
-    alert(`Checkbox checked change: ${checked}`);
+    const config: ToastConfig = {
+      message: `Checkbox changed - checked: ${checked}`,
+      messageType: checked ? 'success' : 'warning',
+      durationInMs: 1500,
+    };
+    this.toastController.showToast(config);
   }
 }

--- a/apps/cookbook/src/app/examples/checkbox-example/examples/list.ts
+++ b/apps/cookbook/src/app/examples/checkbox-example/examples/list.ts
@@ -11,7 +11,7 @@ const config = {
     <kirby-label>{{ item.label }}</kirby-label>
   </kirby-item>
 </kirby-list>`,
-  checkboxItemsCodeSnippet: `checkboxItems = [
+  codeSnippet: `checkboxItems = [
   { label: 'Checkbox 1', checked: true },
   { label: 'Checkbox 2', checked: false },
   { label: 'Checkbox 3', checked: false },
@@ -24,7 +24,7 @@ const config = {
 })
 export class CheckboxListExampleComponent {
   template: string = config.template;
-  checkboxItemsCodeSnippet: string = config.checkboxItemsCodeSnippet;
+  codeSnippet: string = config.codeSnippet;
 
   checkboxItems = [
     { label: 'Checkbox 1', checked: true },

--- a/apps/cookbook/src/app/examples/checkbox-example/examples/sizes.scss
+++ b/apps/cookbook/src/app/examples/checkbox-example/examples/sizes.scss
@@ -1,0 +1,53 @@
+@import './libs/designsystem/src/lib/scss/utils';
+
+kirby-checkbox {
+  margin-bottom: size('xxs');
+  background-color: get-color('semi-light');
+  position: relative;
+}
+
+/* height measure */
+kirby-checkbox::before,
+kirby-checkbox::after {
+  height: 100%;
+  border: 1px solid get-color('danger');
+  position: absolute;
+  right: 0;
+}
+
+/* horizontal measure */
+kirby-checkbox::before {
+  content: '';
+  border-left: 0;
+  border-right: 0;
+  width: size('xxs') + 1px;
+}
+
+/* vertical measure */
+kirby-checkbox::after {
+  content: 'md: #{ size(xxxl) }';
+  border-left: 0;
+  border-top: 0;
+  border-bottom: 0;
+  line-height: size('xxxl');
+  font-size: font-size('xs');
+  color: get-color('danger');
+  padding-right: size('xxs');
+  margin-right: size('xxs') / 2;
+  vertical-align: center;
+}
+
+kirby-checkbox.xs::after {
+  content: 'xs: #{ size(l) }';
+  line-height: size('l');
+}
+
+kirby-checkbox.sm::after {
+  content: 'sm: #{ $fat-finger-size }';
+  line-height: $fat-finger-size;
+}
+
+kirby-checkbox ::ng-deep .wrapper {
+  background-color: #f7e0f0;
+  margin-right: 80px; // Allow room for height measure info
+}

--- a/apps/cookbook/src/app/examples/checkbox-example/examples/sizes.ts
+++ b/apps/cookbook/src/app/examples/checkbox-example/examples/sizes.ts
@@ -2,25 +2,15 @@ import { Component } from '@angular/core';
 
 const config = {
   selector: 'cookbook-checkbox-sizes-example',
-  template: `<kirby-checkbox size="xs" text="Extra small ('xs')"></kirby-checkbox>
-<kirby-checkbox size="sm" text="Small ('sm' - default)"></kirby-checkbox>
-<kirby-checkbox size="md" text="Medium ('md')"></kirby-checkbox>`,
+  template: `<kirby-checkbox size="xs" text="Extra Small"></kirby-checkbox>
+<kirby-checkbox size="sm" text="Small"></kirby-checkbox>
+<kirby-checkbox size="md" text="Medium (default) with a lot more text"></kirby-checkbox>`,
 };
 
 @Component({
   selector: config.selector,
   template: config.template,
-  styles: [
-    `
-      kirby-checkbox {
-        margin-bottom: 8px;
-      }
-
-      kirby-checkbox ::ng-deep ion-checkbox {
-        background-color: pink;
-      }
-    `,
-  ],
+  styleUrls: ['./sizes.scss'],
 })
 export class CheckboxSizesExampleComponent {
   template: string = config.template;

--- a/apps/cookbook/src/app/examples/checkbox-example/examples/sizes.ts
+++ b/apps/cookbook/src/app/examples/checkbox-example/examples/sizes.ts
@@ -1,0 +1,33 @@
+import { Component } from '@angular/core';
+
+const config = {
+  selector: 'cookbook-checkbox-sizes-example',
+  template: `<kirby-checkbox size="xs" text="xs"></kirby-checkbox>
+<kirby-checkbox size="sm" text="sm (default)"></kirby-checkbox>
+<kirby-checkbox size="md" text="md"></kirby-checkbox>`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+  styles: [
+    `
+      :host {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+
+      kirby-checkbox {
+        margin-bottom: 8px;
+      }
+
+      kirby-checkbox ::ng-deep ion-checkbox {
+        background-color: pink;
+      }
+    `,
+  ],
+})
+export class CheckboxSizesExampleComponent {
+  template: string = config.template;
+}

--- a/apps/cookbook/src/app/examples/checkbox-example/examples/sizes.ts
+++ b/apps/cookbook/src/app/examples/checkbox-example/examples/sizes.ts
@@ -4,7 +4,7 @@ const config = {
   selector: 'cookbook-checkbox-sizes-example',
   template: `<kirby-checkbox size="xs" text="Extra Small"></kirby-checkbox>
 <kirby-checkbox size="sm" text="Small"></kirby-checkbox>
-<kirby-checkbox size="md" text="Medium (default) with a lot more text"></kirby-checkbox>`,
+<kirby-checkbox size="md" text="Medium (default)"></kirby-checkbox>`,
 };
 
 @Component({

--- a/apps/cookbook/src/app/examples/checkbox-example/examples/sizes.ts
+++ b/apps/cookbook/src/app/examples/checkbox-example/examples/sizes.ts
@@ -2,9 +2,9 @@ import { Component } from '@angular/core';
 
 const config = {
   selector: 'cookbook-checkbox-sizes-example',
-  template: `<kirby-checkbox size="xs" text="xs"></kirby-checkbox>
-<kirby-checkbox size="sm" text="sm (default)"></kirby-checkbox>
-<kirby-checkbox size="md" text="md"></kirby-checkbox>`,
+  template: `<kirby-checkbox size="xs" text="Extra small ('xs')"></kirby-checkbox>
+<kirby-checkbox size="sm" text="Small ('sm' - default)"></kirby-checkbox>
+<kirby-checkbox size="md" text="Medium ('md')"></kirby-checkbox>`,
 };
 
 @Component({
@@ -12,12 +12,6 @@ const config = {
   template: config.template,
   styles: [
     `
-      :host {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-      }
-
       kirby-checkbox {
         margin-bottom: 8px;
       }

--- a/apps/cookbook/src/app/examples/checkbox-example/examples/states.ts
+++ b/apps/cookbook/src/app/examples/checkbox-example/examples/states.ts
@@ -12,6 +12,14 @@ const config = {
 @Component({
   selector: config.selector,
   template: config.template,
+  styles: [
+    `
+      :host {
+        display: flex;
+        flex-wrap: wrap;
+      }
+    `,
+  ],
 })
 export class CheckboxStatesExampleComponent {
   template: string = config.template;

--- a/apps/cookbook/src/app/examples/dropdown-example/examples/ng-forms.ts
+++ b/apps/cookbook/src/app/examples/dropdown-example/examples/ng-forms.ts
@@ -12,12 +12,18 @@ const config = {
     itemTextProperty="title"
   ></kirby-dropdown>
 </form>
-<fieldset>
+<fieldset class="checkbox-xs">
   <legend>Configuration</legend>
-  <kirby-checkbox [checked]="canSelectFavorite" (checkedChange)="toggleEnabled($event)"></kirby-checkbox>
-  <label (click)="toggleEnabled(!canSelectFavorite)">Form field enabled</label><br />
-  <kirby-checkbox [checked]="favoriteRequired" (checkedChange)="toggleRequired($event)"></kirby-checkbox>
-  <label (click)="toggleRequired(!favoriteRequired)">Form field required</label>
+  <kirby-checkbox
+    [checked]="canSelectFavorite"
+    (checkedChange)="toggleEnabled($event)"
+    text="Form field enabled">
+  </kirby-checkbox>
+  <kirby-checkbox
+    [checked]="favoriteRequired"
+    (checkedChange)="toggleRequired($event)"
+    text="Form field required">
+  </kirby-checkbox>
   <p class="selection">
     form.value: {{ form.value | json }}<br />
     form.favoriteFood:
@@ -45,14 +51,6 @@ toggleRequired(required: boolean) {
   favoriteFoodControl.updateValueAndValidity();
 }`,
   styles: [
-    `label {
-      cursor: pointer;
-      font-size: 14px;
-      font-weight: 300;
-      line-height: 20px;
-      padding-left: 4px;
-      transform: translateY(-4px);
-    }`,
     `.selection {
       margin: 0;
       font-size: 12px;

--- a/apps/cookbook/src/app/examples/form-field-example/examples/input/focus.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/examples/input/focus.ts
@@ -4,13 +4,11 @@ import { FormFieldComponent } from '@kirbydesign/designsystem';
 
 const config = {
   selector: 'cookbook-form-field-focus-example',
-  template: `<label (click)="inputEnabled = !inputEnabled">
-  <kirby-checkbox
-    [checked]="inputEnabled"
-    (checkedChange)="onToggleInput($event)">
-  </kirby-checkbox>
-  Enable input
-</label>
+  template: `<kirby-checkbox
+  [checked]="inputEnabled"
+  (checkedChange)="onToggleInput($event)"
+  text="Enable input">
+</kirby-checkbox>
 <kirby-form-field #formfield>
   <input kirby-input [disabled]="!inputEnabled" placeholder="Enable to focus (+scroll into view on device)" />
 </kirby-form-field>`,
@@ -22,6 +20,7 @@ export class MyComponent {
   inputEnabled = false;
 
   onToggleInput(enable: boolean) {
+    this.inputEnabled = enable;
     if (!enable) return;
     this.formfield.focus();
   }
@@ -49,7 +48,8 @@ export class FormFieldFocusExampleComponent {
   inputEnabled = false;
 
   onToggleInput(enable: boolean) {
+    this.inputEnabled = enable;
     if (!enable) return;
-    this.formfield.focus();
+    setTimeout(() => this.formfield.focus());
   }
 }

--- a/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.html
+++ b/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.html
@@ -17,13 +17,11 @@
     <cookbook-form-field-textarea-counter-example></cookbook-form-field-textarea-counter-example>
 
     <cookbook-example-configuration-wrapper [snapToViewport]="true" style="--header-height: 44px">
-      <label (click)="showDummyKeyboard = !showDummyKeyboard">
-        <kirby-checkbox
-          [checked]="showDummyKeyboard"
-          (checkedChange)="toggleDummyKeyboard()"
-        ></kirby-checkbox
-        >Show dummy keyboard</label
-      >
+      <kirby-checkbox
+        [checked]="showDummyKeyboard"
+        (checkedChange)="toggleDummyKeyboard($event)"
+        text="Show dummy keyboard"
+      ></kirby-checkbox>
     </cookbook-example-configuration-wrapper>
   </kirby-page-content>
 </kirby-page>

--- a/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.scss
+++ b/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.scss
@@ -7,7 +7,3 @@ kirby-page-content > * {
 kirby-page-content > * + * {
   margin-top: size('m');
 }
-
-kirby-checkbox {
-  padding-right: size('xxxs');
-}

--- a/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.ts
@@ -12,8 +12,9 @@ export class FormFieldExampleComponent {
 
   showDummyKeyboard = !!this.window.sessionStorage.getItem('kirby-cookbook-show-dummy-keyboard');
 
-  toggleDummyKeyboard() {
+  toggleDummyKeyboard(show: boolean) {
     const sessionKey = 'kirby-cookbook-show-dummy-keyboard';
+    this.showDummyKeyboard = show;
     this.showDummyKeyboard
       ? this.window.sessionStorage.setItem(sessionKey, 'true')
       : this.window.sessionStorage.removeItem(sessionKey);

--- a/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.html
+++ b/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.html
@@ -155,9 +155,10 @@
       </button>
       <button kirby-button (click)="close()">Close</button>
     </div>
-    <label (click)="snapFooterToKeyboard = !snapFooterToKeyboard">
-      <kirby-checkbox [checked]="snapFooterToKeyboard"></kirby-checkbox>
-      Snap footer to keyboard
-    </label>
+    <kirby-checkbox
+      size="xs"
+      [(checked)]="snapFooterToKeyboard"
+      text="Snap footer to keyboard"
+    ></kirby-checkbox>
   </div>
 </kirby-modal-footer>

--- a/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.scss
+++ b/apps/cookbook/src/app/examples/modal-example/first-embedded-modal-example/first-embedded-modal-example.component.scss
@@ -37,11 +37,7 @@ kirby-modal-footer {
   }
 
   kirby-checkbox {
-    padding-right: size('xxxs');
-  }
-
-  label {
     font-size: font-size('xs');
-    cursor: pointer;
+    text-align: center;
   }
 }

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.html
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.html
@@ -1,50 +1,52 @@
-<label *ngIf="showDummyKeyboard !== undefined" (click)="showDummyKeyboard = !showDummyKeyboard">
-  <kirby-checkbox
-    [checked]="showDummyKeyboard"
-    (checkedChange)="toggleDummyKeyboard()"
-  ></kirby-checkbox
-  >Show dummy keyboard</label
->
-<label *ngIf="showFooter !== undefined" (click)="toggleShowFooter((showFooter = !showFooter))"
-  ><kirby-checkbox [checked]="showFooter"></kirby-checkbox>Show footer</label
->
-<label
+<kirby-checkbox
+  *ngIf="showDummyKeyboard !== undefined"
+  [checked]="showDummyKeyboard"
+  (checkedChange)="toggleDummyKeyboard($event)"
+  text="Show dummy keyboard"
+></kirby-checkbox>
+
+<kirby-checkbox
+  *ngIf="showFooter !== undefined"
+  [checked]="showFooter"
+  (checkedChange)="toggleShowFooter($event)"
+  text="Show footer"
+></kirby-checkbox>
+
+<kirby-checkbox
   *ngIf="disableScroll !== undefined"
-  (click)="toggleDisableScroll((disableScroll = !disableScroll))"
-  ><kirby-checkbox [checked]="disableScroll"></kirby-checkbox>Disable scroll</label
->
-<label
+  [checked]="disableScroll"
+  (checkedChange)="toggleDisableScroll($event)"
+  text="Disable scroll"
+></kirby-checkbox>
+
+<kirby-checkbox
   *ngIf="showDummyContent !== undefined"
-  (click)="toggleShowDummyContent((showDummyContent = !showDummyContent))"
->
-  <kirby-checkbox [checked]="showDummyContent"></kirby-checkbox>Show dummy content</label
->
-<label
+  [checked]="showDummyContent"
+  (checkedChange)="toggleShowDummyContent($event)"
+  text="Show dummy content"
+></kirby-checkbox>
+
+<kirby-checkbox
   *ngIf="delayLoadDummyContent !== undefined"
-  (click)="
-    showDummyContent &&
-      toggleDelayLoadDummyContent((delayLoadDummyContent = !delayLoadDummyContent))
-  "
+  [checked]="delayLoadDummyContent"
+  (checkedChange)="toggleDelayLoadDummyContent($event)"
+  [disabled]="!showDummyContent"
   class="indent"
-  [class.disabled]="!showDummyContent"
->
-  <kirby-checkbox [checked]="delayLoadDummyContent" [disabled]="!showDummyContent"></kirby-checkbox
-  >Delay load modal content</label
->
-<label
+  text="Delay load modal"
+></kirby-checkbox>
+
+<kirby-checkbox
   *ngIf="loadAdditionalContent !== undefined"
-  (click)="
-    showDummyContent &&
-      toggleLoadAdditionalContent((loadAdditionalContent = !loadAdditionalContent))
-  "
+  [checked]="loadAdditionalContent"
+  (checkedChange)="showDummyContent && toggleLoadAdditionalContent($event)"
+  [disabled]="!showDummyContent"
   class="indent"
-  [class.disabled]="!showDummyContent"
->
-  <kirby-checkbox [checked]="loadAdditionalContent" [disabled]="!showDummyContent"></kirby-checkbox
-  >Delay load additional modal content</label
->
-<label
+  text="Delay load additional"
+></kirby-checkbox>
+
+<kirby-checkbox
   *ngIf="openFullHeight !== undefined"
-  (click)="toggleOpenFullHeight((openFullHeight = !openFullHeight))"
-  ><kirby-checkbox [checked]="openFullHeight"></kirby-checkbox>Open in full height</label
->
+  [checked]="openFullHeight"
+  (checkedChange)="toggleOpenFullHeight($event)"
+  text="Open in full height"
+></kirby-checkbox>

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.scss
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.scss
@@ -2,24 +2,14 @@
 
 :host {
   kirby-checkbox {
-    padding-right: size('xxxs');
-  }
-
-  label {
-    cursor: pointer;
-    display: block;
     &:not(:first-of-type) {
-      margin-top: size('xxs');
+      margin-top: size('xxxs');
     }
 
     &.indent {
-      margin-left: size('m');
+      margin-left: size('l');
       margin-top: size('xxxs');
       font-size: font-size('s');
-    }
-
-    &.disabled {
-      color: get-text-color('semi-dark');
     }
   }
 }

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.ts
@@ -1,4 +1,12 @@
-import { Component, EventEmitter, HostListener, Input, NgZone, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  HostBinding,
+  HostListener,
+  Input,
+  NgZone,
+  Output,
+} from '@angular/core';
 
 import { WindowRef } from '@kirbydesign/designsystem/types/window-ref';
 
@@ -29,10 +37,13 @@ export class ModalExampleConfigurationComponent {
   @Input() openFullHeight: boolean;
   @Output() openFullHeightChange = new EventEmitter<boolean>();
 
+  @HostBinding('class.checkbox-xs') true; // Extra small checkboxes
+
   constructor(private window: WindowRef, zone: NgZone) {}
 
-  toggleDummyKeyboard() {
+  toggleDummyKeyboard(show: boolean) {
     const sessionKey = 'kirby-cookbook-show-dummy-keyboard';
+    this.showDummyKeyboard = show;
     this.showDummyKeyboard
       ? this.window.sessionStorage.setItem(sessionKey, 'true')
       : this.window.sessionStorage.removeItem(sessionKey);

--- a/apps/cookbook/src/app/showcase/calendar-showcase/calendar-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/calendar-showcase/calendar-showcase.component.html
@@ -18,26 +18,17 @@
         [useTimezoneUTC]="useTimezoneUTC"
       ></cookbook-calendar-card-example>
       <!-- prettier-ignore -->
-      <fieldset>
+      <fieldset class="checkbox-xs">
           <legend>Configuration</legend>
-          <kirby-checkbox [checked]="disableWeekends" (checkedChange)="disableWeekends = $event;"></kirby-checkbox>
-          <label (click)="disableWeekends = !disableWeekends">Disable weekends</label><br/>
-          <kirby-checkbox [checked]="alwaysEnableToday" (checkedChange)="alwaysEnableToday = $event;"></kirby-checkbox>
-          <label (click)="alwaysEnableToday = !alwaysEnableToday">Always enable current date</label><br/>
-          <kirby-checkbox [checked]="disablePastDates" (checkedChange)="disablePastDates = $event;"></kirby-checkbox>
-          <label (click)="disablePastDates = !disablePastDates">Disable past dates</label><br/>
-          <kirby-checkbox [checked]="disableFutureDates" (checkedChange)="disableFutureDates = $event;"></kirby-checkbox>
-          <label (click)="disableFutureDates = !disableFutureDates">Disable future dates</label><br/>
-          <kirby-checkbox [checked]="setDisabledDates" (checkedChange)="setDisabledDates = $event;"></kirby-checkbox>
-          <label (click)="setDisabledDates = !setDisabledDates">Set disabled dates</label><br/>
-          <kirby-checkbox [checked]="setMinDate" (checkedChange)="setMinDate = $event;"></kirby-checkbox>
-          <label (click)="setMinDate = !setMinDate">Set min date ({{minDate | date:'dd-MM-yyyy':(useTimezoneUTC ? 'UTC' : undefined)}})</label><br/>
-          <kirby-checkbox [checked]="setMaxDate" (checkedChange)="setMaxDate = $event;"></kirby-checkbox>
-          <label (click)="setMaxDate = !setMaxDate">Set max date ({{maxDate | date:'dd-MM-yyyy':(useTimezoneUTC ? 'UTC' : undefined)}})</label><br/>
-          <kirby-checkbox [checked]="setTodayDate" (checkedChange)="setTodayDate = $event;"></kirby-checkbox>
-          <label (click)="setTodayDate = !setTodayDate">Set today date ({{todayDate | date:'dd-MM-yyyy':(useTimezoneUTC ? 'UTC' : undefined)}})</label><br/>  
-          <kirby-checkbox [checked]="" (checkedChange)="useTimezoneUTC = $event;"></kirby-checkbox>
-          <label (click)="useTimezoneUTC = !useTimezoneUTC">Use UTC instead of local time</label>  
+          <kirby-checkbox [(checked)]="disableWeekends" text="Disable weekends"></kirby-checkbox>
+          <kirby-checkbox [(checked)]="alwaysEnableToday" text="Always enable current date"></kirby-checkbox>
+          <kirby-checkbox [(checked)]="disablePastDates" text="Disable past dates"></kirby-checkbox>
+          <kirby-checkbox [(checked)]="disableFutureDates" text="Disable future dates"></kirby-checkbox>
+          <kirby-checkbox [(checked)]="setDisabledDates" text="Set disabled dates"></kirby-checkbox>
+          <kirby-checkbox [(checked)]="setMinDate" text="Set min date ({{minDate | date:'dd-MM-yyyy':(useTimezoneUTC ? 'UTC' : undefined)}})"></kirby-checkbox>
+          <kirby-checkbox [(checked)]="setMaxDate" text="Set max date ({{maxDate | date:'dd-MM-yyyy':(useTimezoneUTC ? 'UTC' : undefined)}})"></kirby-checkbox>
+          <kirby-checkbox [(checked)]="setTodayDate" text="Set today date ({{todayDate | date:'dd-MM-yyyy':(useTimezoneUTC ? 'UTC' : undefined)}})"></kirby-checkbox>
+          <kirby-checkbox [(checked)]="useTimezoneUTC" text="Use UTC instead of local time"></kirby-checkbox>
         </fieldset>
     </div>
     <cookbook-code-viewer [html]="exampleWithCardHtml"></cookbook-code-viewer>

--- a/apps/cookbook/src/app/showcase/calendar-showcase/calendar-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/calendar-showcase/calendar-showcase.component.scss
@@ -13,8 +13,3 @@ cookbook-calendar-example,
 h2.custom-example {
   margin-top: 40px;
 }
-
-kirby-checkbox + label {
-  cursor: pointer;
-  margin-left: 4px;
-}

--- a/apps/cookbook/src/app/showcase/checkbox-showcase/checkbox-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/checkbox-showcase/checkbox-showcase.component.html
@@ -41,6 +41,18 @@
     <cookbook-checkbox-states-example #checkboxStatesExample></cookbook-checkbox-states-example>
   </cookbook-example-viewer>
 
+  <h2>Sizes</h2>
+  <p>
+    The sizes a checkbox can have.
+  </p>
+  <p>
+    The size applies to the clickable/tapable area (highlighted in the examples below). The checkbox
+    and checkmark always have the same size.
+  </p>
+  <cookbook-example-viewer [html]="checkboxSizesExample.template">
+    <cookbook-checkbox-sizes-example #checkboxSizesExample></cookbook-checkbox-sizes-example>
+  </cookbook-example-viewer>
+
   <h2>Checked Change Event</h2>
   <cookbook-example-viewer [html]="checkboxEventsExample.template">
     <cookbook-checkbox-events-example #checkboxEventsExample></cookbook-checkbox-events-example>

--- a/apps/cookbook/src/app/showcase/checkbox-showcase/checkbox-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/checkbox-showcase/checkbox-showcase.component.html
@@ -54,11 +54,11 @@
   </cookbook-example-viewer>
 
   <h2>Checked Change Event</h2>
-  <cookbook-example-viewer [html]="checkboxEventsExample.template">
+  <cookbook-example-viewer
+    [html]="checkboxEventsExample.template"
+    [ts]="checkboxEventsExample.codeSnippet"
+  >
     <cookbook-checkbox-events-example #checkboxEventsExample></cookbook-checkbox-events-example>
-    <cookbook-code-viewer
-      [ts]="checkboxEventsExample.checkboxEventCodeSnippet"
-    ></cookbook-code-viewer>
   </cookbook-example-viewer>
 
   <h2>Properties</h2>

--- a/apps/cookbook/src/app/showcase/checkbox-showcase/checkbox-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/checkbox-showcase/checkbox-showcase.component.html
@@ -13,12 +13,12 @@
     <li>Attention Level 2: Use in a list of check boxes, where multiple choices can be selected</li>
   </ol>
 
-  <h2>Attention Level 1</h2>
+  <h3>Attention Level 1</h3>
   <cookbook-example-viewer [html]="checkboxConfirmExample.template">
     <cookbook-checkbox-confirm-example #checkboxConfirmExample></cookbook-checkbox-confirm-example>
   </cookbook-example-viewer>
 
-  <h2>Attention Level 2</h2>
+  <h3>Attention Level 2</h3>
   <cookbook-example-viewer [html]="checkboxDefaultExample.template">
     <cookbook-checkbox-default-example #checkboxDefaultExample></cookbook-checkbox-default-example>
   </cookbook-example-viewer>
@@ -28,11 +28,11 @@
     For more on using checkbox in an item, see
     <a routerLink="/home/showcase/item">item documentation</a>
   </p>
-  <cookbook-example-viewer [html]="checkboxListExample.template">
+  <cookbook-example-viewer
+    [html]="checkboxListExample.template"
+    [ts]="checkboxListExample.checkboxItemsCodeSnippet"
+  >
     <cookbook-checkbox-list-example #checkboxListExample></cookbook-checkbox-list-example>
-    <cookbook-code-viewer
-      [ts]="checkboxListExample.checkboxItemsCodeSnippet"
-    ></cookbook-code-viewer>
   </cookbook-example-viewer>
 
   <h2>States</h2>

--- a/apps/cookbook/src/app/showcase/checkbox-showcase/checkbox-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/checkbox-showcase/checkbox-showcase.component.html
@@ -7,7 +7,7 @@
   </p>
 
   <h2>Types</h2>
-  <p>There are two types of Checkbox’s:</p>
+  <p>There are two types of Checkboxes:</p>
   <ol>
     <li>Attention Level 1: Use as a binary choice for a standalone check box</li>
     <li>Attention Level 2: Use in a list of check boxes, where multiple choices can be selected</li>
@@ -36,15 +36,11 @@
   </cookbook-example-viewer>
 
   <h2>States</h2>
-  <p>The states a checkbox can have</p>
   <cookbook-example-viewer [html]="checkboxStatesExample.template">
     <cookbook-checkbox-states-example #checkboxStatesExample></cookbook-checkbox-states-example>
   </cookbook-example-viewer>
 
   <h2>Sizes</h2>
-  <p>
-    The sizes a checkbox can have.
-  </p>
   <p>
     The size applies to the clickable/tapable area (highlighted in the examples below). The checkbox
     and checkmark always have the same size.

--- a/apps/cookbook/src/app/showcase/checkbox-showcase/checkbox-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/checkbox-showcase/checkbox-showcase.component.html
@@ -30,7 +30,7 @@
   </p>
   <cookbook-example-viewer
     [html]="checkboxListExample.template"
-    [ts]="checkboxListExample.checkboxItemsCodeSnippet"
+    [ts]="checkboxListExample.codeSnippet"
   >
     <cookbook-checkbox-list-example #checkboxListExample></cookbook-checkbox-list-example>
   </cookbook-example-viewer>

--- a/apps/cookbook/src/app/showcase/checkbox-showcase/checkbox-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/checkbox-showcase/checkbox-showcase.component.scss
@@ -1,6 +1,1 @@
 @import '../showcase.shared';
-
-cookbook-checkbox-states-example {
-  display: flex;
-  flex-wrap: wrap;
-}

--- a/apps/cookbook/src/app/showcase/checkbox-showcase/checkbox-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/checkbox-showcase/checkbox-showcase.component.ts
@@ -36,6 +36,12 @@ Use the default attentionLevel 2 for checkbox lists.`,
       inputValues: ['boolean'],
     },
     {
+      name: 'size',
+      description: 'Sets the size of the clickable/tapable area',
+      defaultValue: 'sm',
+      inputValues: ['xs', 'sm', 'md'],
+    },
+    {
       name: 'text',
       description: 'Adds a label text',
       inputValues: ['string'],

--- a/apps/cookbook/src/app/showcase/fab-sheet-showcase/fab-sheet-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/fab-sheet-showcase/fab-sheet-showcase.component.html
@@ -10,8 +10,8 @@
     <kirby-checkbox
       [checked]="disableFabSheet"
       (checkedChange)="disableFabSheet = $event"
-    ></kirby-checkbox
-    ><label (click)="disableFabSheet = !disableFabSheet">Disable FAB</label>
+      text="Disable FAB"
+    ></kirby-checkbox>
   </fieldset>
   <cookbook-fab-sheet-example [disableFabSheet]="disableFabSheet"></cookbook-fab-sheet-example>
   <cookbook-code-viewer [html]="exampleHtml"></cookbook-code-viewer>

--- a/apps/cookbook/src/app/showcase/fab-sheet-showcase/fab-sheet-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/fab-sheet-showcase/fab-sheet-showcase.component.scss
@@ -1,4 +1,3 @@
-kirby-checkbox + label {
-  cursor: pointer;
-  margin-left: 4px;
+fieldset {
+  display: inline-block;
 }

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.html
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.html
@@ -1,4 +1,4 @@
-<div>
+<div class="wrapper">
   <ion-checkbox
     mode="md"
     [checked]="checked"

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.integration.spec.ts
@@ -1,11 +1,12 @@
 import { SpectatorHost, createHostFactory } from '@ngneat/spectator';
 import { IonCheckbox, IonItem } from '@ionic/angular';
+import { MockComponents } from 'ng-mocks';
 
 import { DesignTokenHelper } from '../../helpers';
 import { ItemComponent } from '../item';
 import { CheckboxComponent } from './checkbox.component';
 
-const checkboxIconSize = DesignTokenHelper.size('m');
+const size = DesignTokenHelper.size;
 
 describe('CheckboxComponent in Item', () => {
   let spectator: SpectatorHost<CheckboxComponent>;
@@ -13,26 +14,44 @@ describe('CheckboxComponent in Item', () => {
 
   const createHost = createHostFactory({
     component: CheckboxComponent,
-    declarations: [ItemComponent, IonItem, IonCheckbox],
+    declarations: MockComponents(ItemComponent, IonItem, IonCheckbox),
   });
 
-  beforeEach(() => {
-    spectator = createHost(`<kirby-item>
+  describe('by default', () => {
+    beforeEach(() => {
+      spectator = createHost(`
+    <kirby-item>
       <kirby-checkbox></kirby-checkbox>
     </kirby-item>`);
-    ionCheckbox = spectator.query('ion-checkbox');
-  });
+      ionCheckbox = spectator.query('ion-checkbox');
+    });
 
-  it(`should be sized to icon size`, () => {
-    expect(ionCheckbox).toHaveComputedStyle({
-      '--size': checkboxIconSize,
-      padding: '0px',
+    it(`icon should not have any margin`, () => {
+      expect(ionCheckbox).toHaveComputedStyle({
+        margin: '0px',
+      });
+    });
+
+    it(`should have z-index`, () => {
+      expect(spectator.element).toHaveComputedStyle({
+        'z-index': '1',
+      });
     });
   });
 
-  it(`should have z-index`, () => {
-    expect(spectator.element).toHaveComputedStyle({
-      'z-index': '1',
+  describe('slotted start', () => {
+    beforeEach(() => {
+      spectator = createHost(`
+    <kirby-item>
+      <kirby-checkbox slot="start"></kirby-checkbox>
+    </kirby-item>`);
+      ionCheckbox = spectator.query('ion-checkbox');
+    });
+
+    it(`should have correct vertical spacing`, () => {
+      expect(spectator.element).toHaveComputedStyle({
+        'margin-inline-end': size('xs'),
+      });
     });
   });
 });

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.integration.spec.ts
@@ -1,0 +1,38 @@
+import { SpectatorHost, createHostFactory } from '@ngneat/spectator';
+import { IonCheckbox, IonItem } from '@ionic/angular';
+
+import { DesignTokenHelper } from '../../helpers';
+import { ItemComponent } from '../item';
+import { CheckboxComponent } from './checkbox.component';
+
+const checkboxIconSize = DesignTokenHelper.size('m');
+
+describe('CheckboxComponent in Item', () => {
+  let spectator: SpectatorHost<CheckboxComponent>;
+  let ionCheckbox: HTMLIonCheckboxElement;
+
+  const createHost = createHostFactory({
+    component: CheckboxComponent,
+    declarations: [ItemComponent, IonItem, IonCheckbox],
+  });
+
+  beforeEach(() => {
+    spectator = createHost(`<kirby-item>
+      <kirby-checkbox></kirby-checkbox>
+    </kirby-item>`);
+    ionCheckbox = spectator.query('ion-checkbox');
+  });
+
+  it(`should be sized to icon size`, () => {
+    expect(ionCheckbox).toHaveComputedStyle({
+      '--size': checkboxIconSize,
+      padding: '0px',
+    });
+  });
+
+  it(`should have z-index`, () => {
+    expect(spectator.element).toHaveComputedStyle({
+      'z-index': '1',
+    });
+  });
+});

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
@@ -81,13 +81,14 @@ $checkbox-margin-right: size('xs');
   &.has-label {
     display: block;
 
-    div {
+    .wrapper {
       position: relative;
       display: inline-flex;
       align-items: center;
       vertical-align: top;
       padding-right: size('s');
     }
+
     ion-checkbox {
       position: static;
       margin-right: Max(calc(#{$checkbox-margin-right} - var(--kirby-checkbox-padding)), 0px);

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
@@ -2,10 +2,13 @@
 
 $border-radius: 6px;
 $checkbox-icon-size: size('m');
-$checkbox-size-xs: size('l');
-$checkbox-size-sm: $fat-finger-size;
-$checkbox-size-md: size('xxxl');
-$checkbox-margin-right: size('xs');
+$checkbox-sizes: (
+  'xs': size('l'),
+  'sm': $fat-finger-size,
+  'md': size('xxxl'),
+);
+$spacing-to-label: size('xs');
+$spacing-to-edge: size('xs');
 
 :host {
   display: inline-block;
@@ -51,20 +54,18 @@ $checkbox-margin-right: size('xs');
   }
 
   ion-checkbox {
+    --size: #{$checkbox-icon-size};
     --checkmark-width: #{size('xxxs')};
     --background: #{get-color('white')};
     --border-width: 1px;
     --border-color: #{get-color('semi-dark')};
     --border-radius: #{$border-radius};
 
-    // Making clickable area bigger without making icon bigger
-    --size: #{$checkbox-size-sm};
-    --kirby-checkbox-padding: calc((var(--size) - #{$checkbox-icon-size}) / 2);
-    padding: var(--kirby-checkbox-padding);
-    box-sizing: border-box; // Ensure padding is not added to checkbox width/height
+    margin-left: $spacing-to-edge;
+    margin-right: $spacing-to-label;
 
     &::part(container) {
-      padding: size('xxxs');
+      padding: size('xxxs'); // Spacing between checkmark and container box
     }
 
     &:focus-within::part(container) {
@@ -86,33 +87,23 @@ $checkbox-margin-right: size('xs');
       display: inline-flex;
       align-items: center;
       vertical-align: top;
-      padding-right: size('s');
+      padding-right: $spacing-to-label; // Ensure same padding on right side of label
+      min-height: map-get($checkbox-sizes, 'sm');
+    }
+
+    @each $size, $height in $checkbox-sizes {
+      :host-context(.checkbox-#{$size}),
+      &.#{$size} {
+        .wrapper {
+          min-height: $height;
+        }
+      }
     }
 
     ion-checkbox {
       position: static;
-      margin-right: Max(calc(#{$checkbox-margin-right} - var(--kirby-checkbox-padding)), 0px);
-    }
-  }
-
-  :host-context(.checkbox-xs),
-  &.xs {
-    ion-checkbox {
-      --size: #{$checkbox-size-xs};
-    }
-  }
-
-  :host-context(.checkbox-sm),
-  &.sm {
-    ion-checkbox {
-      --size: #{$checkbox-size-sm};
-    }
-  }
-
-  :host-context(.checkbox-md),
-  &.md {
-    ion-checkbox {
-      --size: #{$checkbox-size-md};
+      flex-shrink: 0;
+      flex-grow: 0;
     }
   }
 }
@@ -121,12 +112,10 @@ $checkbox-margin-right: size('xs');
   z-index: z('default'); // Makes whole kirby-item clickable above item-inner.
 
   ion-checkbox {
-    --size: #{$checkbox-icon-size};
-    padding: 0;
+    margin: 0;
   }
 
   &[slot='start'] {
-    margin: 0;
-    margin-inline-end: size('s');
+    margin-inline-end: $spacing-to-label;
   }
 }

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
@@ -88,7 +88,7 @@ $spacing-to-label: size('xs');
       align-items: center;
       vertical-align: top;
       padding-right: $spacing-to-label; // Ensure same padding on right side of label
-      min-height: map-get($checkbox-sizes, 'sm');
+      min-height: map-get($checkbox-sizes, 'md');
     }
 
     @each $size, $height in $checkbox-sizes {

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
@@ -7,8 +7,8 @@ $checkbox-sizes: (
   'sm': $fat-finger-size,
   'md': size('xxxl'),
 );
+$spacing-to-edge: size('s');
 $spacing-to-label: size('xs');
-$spacing-to-edge: size('xs');
 
 :host {
   display: inline-block;

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
@@ -5,6 +5,7 @@ $checkbox-icon-size: size('m');
 $checkbox-size-xs: size('l');
 $checkbox-size-sm: $fat-finger-size;
 $checkbox-size-md: size('xxxl');
+$checkbox-margin-right: size('xs');
 
 :host {
   display: inline-block;
@@ -58,7 +59,8 @@ $checkbox-size-md: size('xxxl');
 
     // Making clickable area bigger without making icon bigger
     --size: #{$checkbox-size-sm};
-    padding: calc((var(--size) - #{$checkbox-icon-size}) / 2);
+    --kirby-checkbox-padding: calc((var(--size) - #{$checkbox-icon-size}) / 2);
+    padding: var(--kirby-checkbox-padding);
     box-sizing: border-box; // Ensure padding is not added to checkbox width/height
 
     &::part(container) {
@@ -88,7 +90,7 @@ $checkbox-size-md: size('xxxl');
     }
     ion-checkbox {
       position: static;
-      margin-right: size('xxxs');
+      margin-right: Max(calc(#{$checkbox-margin-right} - var(--kirby-checkbox-padding)), 0px);
     }
   }
 

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
@@ -2,6 +2,9 @@
 
 $border-radius: 6px;
 $checkbox-icon-size: size('m');
+$checkbox-size-xs: size('l');
+$checkbox-size-sm: $fat-finger-size;
+$checkbox-size-md: size('xxxl');
 
 :host {
   display: inline-block;
@@ -54,8 +57,9 @@ $checkbox-icon-size: size('m');
     --border-radius: #{$border-radius};
 
     // Making clickable area bigger without making icon bigger
-    --size: #{$fat-finger-size};
-    padding: #{($fat-finger-size - $checkbox-icon-size) / 2};
+    --size: #{$checkbox-size-sm};
+    padding: calc((var(--size) - #{$checkbox-icon-size}) / 2);
+    box-sizing: border-box; // Ensure padding is not added to checkbox width/height
 
     &::part(container) {
       padding: size('xxxs');
@@ -85,6 +89,27 @@ $checkbox-icon-size: size('m');
     ion-checkbox {
       position: static;
       margin-right: size('xxxs');
+    }
+  }
+
+  :host-context(.checkbox-xs),
+  &.xs {
+    ion-checkbox {
+      --size: #{$checkbox-size-xs};
+    }
+  }
+
+  :host-context(.checkbox-sm),
+  &.sm {
+    ion-checkbox {
+      --size: #{$checkbox-size-sm};
+    }
+  }
+
+  :host-context(.checkbox-md),
+  &.md {
+    ion-checkbox {
+      --size: #{$checkbox-size-md};
     }
   }
 }

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.spec.ts
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.spec.ts
@@ -88,7 +88,7 @@ describe('CheckboxComponent', () => {
     describe('with size', () => {
       it(`should have 'sm' size by default`, () => {
         expect(spectator.element).toHaveComputedStyle({
-          height: checkboxSizeSm,
+          height: checkboxSizeMd,
         });
       });
 

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.spec.ts
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.spec.ts
@@ -1,11 +1,16 @@
 import { Spectator, createHostFactory } from '@ngneat/spectator';
-import { IonicModule } from '@ionic/angular';
+import { IonCheckbox } from '@ionic/angular';
 
 import { CheckboxComponent } from './checkbox.component';
 import { DesignTokenHelper } from '../../helpers';
 
 const getColor = DesignTokenHelper.getColor;
 const getTextColor = DesignTokenHelper.getTextColor;
+const fatFingerSize = DesignTokenHelper.fatFingerSize();
+const checkboxIconSizeValue = parseInt(DesignTokenHelper.size('m'));
+const checkboxSizeXs = DesignTokenHelper.size('l');
+const checkboxSizeSm = fatFingerSize;
+const checkboxSizeMd = DesignTokenHelper.size('xxxl');
 
 describe('CheckboxComponent', () => {
   let spectator: Spectator<CheckboxComponent>;
@@ -13,7 +18,7 @@ describe('CheckboxComponent', () => {
 
   const createHost = createHostFactory({
     component: CheckboxComponent,
-    imports: [IonicModule.forRoot({ _testing: true })],
+    declarations: [IonCheckbox],
   });
 
   beforeEach(() => {
@@ -69,6 +74,45 @@ describe('CheckboxComponent', () => {
 
       spectator.setInput('checked', false);
       expect(ionCheckbox.checked).toBe(false);
+    });
+
+    describe('with size', () => {
+      it(`should have 'sm' size by default`, () => {
+        expect(ionCheckbox).toHaveComputedStyle({
+          '--size': checkboxSizeSm,
+          padding: `${(parseInt(checkboxSizeSm) - checkboxIconSizeValue) / 2}px`,
+        });
+      });
+
+      it(`should have correct size when size = 'xs'`, () => {
+        spectator.setInput('size', 'xs');
+        spectator.detectChanges();
+
+        expect(ionCheckbox).toHaveComputedStyle({
+          '--size': checkboxSizeXs,
+          padding: `${(parseInt(checkboxSizeXs) - checkboxIconSizeValue) / 2}px`,
+        });
+      });
+
+      it(`should have correct size when size = 'sm'`, () => {
+        spectator.setInput('size', 'sm');
+        spectator.detectChanges();
+
+        expect(ionCheckbox).toHaveComputedStyle({
+          '--size': checkboxSizeSm,
+          padding: `${(parseInt(checkboxSizeSm) - checkboxIconSizeValue) / 2}px`,
+        });
+      });
+
+      it(`should have correct size when size = 'md'`, () => {
+        spectator.setInput('size', 'md');
+        spectator.detectChanges();
+
+        expect(ionCheckbox).toHaveComputedStyle({
+          '--size': checkboxSizeMd,
+          padding: `${(parseInt(checkboxSizeMd) - checkboxIconSizeValue) / 2}px`,
+        });
+      });
     });
 
     describe('when disabled', () => {

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.spec.ts
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.spec.ts
@@ -4,13 +4,14 @@ import { IonCheckbox } from '@ionic/angular';
 import { CheckboxComponent } from './checkbox.component';
 import { DesignTokenHelper } from '../../helpers';
 
+const size = DesignTokenHelper.size;
 const getColor = DesignTokenHelper.getColor;
 const getTextColor = DesignTokenHelper.getTextColor;
 const fatFingerSize = DesignTokenHelper.fatFingerSize();
-const checkboxIconSizeValue = parseInt(DesignTokenHelper.size('m'));
-const checkboxSizeXs = DesignTokenHelper.size('l');
+const checkboxIconSize = size('m');
+const checkboxSizeXs = size('l');
 const checkboxSizeSm = fatFingerSize;
-const checkboxSizeMd = DesignTokenHelper.size('xxxl');
+const checkboxSizeMd = size('xxxl');
 
 describe('CheckboxComponent', () => {
   let spectator: Spectator<CheckboxComponent>;
@@ -22,7 +23,7 @@ describe('CheckboxComponent', () => {
   });
 
   beforeEach(() => {
-    spectator = createHost(`<kirby-checkbox></kirby-checkbox>`);
+    spectator = createHost(`<kirby-checkbox text="test"></kirby-checkbox>`);
     ionCheckbox = spectator.query('ion-checkbox');
   });
 
@@ -38,9 +39,17 @@ describe('CheckboxComponent', () => {
 
     it('should have correct icon styling', () => {
       expect(ionCheckbox).toHaveComputedStyle({
+        '--size': checkboxIconSize,
         '--checkmark-color': getColor('white'),
         '--background-checked': getColor('black'),
         '--border-color-checked': getColor('black'),
+      });
+    });
+
+    it('should have correct vertical spacing', () => {
+      expect(ionCheckbox).toHaveComputedStyle({
+        'margin-left': size('s'),
+        'margin-right': size('xs'),
       });
     });
 
@@ -78,9 +87,8 @@ describe('CheckboxComponent', () => {
 
     describe('with size', () => {
       it(`should have 'sm' size by default`, () => {
-        expect(ionCheckbox).toHaveComputedStyle({
-          '--size': checkboxSizeSm,
-          padding: `${(parseInt(checkboxSizeSm) - checkboxIconSizeValue) / 2}px`,
+        expect(spectator.element).toHaveComputedStyle({
+          height: checkboxSizeSm,
         });
       });
 
@@ -88,9 +96,8 @@ describe('CheckboxComponent', () => {
         spectator.setInput('size', 'xs');
         spectator.detectChanges();
 
-        expect(ionCheckbox).toHaveComputedStyle({
-          '--size': checkboxSizeXs,
-          padding: `${(parseInt(checkboxSizeXs) - checkboxIconSizeValue) / 2}px`,
+        expect(spectator.element).toHaveComputedStyle({
+          height: checkboxSizeXs,
         });
       });
 
@@ -98,9 +105,8 @@ describe('CheckboxComponent', () => {
         spectator.setInput('size', 'sm');
         spectator.detectChanges();
 
-        expect(ionCheckbox).toHaveComputedStyle({
-          '--size': checkboxSizeSm,
-          padding: `${(parseInt(checkboxSizeSm) - checkboxIconSizeValue) / 2}px`,
+        expect(spectator.element).toHaveComputedStyle({
+          height: checkboxSizeSm,
         });
       });
 
@@ -108,9 +114,8 @@ describe('CheckboxComponent', () => {
         spectator.setInput('size', 'md');
         spectator.detectChanges();
 
-        expect(ionCheckbox).toHaveComputedStyle({
-          '--size': checkboxSizeMd,
-          padding: `${(parseInt(checkboxSizeMd) - checkboxIconSizeValue) / 2}px`,
+        expect(spectator.element).toHaveComputedStyle({
+          height: checkboxSizeMd,
         });
       });
     });

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.ts
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.ts
@@ -24,6 +24,10 @@ export class CheckboxComponent {
   @Input()
   text: string;
 
+  @HostBinding('class')
+  @Input()
+  size?: 'xs' | 'sm' | 'md';
+
   @HostBinding('class.error')
   @Input()
   hasError: boolean = false;

--- a/libs/designsystem/testing-base/src/lib/components/mock.checkbox.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.checkbox.component.ts
@@ -17,6 +17,7 @@ export class MockCheckboxComponent {
   @Input() checked: boolean;
   @Input() attentionLevel: '1' | '2';
   @Input() text: string;
+  @Input() size: 'xs' | 'sm' | 'md';
   @Input() hasError: boolean;
   @Input() disabled: boolean;
   @Output() checkedChange = new EventEmitter<boolean>();


### PR DESCRIPTION
This PR closes # (reference issue number here)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
- Checkbox size defaults to `sm` (44px)
- Checkbox size is wrong if parent container has `box-sizing: content-box`.
- All checkboxes in cookbook also had layout issues.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
- Checkbox size is always `md` (56px) by default.
- Additionally a `size` property has been added that controls the clickable/tapable area: xs: 32px, sm: 44px; md: 56px. 
  - Icon/checkmark size is always 24px.
- All checkboxes in cookbook has been refactored to use the checkbox' own `text` property.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
### BEFORE:
![image](https://user-images.githubusercontent.com/9556693/102497870-7f8b7b00-4079-11eb-8c51-a5ba27dffb3e.png)

### AFTER:
![image](https://user-images.githubusercontent.com/9556693/102497901-89ad7980-4079-11eb-8df0-e70e8637c38a.png)

### SIZES
![image](https://user-images.githubusercontent.com/9556693/102623202-6bf81700-4142-11eb-9ee5-3c3743239bbe.png)