### PR TITLE
Enhancement/ability to add prefix and suffix 459

### DIFF
--- a/apps/cookbook/src/app/examples/form-field-example/examples/input/form-field-input-prefix-postfix-example.component.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/examples/input/form-field-input-prefix-postfix-example.component.ts
@@ -1,0 +1,54 @@
+import { Component } from '@angular/core';
+
+const config = {
+  selector: 'cookbook-form-field-input-prefix-postfix-example',
+  template: `
+<kirby-form-field label="Input with Prefix">
+<kirby-input-prefix >@</kirby-input-prefix>
+  <input type="text" kirby-input class="input-prefix-postfix" placeholder="Username"/>
+</kirby-form-field>
+<kirby-form-field label="Input with Postfix">
+  <input type="text" kirby-input class="input-prefix-postfix" placeholder="Recipient's username"/>
+  <kirby-input-postfix>@bankdata.dk</kirby-input-postfix>
+</kirby-form-field>
+
+
+<kirby-form-field label="Input with Prefix and Postfix">
+<kirby-input-prefix >$</kirby-input-prefix>
+  <input type="text" kirby-input class="input-prefix-postfix"/>
+<kirby-input-postfix>.00</kirby-input-postfix>
+</kirby-form-field>
+
+
+<kirby-form-field label="Input with Prefix and Postfix">
+<kirby-input-prefix >email</kirby-input-prefix>
+  <input type="email" kirby-input class="input-prefix-postfix"/>
+<kirby-input-postfix>@bankdata.dk</kirby-input-postfix>
+</kirby-form-field>
+
+<div>Input without label</div>
+<kirby-form-field >
+<kirby-input-prefix >email</kirby-input-prefix>
+  <input type="email" kirby-input class="input-prefix-postfix"/>
+<kirby-input-postfix>@bankdata.dk</kirby-input-postfix>
+</kirby-form-field>
+
+<kirby-form-field >
+<kirby-input-prefix >Name</kirby-input-prefix>
+<kirby-dropdown  class="input-prefix-postfix"
+  [size]="size"
+  [items]="['Item 1','Item 2','Item 3','Item 4','Item 5']"
+></kirby-dropdown>
+  
+<kirby-input-postfix>@bankdata.dk</kirby-input-postfix>
+</kirby-form-field>
+`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+})
+export class FormFieldInputPrefixPostfixExampleComponent {
+  template: string = config.template;
+}

--- a/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.html
+++ b/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.html
@@ -5,6 +5,7 @@
     <cookbook-form-field-input-label-example></cookbook-form-field-input-label-example>
     <cookbook-form-field-input-label-message-example></cookbook-form-field-input-label-message-example>
     <cookbook-form-field-input-counter-example></cookbook-form-field-input-counter-example>
+    <cookbook-form-field-input-prefix-postfix-example></cookbook-form-field-input-prefix-postfix-example>
     <cookbook-form-field-input-numeric-example></cookbook-form-field-input-numeric-example>
     <cookbook-form-field-input-disabled-example></cookbook-form-field-input-disabled-example>
     <cookbook-form-field-input-error-example></cookbook-form-field-input-error-example>

--- a/apps/cookbook/src/app/examples/form-field-example/form-field-example.module.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/form-field-example.module.ts
@@ -14,6 +14,7 @@ import { FormFieldFocusExampleComponent } from './examples/input/focus';
 import { FormFieldTextareaDefaultExampleComponent } from './examples/textarea/default';
 import { FormFieldTextareaLabelExampleComponent } from './examples/textarea/label';
 import { FormFieldTextareaCounterExampleComponent } from './examples/textarea/counter';
+import { FormFieldInputPrefixPostfixExampleComponent } from './examples/input/form-field-input-prefix-postfix-example.component';
 
 const COMPONENT_DECLARATIONS = [
   FormFieldInputDefaultExampleComponent,
@@ -28,6 +29,7 @@ const COMPONENT_DECLARATIONS = [
   FormFieldTextareaDefaultExampleComponent,
   FormFieldTextareaLabelExampleComponent,
   FormFieldTextareaCounterExampleComponent,
+  FormFieldInputPrefixPostfixExampleComponent,
 ];
 
 @NgModule({

--- a/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
@@ -26,6 +26,13 @@
   ></cookbook-form-field-input-counter-example>
 </cookbook-example-viewer>
 
+<h3>Prefix - Postfix</h3>
+<cookbook-example-viewer [html]="inputPrefixPostfixExample.template">
+  <cookbook-form-field-input-prefix-postfix-example
+    #inputPrefixPostfixExample
+  ></cookbook-form-field-input-prefix-postfix-example>
+</cookbook-example-viewer>
+
 <h3>Numeric</h3>
 <cookbook-example-viewer [html]="inputNumericExample.template">
   <cookbook-form-field-input-numeric-example
@@ -108,3 +115,7 @@
 <h2>Input Counter</h2>
 <h4>Properties:</h4>
 <cookbook-showcase-properties [properties]="counterProperties"></cookbook-showcase-properties>
+
+<h2>Prefix Postfix</h2>
+<h4>Properties:</h4>
+<cookbook-showcase-properties [properties]="prefixPostProperties"></cookbook-showcase-properties>

--- a/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.ts
@@ -159,4 +159,16 @@ On native devices this method also ensures the form field is scrolled into the v
       inputValues: ['string'],
     },
   ];
+
+  prefixPostProperties: ShowcaseProperty[] = [
+    {
+      name: 'prefixPostfix',
+      defaultValue: undefined,
+      description:
+        'Reference to the kirby-input component that Prefix and or Postfix should be applied to. ' +
+        '' +
+        '',
+      inputValues: ['string'],
+    },
+  ];
 }

--- a/libs/designsystem/debug.log
+++ b/libs/designsystem/debug.log
@@ -1,0 +1,1 @@
+[0114/135924.982:ERROR:directory_reader_win.cc(43)] FindFirstFile: The system cannot find the path specified. (0x3)

--- a/libs/designsystem/src/lib/components/form-field/form-field.component.html
+++ b/libs/designsystem/src/lib/components/form-field/form-field.component.html
@@ -11,9 +11,7 @@
   </div>
 </ng-container>
 
-<div class="prefix-postfix-group">
-  <ng-content select="kirby-dropdown"></ng-content>
-</div>
+<ng-content select="kirby-dropdown"></ng-content>
 
 <div *ngIf="message || counter" class="texts">
   <kirby-form-field-message

--- a/libs/designsystem/src/lib/components/form-field/form-field.component.html
+++ b/libs/designsystem/src/lib/components/form-field/form-field.component.html
@@ -1,11 +1,20 @@
 <label *ngIf="label">
   <div class="text">{{ label }}</div>
-  <ng-container *ngTemplateOutlet="slottedInput"></ng-container>
+  <div class="prefix-postfix-group">
+    <ng-container *ngTemplateOutlet="slottedInput"></ng-container>
+  </div>
 </label>
+
 <ng-container *ngIf="!label">
-  <ng-container *ngTemplateOutlet="slottedInput"></ng-container>
+  <div class="prefix-postfix-group">
+    <ng-container *ngTemplateOutlet="slottedInput"></ng-container>
+  </div>
 </ng-container>
-<ng-content select="kirby-dropdown"></ng-content>
+
+<div class="prefix-postfix-group">
+  <ng-content select="kirby-dropdown"></ng-content>
+</div>
+
 <div *ngIf="message || counter" class="texts">
   <kirby-form-field-message
     *ngIf="message"
@@ -19,6 +28,8 @@
 </div>
 
 <ng-template #slottedInput>
+  <ng-content select="kirby-input-prefix"></ng-content>
   <ng-content select="input[kirby-input]"></ng-content>
   <ng-content select="textarea[kirby-textarea]"></ng-content>
+  <ng-content select="kirby-input-postfix"></ng-content>
 </ng-template>

--- a/libs/designsystem/src/lib/components/form-field/form-field.component.scss
+++ b/libs/designsystem/src/lib/components/form-field/form-field.component.scss
@@ -40,3 +40,13 @@ label {
     padding: 0 size('s');
   }
 }
+.prefix-postfix-group {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0.375rem 0.75rem;
+  margin-bottom: 0;
+}

--- a/libs/designsystem/src/lib/components/form-field/form-field.component.spec.ts
+++ b/libs/designsystem/src/lib/components/form-field/form-field.component.spec.ts
@@ -165,8 +165,8 @@ describe('FormFieldComponent', () => {
 
       it('should render the message with correct width', () => {
         const availableTextWidth = getAvailableTextWidth();
-        const expectedMessageWidth = availableTextWidth * 0.75;
-        const messageWidth = messageElement.getBoundingClientRect().width;
+        const expectedMessageWidth = (availableTextWidth * 0.75).toFixed(0);
+        const messageWidth = messageElement.getBoundingClientRect().width.toFixed(0);
         expect(messageWidth).toEqual(expectedMessageWidth);
       });
 
@@ -201,10 +201,10 @@ describe('FormFieldComponent', () => {
         expect(inputElement).toBeTruthy();
       });
 
-      it('should render the input as a direct descendant', () => {
+      it('should render the input as a 2nd level descendant', () => {
         const inputElement = spectator.queryHost('input[kirby-input]');
         expect(inputElement).toBeTruthy();
-        expect(inputElement.parentElement).toEqual(spectator.element);
+        expect(inputElement.parentElement.parentElement).toEqual(spectator.element);
       });
 
       it('should not render the input within a label', () => {
@@ -289,10 +289,10 @@ describe('FormFieldComponent', () => {
         expect(textareaElement).toBeTruthy();
       });
 
-      it('should render the textarea as a direct descendant', () => {
+      it('should render the textarea as a 2nd level descendant', () => {
         const textareaElement = spectator.queryHost('textarea[kirby-textarea]');
         expect(textareaElement).toBeTruthy();
-        expect(textareaElement.parentElement).toEqual(spectator.element);
+        expect(textareaElement.parentElement.parentElement).toEqual(spectator.element);
       });
 
       it('should not render the textarea within a label', () => {

--- a/libs/designsystem/src/lib/components/form-field/index.ts
+++ b/libs/designsystem/src/lib/components/form-field/index.ts
@@ -3,3 +3,5 @@ export { FormFieldMessageComponent } from './form-field-message/form-field-messa
 export { InputComponent } from './input/input.component';
 export { InputCounterComponent } from './input-counter/input-counter.component';
 export { TextareaComponent } from './textarea/textarea.component';
+export { InputPrefixComponent } from './input-prefix/input-prefix.component';
+export { InputPostfixComponent } from './input-postfix/input-postfix.component';

--- a/libs/designsystem/src/lib/components/form-field/input-postfix/input-postfix.component.scss
+++ b/libs/designsystem/src/lib/components/form-field/input-postfix/input-postfix.component.scss
@@ -1,0 +1,11 @@
+.input-append {
+  margin-left: -1px;
+}
+
+.input-postfix {
+  position: relative;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  width: 1%;
+  margin-bottom: 0;
+}

--- a/libs/designsystem/src/lib/components/form-field/input-postfix/input-postfix.component.spec.ts
+++ b/libs/designsystem/src/lib/components/form-field/input-postfix/input-postfix.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+
 import { InputPostfixComponent } from './input-postfix.component';
 
 describe('InputPostfixComponent', () => {

--- a/libs/designsystem/src/lib/components/form-field/input-postfix/input-postfix.component.spec.ts
+++ b/libs/designsystem/src/lib/components/form-field/input-postfix/input-postfix.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InputPostfixComponent } from './input-postfix.component';
+
+describe('InputPostfixComponent', () => {
+  let component: InputPostfixComponent;
+  let fixture: ComponentFixture<InputPostfixComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [InputPostfixComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(InputPostfixComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/designsystem/src/lib/components/form-field/input-postfix/input-postfix.component.ts
+++ b/libs/designsystem/src/lib/components/form-field/input-postfix/input-postfix.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'kirby-input-postfix',
+  template:
+    '<span class="input-prepend prefix-postfix" [ngClass]="cssClass"><ng-content></ng-content></span>',
+  styleUrls: ['./input-postfix.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+})
+export class InputPostfixComponent {
+  @Input()
+  cssClass: string;
+}

--- a/libs/designsystem/src/lib/components/form-field/input-prefix/input-prefix.component.scss
+++ b/libs/designsystem/src/lib/components/form-field/input-prefix/input-prefix.component.scss
@@ -1,0 +1,36 @@
+.input-prepend {
+  margin-right: -1px;
+}
+
+//TODO: shared style
+.prefix-postfix-group {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  padding: 0.375rem 0.75rem;
+  margin-bottom: 0;
+}
+.prefix-postfix {
+  padding: 0.375rem 0.75rem;
+  margin-bottom: 0;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #495057;
+  text-align: center;
+  white-space: nowrap;
+  // background-color: #e9ecef;
+  border: 1px solid #ced4da;
+  border-radius: 0.25rem;
+}
+.input-prefix-postfix {
+  position: relative;
+  /* -webkit-box-flex: 1; */
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  width: 1%;
+  margin-bottom: 0;
+}

--- a/libs/designsystem/src/lib/components/form-field/input-prefix/input-prefix.component.spec.ts
+++ b/libs/designsystem/src/lib/components/form-field/input-prefix/input-prefix.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InputPrefixComponent } from './input-prefix.component';
+
+describe('InputPrefixComponent', () => {
+  let component: InputPrefixComponent;
+  let fixture: ComponentFixture<InputPrefixComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [InputPrefixComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(InputPrefixComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/designsystem/src/lib/components/form-field/input-prefix/input-prefix.component.spec.ts
+++ b/libs/designsystem/src/lib/components/form-field/input-prefix/input-prefix.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+
 import { InputPrefixComponent } from './input-prefix.component';
 
 describe('InputPrefixComponent', () => {

--- a/libs/designsystem/src/lib/components/form-field/input-prefix/input-prefix.component.ts
+++ b/libs/designsystem/src/lib/components/form-field/input-prefix/input-prefix.component.ts
@@ -1,0 +1,13 @@
+import { Component, HostBinding, Input, OnInit, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'kirby-input-prefix',
+  template:
+    '<span class="input-prepend prefix-postfix" [ngClass]="cssClass"><ng-content></ng-content></span>',
+  styleUrls: ['./input-prefix.component.scss'],
+  encapsulation: ViewEncapsulation.None,
+})
+export class InputPrefixComponent {
+  @Input()
+  cssClass: string;
+}

--- a/libs/designsystem/src/lib/kirby.module.ts
+++ b/libs/designsystem/src/lib/kirby.module.ts
@@ -82,6 +82,7 @@ import { ToggleButtonModule } from './components/toggle-button/toggle-button.mod
 import { SlideDirective, SlidesComponent } from './components/slides/slides.component';
 import { AccordionDirective } from './components/accordion/accordion.directive';
 import { AccordionItemComponent } from './components/accordion/accordion-item.component';
+import { InputPostfixComponent, InputPrefixComponent } from './components';
 
 const exportedDeclarations = [
   CardComponent,
@@ -110,6 +111,8 @@ const exportedDeclarations = [
   ModalFooterComponent,
   ModalRouterLinkDirective,
   SegmentedControlComponent,
+  InputPrefixComponent,
+  InputPostfixComponent,
   ChipComponent,
   BadgeComponent,
   SizeDirective,

--- a/libs/designsystem/testing-base/src/lib/components/mock.input-postfix.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.input-postfix.component.ts
@@ -1,0 +1,20 @@
+import { forwardRef, Component, Input } from '@angular/core';
+
+import { InputPostfixComponent } from '@kirbydesign/designsystem';
+
+// #region AUTO-GENERATED - PLEASE DON'T EDIT CONTENT WITHIN!
+@Component({
+  selector: 'kirby-input-postfix',
+  template: '<ng-content></ng-content>',
+  providers: [
+    {
+      provide: InputPostfixComponent,
+      useExisting: forwardRef(() => MockInputPostfixComponent),
+    },
+  ],
+})
+export class MockInputPostfixComponent {
+  @Input() cssClass: string;
+}
+
+// #endregion

--- a/libs/designsystem/testing-base/src/lib/components/mock.input-prefix.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.input-prefix.component.ts
@@ -1,0 +1,20 @@
+import { forwardRef, Component, Input } from '@angular/core';
+
+import { InputPrefixComponent } from '@kirbydesign/designsystem';
+
+// #region AUTO-GENERATED - PLEASE DON'T EDIT CONTENT WITHIN!
+@Component({
+  selector: 'kirby-input-prefix',
+  template: '<ng-content></ng-content>',
+  providers: [
+    {
+      provide: InputPrefixComponent,
+      useExisting: forwardRef(() => MockInputPrefixComponent),
+    },
+  ],
+})
+export class MockInputPrefixComponent {
+  @Input() cssClass: string;
+}
+
+// #endregion

--- a/libs/designsystem/testing-base/src/lib/mock-components.ts
+++ b/libs/designsystem/testing-base/src/lib/mock-components.ts
@@ -18,6 +18,8 @@ import { MockFormFieldMessageComponent } from './components/mock.form-field-mess
 import { MockFormFieldComponent } from './components/mock.form-field.component';
 import { MockInputComponent } from './components/mock.input.component';
 import { MockInputCounterComponent } from './components/mock.input-counter.component';
+import { MockInputPostfixComponent } from './components/mock.input-postfix.component';
+import { MockInputPrefixComponent } from './components/mock.input-prefix.component';
 import { MockTextareaComponent } from './components/mock.textarea.component';
 import { MockGridComponent } from './components/mock.grid.component';
 import { MockIconComponent } from './components/mock.icon.component';
@@ -73,6 +75,8 @@ export const MOCK_COMPONENTS = [
   MockFormFieldComponent,
   MockInputComponent,
   MockInputCounterComponent,
+  MockInputPostfixComponent,
+  MockInputPrefixComponent,
   MockTextareaComponent,
   MockGridComponent,
   MockIconComponent,


### PR DESCRIPTION
This PR wil close #459 when finalized

The vocabulary for suffix has been changes to postfix, to be more precise/correct

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Due to kirby-form-field being content based with only accepting input and textarea and kirby-dropdown, 
Issue Number: 459

## What is the new behavior?
Extended kirby-form-field to accept prefix and postfix components 
Added div container with flex style to create a row based alignment, except for kirby-dropdown.


## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
The kirby-dropdown still represents an issue with respect to being nested inside a div container for creating a flex row