### PR TITLE
fix: ignored click item in when scrollend (ios)

### DIFF
--- a/libs/designsystem/src/lib/components/item/item.component.scss
+++ b/libs/designsystem/src/lib/components/item/item.component.scss
@@ -15,7 +15,7 @@
 
     --background: var(--kirby-item-background, #{get-color('white')});
     --background-activated: var(--kirby-item-background-activated, #{get-color('white-shade')});
-    // WORKAROUND: Needed to fix ignored clicked on scrollend
+    // WORKAROUND: Needed to fix ignored click on scrollend
     // https://github.com/ionic-team/ionic-framework/issues/21871
     --background-activated-opacity: 0.99;
     --background-focused: var(--kirby-item-background-focused, #{get-color('background-color')});

--- a/libs/designsystem/src/lib/components/item/item.component.scss
+++ b/libs/designsystem/src/lib/components/item/item.component.scss
@@ -15,7 +15,6 @@
 
     --background: var(--kirby-item-background, #{get-color('white')});
     --background-activated: var(--kirby-item-background-activated, #{get-color('white-shade')});
-    --background-activated-opacity: 1;
     --background-focused: var(--kirby-item-background-focused, #{get-color('background-color')});
     --background-focused-opacity: 1;
     --background-hover: var(--kirby-item-background-hover, #{get-color('background-color')});

--- a/libs/designsystem/src/lib/components/item/item.component.scss
+++ b/libs/designsystem/src/lib/components/item/item.component.scss
@@ -15,6 +15,9 @@
 
     --background: var(--kirby-item-background, #{get-color('white')});
     --background-activated: var(--kirby-item-background-activated, #{get-color('white-shade')});
+    // WORKAROUND: Needed to fix ignored clicked on scrollend
+    // https://github.com/ionic-team/ionic-framework/issues/21871
+    --background-activated-opacity: 0.99;
     --background-focused: var(--kirby-item-background-focused, #{get-color('background-color')});
     --background-focused-opacity: 1;
     --background-hover: var(--kirby-item-background-hover, #{get-color('background-color')});


### PR DESCRIPTION
This PR closes # (reference issue number here)
With Capacitor it is not triggering click first time if:
1. Ion content with some padding (50px here) and scrollEvents true
2. --background-activated-opacity: 1 and "button" on item
3. Scroll to very bottom of list and click on an item
4. See list i "moving" and click is ignored, second click will work


Click is ignored as in video
![bug-click-item-in-modal](https://user-images.githubusercontent.com/9210691/104791892-94544f00-579c-11eb-9727-4ce82e40529c.gif)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
With Capacitor it is not triggering click first time if:
1. Ion content with some padding (50px here) and scrollEvents true
2. --background-activated-opacity: 1 and "button" on item
3. Scroll to very bottom of list and click on an item
4. See list i "moving" and click is ignored, second click will work

https://github.com/ionic-team/ionic-framework/issues/21871

Click is ignored as in video

Issue Number: N/A

## What is the new behavior?
Click is not ignored first time

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
