### PR TITLE
Updated Size directive to target input, added styling for medium

### DIFF
--- a/apps/cookbook/src/app/examples/form-field-example/examples/input-medium/borderless.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/examples/input-medium/borderless.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+
+const config = {
+  selector: 'cookbook-form-field-input-medium-borderless-example',
+  template: `<kirby-form-field size="md" label="Input field with no borders and initial width">
+  <input kirby-input borderless="true" />
+</kirby-form-field>`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+})
+export class FormFieldInputMediumBorderlessExampleComponent {
+  template: string = config.template;
+}

--- a/apps/cookbook/src/app/examples/form-field-example/examples/input-medium/counter.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/examples/input-medium/counter.ts
@@ -1,0 +1,27 @@
+import { Component } from '@angular/core';
+
+const config = {
+  selector: 'cookbook-form-field-input-medium-counter-example',
+  template: `<kirby-form-field>
+  <input kirby-input size="md" placeholder="Tweet your message (max 140 chars)" #tweet maxlength="140" />
+  <kirby-input-counter [listenTo]="tweet"></kirby-input-counter>
+</kirby-form-field>
+
+<kirby-form-field>
+  <input kirby-input size="md" value="Character counter with prefilled value" #prefilled maxlength="50" />
+  <kirby-input-counter [listenTo]="prefilled"></kirby-input-counter>
+</kirby-form-field>
+
+<kirby-form-field message="Character counter with message and no maxlength">
+  <input kirby-input size="md" #message />
+  <kirby-input-counter [listenTo]="message"></kirby-input-counter>
+</kirby-form-field>`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+})
+export class FormFieldInputMediumCounterExampleComponent {
+  template: string = config.template;
+}

--- a/apps/cookbook/src/app/examples/form-field-example/examples/input-medium/default.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/examples/input-medium/default.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+
+const config = {
+  selector: 'cookbook-form-field-input-medium-example',
+  template: `<kirby-form-field>
+  <input kirby-input size="md" placeholder="Default input with placeholder text" />
+</kirby-form-field>`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+})
+export class FormFieldInputMediumDefaultExampleComponent {
+  template: string = config.template;
+}

--- a/apps/cookbook/src/app/examples/form-field-example/examples/input-medium/disabled.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/examples/input-medium/disabled.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+
+const config = {
+  selector: 'cookbook-form-field-input-medium-disabled-example',
+  template: `<kirby-form-field>
+  <input kirby-input size="md" disabled value="Disabled input" />
+</kirby-form-field>`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+})
+export class FormFieldInputMediumDisabledExampleComponent {
+  template = config.template;
+}

--- a/apps/cookbook/src/app/examples/form-field-example/examples/input-medium/error.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/examples/input-medium/error.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+
+const config = {
+  selector: 'cookbook-form-field-input-medium-error-example',
+  template: `<kirby-form-field label="Error" message="This is an error message">
+  <input kirby-input size="md" hasError="true" />
+</kirby-form-field>`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+})
+export class FormFieldInputMediumErrorExampleComponent {
+  template: string = config.template;
+}

--- a/apps/cookbook/src/app/examples/form-field-example/examples/input-medium/label-message.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/examples/input-medium/label-message.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+
+const config = {
+  selector: 'cookbook-form-field-input-medium-label-message-example',
+  template: `<kirby-form-field label="Input with label and message" message="This is additional info that will be shown below the input">
+  <input kirby-input size="md" />
+</kirby-form-field>`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+})
+export class FormFieldInputMediumLabelMessageExampleComponent {
+  template: string = config.template;
+}

--- a/apps/cookbook/src/app/examples/form-field-example/examples/input-medium/label.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/examples/input-medium/label.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+
+const config = {
+  selector: 'cookbook-form-field-input-medium-label-example',
+  template: `<kirby-form-field label="Input with label">
+  <input kirby-input size="md"/>
+</kirby-form-field>`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+})
+export class FormFieldInputMediumLabelExampleComponent {
+  template: string = config.template;
+}

--- a/apps/cookbook/src/app/examples/form-field-example/examples/input-medium/numeric.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/examples/input-medium/numeric.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+
+const config = {
+  selector: 'cookbook-form-field-input-medium-numeric-example',
+  template: `<kirby-form-field label="Numeric input">
+  <input type="number" kirby-input size="md" />
+</kirby-form-field>`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+})
+export class FormFieldInputMediumNumericExampleComponent {
+  template: string = config.template;
+}

--- a/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.html
+++ b/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.html
@@ -11,6 +11,16 @@
     <cookbook-form-field-input-borderless-example></cookbook-form-field-input-borderless-example>
     <cookbook-form-field-focus-example></cookbook-form-field-focus-example>
 
+    <h2>Input Medium</h2>
+    <cookbook-form-field-input-medium-example></cookbook-form-field-input-medium-example>
+    <cookbook-form-field-input-medium-label-example></cookbook-form-field-input-medium-label-example>
+    <cookbook-form-field-input-medium-label-message-example></cookbook-form-field-input-medium-label-message-example>
+    <cookbook-form-field-input-medium-counter-example></cookbook-form-field-input-medium-counter-example>
+    <cookbook-form-field-input-medium-numeric-example></cookbook-form-field-input-medium-numeric-example>
+    <cookbook-form-field-input-medium-disabled-example></cookbook-form-field-input-medium-disabled-example>
+    <cookbook-form-field-input-medium-error-example></cookbook-form-field-input-medium-error-example>
+    <cookbook-form-field-input-medium-borderless-example></cookbook-form-field-input-medium-borderless-example>
+
     <h2>Textarea</h2>
     <cookbook-form-field-textarea-example></cookbook-form-field-textarea-example>
     <cookbook-form-field-textarea-label-example></cookbook-form-field-textarea-label-example>

--- a/apps/cookbook/src/app/examples/form-field-example/form-field-example.module.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/form-field-example.module.ts
@@ -1,19 +1,28 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 
 import { KirbyModule } from '@kirbydesign/designsystem';
-import { FormFieldInputDefaultExampleComponent } from './examples/input/default';
-import { FormFieldInputLabelExampleComponent } from './examples/input/label';
-import { FormFieldInputLabelMessageExampleComponent } from './examples/input/label-message';
+
+import { FormFieldInputMediumBorderlessExampleComponent } from './examples/input-medium/borderless';
+import { FormFieldInputMediumCounterExampleComponent } from './examples/input-medium/counter';
+import { FormFieldInputMediumDefaultExampleComponent } from './examples/input-medium/default';
+import { FormFieldInputMediumDisabledExampleComponent } from './examples/input-medium/disabled';
+import { FormFieldInputMediumErrorExampleComponent } from './examples/input-medium/error';
+import { FormFieldInputMediumLabelExampleComponent } from './examples/input-medium/label';
+import { FormFieldInputMediumLabelMessageExampleComponent } from './examples/input-medium/label-message';
+import { FormFieldInputMediumNumericExampleComponent } from './examples/input-medium/numeric';
+import { FormFieldInputBorderlessExampleComponent } from './examples/input/borderless';
 import { FormFieldInputCounterExampleComponent } from './examples/input/counter';
-import { FormFieldInputNumericExampleComponent } from './examples/input/numeric';
+import { FormFieldInputDefaultExampleComponent } from './examples/input/default';
 import { FormFieldInputDisabledExampleComponent } from './examples/input/disabled';
 import { FormFieldInputErrorExampleComponent } from './examples/input/error';
-import { FormFieldInputBorderlessExampleComponent } from './examples/input/borderless';
 import { FormFieldFocusExampleComponent } from './examples/input/focus';
+import { FormFieldInputLabelExampleComponent } from './examples/input/label';
+import { FormFieldInputLabelMessageExampleComponent } from './examples/input/label-message';
+import { FormFieldInputNumericExampleComponent } from './examples/input/numeric';
+import { FormFieldTextareaCounterExampleComponent } from './examples/textarea/counter';
 import { FormFieldTextareaDefaultExampleComponent } from './examples/textarea/default';
 import { FormFieldTextareaLabelExampleComponent } from './examples/textarea/label';
-import { FormFieldTextareaCounterExampleComponent } from './examples/textarea/counter';
 
 const COMPONENT_DECLARATIONS = [
   FormFieldInputDefaultExampleComponent,
@@ -25,6 +34,14 @@ const COMPONENT_DECLARATIONS = [
   FormFieldInputErrorExampleComponent,
   FormFieldInputBorderlessExampleComponent,
   FormFieldFocusExampleComponent,
+  FormFieldInputMediumDefaultExampleComponent,
+  FormFieldInputMediumLabelExampleComponent,
+  FormFieldInputMediumLabelMessageExampleComponent,
+  FormFieldInputMediumCounterExampleComponent,
+  FormFieldInputMediumNumericExampleComponent,
+  FormFieldInputMediumDisabledExampleComponent,
+  FormFieldInputMediumErrorExampleComponent,
+  FormFieldInputMediumBorderlessExampleComponent,
   FormFieldTextareaDefaultExampleComponent,
   FormFieldTextareaLabelExampleComponent,
   FormFieldTextareaCounterExampleComponent,

--- a/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
@@ -1,4 +1,4 @@
-<h2>Input</h2>
+<h2>Input Large (default)</h2>
 
 <h3>Default</h3>
 <cookbook-example-viewer [html]="inputDefaultExample.template">
@@ -57,6 +57,64 @@
 <h3>Focus programmatically</h3>
 <cookbook-example-viewer [html]="focusExample.template" [ts]="focusExample.codeSnippet">
   <cookbook-form-field-focus-example #focusExample></cookbook-form-field-focus-example>
+</cookbook-example-viewer>
+
+<h2>Input Medium</h2>
+
+<h3>Default</h3>
+<cookbook-example-viewer [html]="mediumInputDefaultExample.template">
+  <cookbook-form-field-input-medium-example
+    #mediumInputDefaultExample
+  ></cookbook-form-field-input-medium-example>
+</cookbook-example-viewer>
+
+<h3>Label</h3>
+<cookbook-example-viewer [html]="inputMediumLabelExample.template">
+  <cookbook-form-field-input-medium-label-example
+    #inputMediumLabelExample
+  ></cookbook-form-field-input-medium-label-example>
+</cookbook-example-viewer>
+
+<h3>Label & Message</h3>
+<cookbook-example-viewer [html]="inputMediumLabelMessageExample.template">
+  <cookbook-form-field-input-medium-label-message-example
+    #inputMediumLabelMessageExample
+  ></cookbook-form-field-input-medium-label-message-example>
+</cookbook-example-viewer>
+
+<h3>Character counter</h3>
+<cookbook-example-viewer [html]="inputMediumCounterExample.template">
+  <cookbook-form-field-input-medium-counter-example
+    #inputMediumCounterExample
+  ></cookbook-form-field-input-medium-counter-example>
+</cookbook-example-viewer>
+
+<h3>Numeric</h3>
+<cookbook-example-viewer [html]="inputMediumNumericExample.template">
+  <cookbook-form-field-input-medium-numeric-example
+    #inputMediumNumericExample
+  ></cookbook-form-field-input-medium-numeric-example>
+</cookbook-example-viewer>
+
+<h3>Disabled</h3>
+<cookbook-example-viewer [html]="inputMediumDisabledExample.template">
+  <cookbook-form-field-input-medium-disabled-example
+    #inputMediumDisabledExample
+  ></cookbook-form-field-input-medium-disabled-example>
+</cookbook-example-viewer>
+
+<h3>Error</h3>
+<cookbook-example-viewer [html]="inputMediumErrorExample.template">
+  <cookbook-form-field-input-medium-error-example
+    #inputMediumErrorExample
+  ></cookbook-form-field-input-medium-error-example>
+</cookbook-example-viewer>
+
+<h3>Borderless</h3>
+<cookbook-example-viewer [html]="inputMediumBorderlessExample.template">
+  <cookbook-form-field-input-medium-borderless-example
+    #inputMediumBorderlessExample
+  ></cookbook-form-field-input-medium-borderless-example>
 </cookbook-example-viewer>
 
 <h2>Textarea</h2>

--- a/libs/designsystem/src/lib/components/form-field/input/input.component.scss
+++ b/libs/designsystem/src/lib/components/form-field/input/input.component.scss
@@ -18,6 +18,11 @@
   height: size('xxxl');
 }
 
+:host(.md) {
+  height: size('xl');
+  border-radius: size('m');
+}
+
 /* clean-css ignore:start */
 :host-context(kirby-item kirby-form-field[slot='end']) {
   &[type='number'] {

--- a/libs/designsystem/src/lib/components/form-field/input/input.component.spec.ts
+++ b/libs/designsystem/src/lib/components/form-field/input/input.component.spec.ts
@@ -1,7 +1,8 @@
-import { SpectatorHost, createHostFactory } from '@ngneat/spectator';
 import { fakeAsync, tick } from '@angular/core/testing';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
 
 import { DesignTokenHelper } from '../../../helpers/design-token-helper';
+
 import { InputComponent } from './input.component';
 
 const getColor = DesignTokenHelper.getColor;

--- a/libs/designsystem/src/lib/directives/size/size.directive.ts
+++ b/libs/designsystem/src/lib/directives/size/size.directive.ts
@@ -1,9 +1,10 @@
-import { Directive, Input, HostBinding } from '@angular/core';
+import { Directive, HostBinding, Input } from '@angular/core';
 
 @Directive({
   // don't worry. I know what i am doing!
-  // tslint:disable-next-line:directive-selector
-  selector: 'button[size], kirby-icon[size], kirby-avatar[size], kirby-item[size]',
+  selector:
+    // tslint:disable-next-line: directive-selector
+    'button[size], kirby-icon[size], kirby-avatar[size], kirby-item[size] input[kirby-input][size]',
 })
 export class SizeDirective {
   @HostBinding('class.xs')
@@ -15,10 +16,10 @@ export class SizeDirective {
   @HostBinding('class.lg')
   isLargeSize: boolean;
   @Input() set size(size: Sizes) {
-    this.isExtraSmall = size === 'xs';
-    this.isSmallSize = size === 'sm';
-    this.isMediumSize = size === 'md';
-    this.isLargeSize = size === 'lg';
+    this.isExtraSmall = size === Sizes.extraSmall;
+    this.isSmallSize = size === Sizes.small;
+    this.isMediumSize = size === Sizes.medium;
+    this.isLargeSize = size === Sizes.large;
   }
 }
 


### PR DESCRIPTION
This PR closes #992 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Form field inputs only have one size, Large, that is 56px high

## What is the new behavior?
It is now possible to add a `size="md"` to the input, which results in an input field that is 40px high.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
