### PR TITLE
Feat/modal navigation module root path

### DIFF
--- a/apps/cookbook/src/app/showcase/showcase.module.ts
+++ b/apps/cookbook/src/app/showcase/showcase.module.ts
@@ -1,15 +1,17 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { IonicModule } from '@ionic/angular';
 
 import { KirbyModule } from '@kirbydesign/designsystem';
-import { COMPONENT_IMPORTS, COMPONENT_EXPORTS, COMPONENT_DECLARATIONS } from './showcase.common';
+
+import { IphoneModule } from '../iphone/iphone.module';
 import { CodeViewerComponent } from '../shared/code-viewer/code-viewer.component';
 import { ExampleViewerComponent } from '../shared/example-viewer/example-viewer.component';
 import { ShowcasePropertiesComponent } from '../shared/showcase-properties/showcase-properties.component';
-import { IphoneModule } from '../iphone/iphone.module';
+
 import { DividerShowcaseComponent } from './divider-showcase/divider-showcase.component';
+import { COMPONENT_DECLARATIONS, COMPONENT_EXPORTS, COMPONENT_IMPORTS } from './showcase.common';
 
 @NgModule({
   imports: [
@@ -17,7 +19,7 @@ import { DividerShowcaseComponent } from './divider-showcase/divider-showcase.co
     CommonModule,
     FormsModule,
     IonicModule,
-    KirbyModule,
+    KirbyModule.forChild({ moduleRootRoutePath: '/home/showcase/' }),
     IphoneModule,
   ],
   declarations: [

--- a/apps/cookbook/src/app/showcase/showcase.module.ts
+++ b/apps/cookbook/src/app/showcase/showcase.module.ts
@@ -19,7 +19,7 @@ import { COMPONENT_DECLARATIONS, COMPONENT_EXPORTS, COMPONENT_IMPORTS } from './
     CommonModule,
     FormsModule,
     IonicModule,
-    KirbyModule.forChild({ moduleRootRoutePath: '/home/showcase/' }),
+    KirbyModule.forChild({ moduleRootRoutePath: '/home/showcase' }),
     IphoneModule,
   ],
   declarations: [

--- a/libs/designsystem/src/lib/components/modal/services/modal-navigation.service.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal-navigation.service.ts
@@ -28,12 +28,8 @@ export class ModalNavigationService {
     const flattenedRoutes: Routes = [].concat(...routeConfig);
     let modalRoutes: string[] = [];
     const moduleRootPaths = await this.getModuleRootPath(flattenedRoutes, moduleRootRoutePath);
-    if (moduleRootRoutePath) {
-      console.warn('ModalNavigationService.getModalRouteMap - moduleRootPaths:', moduleRootPaths);
-    }
     if (moduleRootPaths) {
       modalRoutes = this.getModalRoutePaths(flattenedRoutes, moduleRootPaths);
-      console.warn('ModalNavigationService.getModalRouteMap - modalRoutes:', modalRoutes);
     }
     return new Map(modalRoutes.map((modalRoute) => [modalRoute, modalRoute]));
   }

--- a/libs/designsystem/src/lib/components/modal/services/modal-navigation.service.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal-navigation.service.ts
@@ -1,15 +1,13 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRoute, NavigationEnd, Route, Router, Routes } from '@angular/router';
 import { EMPTY, Observable } from 'rxjs';
-import { filter, first, map, pairwise, startWith, tap } from 'rxjs/operators';
+import { filter, first, map, pairwise, startWith } from 'rxjs/operators';
 
 import { ModalRouteActivation } from './modal.interfaces';
 
 @Injectable({ providedIn: 'root' })
 export class ModalNavigationService {
-  constructor(private router: Router, private route: ActivatedRoute) {
-    console.log('*************** ModalNavigationService ctor ***************');
-  }
+  constructor(private router: Router, private route: ActivatedRoute) {}
 
   isModalRoute(url: string): boolean {
     return url.includes('(modal:');
@@ -51,9 +49,7 @@ export class ModalNavigationService {
     }
 
     const currentRoutePaths = await this.getCurrentRoutePaths();
-    console.log('currentRoutePaths BEFORE:', currentRoutePaths);
     this.removeChildSegments(currentRoutePaths, routes);
-    console.log('currentRoutePaths AFTER:', currentRoutePaths);
     return currentRoutePaths;
   }
 
@@ -61,11 +57,8 @@ export class ModalNavigationService {
     const rootPath = [''];
     const currentNavigation = this.router.getCurrentNavigation();
 
-    console.log('this.router.navigated:', this.router.navigated);
-    console.log('currentNavigation:', currentNavigation);
     if (!this.router.navigated && !currentNavigation) {
       // If router hasn't navigated yet and we are not in the middle of navigating, assume root:
-      console.log('assume root...');
       return rootPath;
     }
 
@@ -182,12 +175,6 @@ export class ModalNavigationService {
     modalRouteMap: Map<string, string>
   ): Observable<ModalRouteActivation> {
     return navigationEnd$.pipe(
-      tap((navigationEnd) => {
-        console.log('navigationEnd:', navigationEnd);
-        console.log('isModalRoute:', this.isModalRoute(navigationEnd.urlAfterRedirects));
-        console.log('isNewModal:', this.isNewModalWindow(navigationEnd));
-        console.log('modalRouteMap:', modalRouteMap);
-      }),
       filter((navigationEnd) => modalRouteMap.has(navigationEnd.urlAfterRedirects)),
       map((navigationEnd) => ({
         route: this.getCurrentActivatedRoute(),

--- a/libs/designsystem/src/lib/components/modal/services/modal.controller.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal.controller.ts
@@ -5,12 +5,13 @@ import { filter, map, takeUntil } from 'rxjs/operators';
 
 import { KirbyAnimation } from '../../../animation/kirby-animation';
 import { ActionSheetConfig } from '../action-sheet/config/action-sheet-config';
-import { ModalConfig } from '../modal-wrapper/config/modal-config';
-import { ActionSheetHelper } from './action-sheet.helper';
 import { AlertConfig } from '../alert/config/alert-config';
+import { ModalConfig } from '../modal-wrapper/config/modal-config';
+
+import { ActionSheetHelper } from './action-sheet.helper';
 import { AlertHelper } from './alert.helper';
-import { ModalHelper } from './modal.helper';
 import { ModalNavigationService } from './modal-navigation.service';
+import { ModalHelper } from './modal.helper';
 import { ModalRouteActivation, Overlay } from './modal.interfaces';
 
 @Injectable()
@@ -25,10 +26,17 @@ export class ModalController implements OnDestroy {
     private alertHelper: AlertHelper,
     private modalNavigationService: ModalNavigationService,
     @Optional() @Inject(ROUTES) private routeConfig: Routes[]
-  ) {}
+  ) {
+    console.log('**************************************');
+    console.log('ModalController constructorzzzz...');
+    console.log('**************************************');
+  }
 
-  async initialize() {
-    const modalNavigation = await this.modalNavigationService.getModalNavigation(this.routeConfig);
+  async initialize(moduleRootRoutePath?: string) {
+    const modalNavigation = await this.modalNavigationService.getModalNavigation(
+      this.routeConfig,
+      moduleRootRoutePath
+    );
     this.onModalRouteActivated(modalNavigation.activated$);
     this.onModalRouteDeactivated(modalNavigation.deactivated$); // TODO: Do we want to close modal when routing out of modal route? Or should the code that navigates close the window??
   }

--- a/libs/designsystem/src/lib/components/modal/services/modal.controller.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal.controller.ts
@@ -26,11 +26,7 @@ export class ModalController implements OnDestroy {
     private alertHelper: AlertHelper,
     private modalNavigationService: ModalNavigationService,
     @Optional() @Inject(ROUTES) private routeConfig: Routes[]
-  ) {
-    console.log('**************************************');
-    console.log('ModalController constructorzzzz...');
-    console.log('**************************************');
-  }
+  ) {}
 
   async initialize(moduleRootRoutePath?: string) {
     const modalNavigation = await this.modalNavigationService.getModalNavigation(

--- a/libs/designsystem/src/lib/kirby.module.spec.ts
+++ b/libs/designsystem/src/lib/kirby.module.spec.ts
@@ -7,7 +7,7 @@ describe('KirbyModule', () => {
 
   beforeEach(() => {
     modalControllerSpy = jasmine.createSpyObj<ModalController>('ModalController', ['initialize']);
-    kirbyModule = new KirbyModule(modalControllerSpy, {});
+    kirbyModule = new KirbyModule(modalControllerSpy);
   });
 
   it('should create an instance', () => {

--- a/libs/designsystem/src/lib/kirby.module.spec.ts
+++ b/libs/designsystem/src/lib/kirby.module.spec.ts
@@ -7,7 +7,7 @@ describe('KirbyModule', () => {
 
   beforeEach(() => {
     modalControllerSpy = jasmine.createSpyObj<ModalController>('ModalController', ['initialize']);
-    kirbyModule = new KirbyModule(modalControllerSpy);
+    kirbyModule = new KirbyModule(modalControllerSpy, {});
   });
 
   it('should create an instance', () => {

--- a/libs/designsystem/src/lib/kirby.module.ts
+++ b/libs/designsystem/src/lib/kirby.module.ts
@@ -228,7 +228,7 @@ export class KirbyModule {
 
   constructor(
     modalController: ModalController,
-    @Optional() @Inject(ConfigToken) config: KirbyConfig
+    @Optional() @Inject(ConfigToken) config?: KirbyConfig
   ) {
     modalController.initialize(config && config.moduleRootRoutePath);
   }

--- a/libs/designsystem/src/lib/kirby.module.ts
+++ b/libs/designsystem/src/lib/kirby.module.ts
@@ -1,27 +1,12 @@
-import { NgModule } from '@angular/core';
+import { OverlayModule } from '@angular/cdk/overlay';
 import { CommonModule } from '@angular/common';
+import { Inject, InjectionToken, ModuleWithProviders, NgModule, Optional } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { IonicModule } from '@ionic/angular';
-import { OverlayModule } from '@angular/cdk/overlay';
 
-import { InfiniteScrollDirective } from './components/list/directives/infinite-scroll.directive';
-import { ModalWrapperComponent } from './components/modal/modal-wrapper/modal-wrapper.component';
-import { ModalCompactWrapperComponent } from './components/modal/modal-wrapper/compact/modal-compact-wrapper.component';
-import { ModalFooterComponent } from './components/modal/footer/modal-footer.component';
-import { ModalRouterLinkDirective } from './directives/modal-router-link/modal-router-link.directive';
-import { KeyHandlerDirective } from './directives/key-handler/key-handler.directive';
-import { FullscreenLoadingOverlayComponent } from './components/loading-overlay/fullscreen-loading-overlay/fullscreen-loading-overlay.component';
-import { LoadingOverlayComponent } from './components/loading-overlay/loading-overlay.component';
-import { ListItemColorDirective } from './components/list/directives/list-item-color.directive';
-import { AlertComponent } from './components/modal/alert/alert.component';
-import { PageModule } from './components/page/page.module';
-import { FormFieldMessageComponent } from './components/form-field/form-field-message/form-field-message.component';
-import { RouterOutletModule } from './components/router-outlet/router-outlet.module';
-import { TabsModule } from './components/tabs/tabs.module';
-import { IconModule } from './components/icon/icon.module';
-import { ItemModule } from './components/item/item.module';
+import { AccordionItemComponent } from './components/accordion/accordion-item.component';
+import { AccordionDirective } from './components/accordion/accordion.directive';
 import { AppModule } from './components/app/app.module';
-import { ReorderListComponent } from './components/reorder-list/reorder-list.component';
 import { AvatarComponent } from './components/avatar/avatar.component';
 import { BadgeComponent } from './components/badge/badge.component';
 import { ButtonComponent } from './components/button/button.component';
@@ -30,11 +15,25 @@ import { CardFooterComponent } from './components/card/card-footer/card-footer.c
 import { CardHeaderComponent } from './components/card/card-header/card-header.component';
 import { CardComponent } from './components/card/card.component';
 import { ChartComponent } from './components/chart/chart.component';
-import { StockChartComponent } from './components/stock-chart/stock-chart.component';
 import { CheckboxComponent } from './components/checkbox/checkbox.component';
 import { ChipComponent } from './components/chip/chip.component';
+import { DividerComponent } from './components/divider/divider.component';
+import { DropdownComponent } from './components/dropdown/dropdown.component';
 import { EmptyStateComponent } from './components/empty-state/empty-state.component';
+import { FabSheetComponent } from './components/fab-sheet/fab-sheet.component';
+import { FlagComponent } from './components/flag/flag.component';
+import { FormFieldMessageComponent } from './components/form-field/form-field-message/form-field-message.component';
+import { FormFieldComponent } from './components/form-field/form-field.component';
+import { InputCounterComponent } from './components/form-field/input-counter/input-counter.component';
+import { InputComponent } from './components/form-field/input/input.component';
+import { TextareaComponent } from './components/form-field/textarea/textarea.component';
+import { BreakpointHelperService } from './components/grid/breakpoint-helper.service';
 import { GridComponent } from './components/grid/grid.component';
+import { IconRegistryService } from './components/icon/icon-registry.service';
+import { IconModule } from './components/icon/icon.module';
+import { ItemModule } from './components/item/item.module';
+import { InfiniteScrollDirective } from './components/list/directives/infinite-scroll.directive';
+import { ListItemColorDirective } from './components/list/directives/list-item-color.directive';
 import { ListHeaderComponent } from './components/list/list-header/list-header.component';
 import { ListSectionHeaderComponent } from './components/list/list-section-header/list-section-header.component';
 import { ListComponent } from './components/list/list.component';
@@ -47,43 +46,44 @@ import {
   ListSectionHeaderDirective,
 } from './components/list/list.directive';
 import { GroupByPipe } from './components/list/pipes/group-by.pipe';
+import { FullscreenLoadingOverlayComponent } from './components/loading-overlay/fullscreen-loading-overlay/fullscreen-loading-overlay.component';
+import { LoadingOverlayService } from './components/loading-overlay/fullscreen-loading-overlay/loading-overlay.service';
+import { LoadingOverlayComponent } from './components/loading-overlay/loading-overlay.component';
 import { ActionSheetComponent } from './components/modal/action-sheet/action-sheet.component';
+import { AlertComponent } from './components/modal/alert/alert.component';
+import { ModalFooterComponent } from './components/modal/footer/modal-footer.component';
+import { ModalCompactWrapperComponent } from './components/modal/modal-wrapper/compact/modal-compact-wrapper.component';
+import { ModalWrapperComponent } from './components/modal/modal-wrapper/modal-wrapper.component';
 import { ActionSheetHelper } from './components/modal/services/action-sheet.helper';
 import { AlertHelper } from './components/modal/services/alert.helper';
-import { SegmentedControlComponent } from './components/segmented-control/segmented-control.component';
 import { ModalController } from './components/modal/services/modal.controller';
 import { ModalHelper } from './components/modal/services/modal.helper';
+import { PageModule } from './components/page/page.module';
+import { ProgressCircleRingComponent } from './components/progress-circle/progress-circle-ring.component';
+import { ProgressCircleComponent } from './components/progress-circle/progress-circle.component';
+import { RadioGroupComponent } from './components/radio/radio-group/radio-group.component';
+import { RadioComponent } from './components/radio/radio.component';
+import { ReorderListComponent } from './components/reorder-list/reorder-list.component';
+import { RouterOutletModule } from './components/router-outlet/router-outlet.module';
+import { SegmentedControlComponent } from './components/segmented-control/segmented-control.component';
 import { ComponentLoaderDirective } from './components/shared/component-loader.directive';
-import { SlideButtonComponent } from './components/slide-button/slide-button.component';
-import { SpinnerComponent } from './components/spinner/spinner.component';
-import { ToastController } from './components/toast/services/toast.controller';
-import { ToastHelper } from './components/toast/services/toast.helper';
-import { ToggleComponent } from './components/toggle/toggle.component';
-import { SizeDirective } from './directives/size/size.directive';
-import { ThemeColorDirective } from './directives/theme-color/theme-color.directive';
-import { ToolbarComponent } from './components/toolbar/toolbar.component';
-import { FabSheetComponent } from './components/fab-sheet/fab-sheet.component';
-import { FormFieldComponent } from './components/form-field/form-field.component';
-import { InputComponent } from './components/form-field/input/input.component';
-import { TextareaComponent } from './components/form-field/textarea/textarea.component';
-import { InputCounterComponent } from './components/form-field/input-counter/input-counter.component';
-import { DividerComponent } from './components/divider/divider.component';
-import { DropdownComponent } from './components/dropdown/dropdown.component';
-import { BreakpointHelperService } from './components/grid/breakpoint-helper.service';
-import { LoadingOverlayService } from './components/loading-overlay/fullscreen-loading-overlay/loading-overlay.service';
 import { ResizeObserverFactory } from './components/shared/resize-observer/resize-observer.factory';
 import { ResizeObserverService } from './components/shared/resize-observer/resize-observer.service';
-import { ProgressCircleComponent } from './components/progress-circle/progress-circle.component';
-import { ProgressCircleRingComponent } from './components/progress-circle/progress-circle-ring.component';
-import { FlagComponent } from './components/flag/flag.component';
-import { IconRegistryService } from './components/icon/icon-registry.service';
-import { WindowRef } from './types/window-ref';
-import { ToggleButtonModule } from './components/toggle-button/toggle-button.module';
+import { SlideButtonComponent } from './components/slide-button/slide-button.component';
 import { SlideDirective, SlidesComponent } from './components/slides/slides.component';
-import { AccordionDirective } from './components/accordion/accordion.directive';
-import { AccordionItemComponent } from './components/accordion/accordion-item.component';
-import { RadioComponent } from './components/radio/radio.component';
-import { RadioGroupComponent } from './components/radio/radio-group/radio-group.component';
+import { SpinnerComponent } from './components/spinner/spinner.component';
+import { StockChartComponent } from './components/stock-chart/stock-chart.component';
+import { TabsModule } from './components/tabs/tabs.module';
+import { ToastController } from './components/toast/services/toast.controller';
+import { ToastHelper } from './components/toast/services/toast.helper';
+import { ToggleButtonModule } from './components/toggle-button/toggle-button.module';
+import { ToggleComponent } from './components/toggle/toggle.component';
+import { ToolbarComponent } from './components/toolbar/toolbar.component';
+import { KeyHandlerDirective } from './directives/key-handler/key-handler.directive';
+import { ModalRouterLinkDirective } from './directives/modal-router-link/modal-router-link.directive';
+import { SizeDirective } from './directives/size/size.directive';
+import { ThemeColorDirective } from './directives/theme-color/theme-color.directive';
+import { WindowRef } from './types/window-ref';
 
 const exportedDeclarations = [
   CardComponent,
@@ -191,6 +191,11 @@ const entryComponents = [
   AlertComponent,
 ];
 
+const ConfigToken = new InjectionToken<any>('USERCONFIG');
+export interface KirbyConfig {
+  moduleRootRoutePath?: string;
+}
+
 @NgModule({
   imports: [
     CommonModule,
@@ -209,7 +214,22 @@ const entryComponents = [
   exports: exports,
 })
 export class KirbyModule {
-  constructor(modalController: ModalController) {
-    modalController.initialize();
+  static forChild(config?: KirbyConfig): ModuleWithProviders<KirbyModule> {
+    return {
+      ngModule: KirbyModule,
+      providers: [
+        {
+          provide: ConfigToken,
+          useValue: config,
+        },
+      ],
+    };
+  }
+
+  constructor(
+    modalController: ModalController,
+    @Optional() @Inject(ConfigToken) config: KirbyConfig
+  ) {
+    modalController.initialize(config && config.moduleRootRoutePath);
   }
 }


### PR DESCRIPTION
This PR closes #1285 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Right now modal-navigation.service assumes that the moduleRootPath is known on init which is not always the case.

Issue Number: #1285 

## What is the new behavior?
Makes it possible to configure custom moduleRootPath for modal navigation (outlets) 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
