### PR TITLE
Empty state button rules

### DIFF
--- a/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.component.html
+++ b/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.component.html
@@ -42,3 +42,12 @@
 >
 </kirby-empty-state>
 <hr />
+<kirby-empty-state
+  iconName="help"
+  title="Button attention levels"
+  subtitle="All slotted buttons will have attention level 3. Except the first button with level 1. "
+>
+  <button kirby-button attentionLevel="1">Call support</button>
+  <button kirby-button attentionLevel="2">Mail support</button>
+  <button kirby-button attentionLevel="4">Get directions</button>
+</kirby-empty-state>

--- a/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.component.html
+++ b/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.component.html
@@ -45,7 +45,7 @@
 <kirby-empty-state
   iconName="help"
   title="Button attention levels"
-  subtitle="All slotted buttons will have attention level 3. Except the first button with level 1. "
+  subtitle="All slotted buttons will be rendered with attention level 3, except the first button if it is configured with attention level 1."
 >
   <button kirby-button attentionLevel="1">Call support</button>
   <button kirby-button attentionLevel="2">Mail support</button>

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.integration.spec.ts
@@ -22,10 +22,10 @@ describe('EmptyStateComponent with slotted buttons', () => {
               title="No items"
               subtitle="You don't have any items. Call support to add some items to your account."
           >
-              <button kirby-button attentionLevel='4'>Call support</button>
-              <button kirby-button attentionLevel='3'>Mail support</button>
-              <button kirby-button attentionLevel='2'>Get directions</button>
-              <button kirby-button attentionLevel='1'>Cancel</button>
+              <button kirby-button attentionLevel="4">Call support</button>
+              <button kirby-button attentionLevel="3">Mail support</button>
+              <button kirby-button attentionLevel="2">Get directions</button>
+              <button kirby-button attentionLevel="1">Cancel</button>
           </kirby-empty-state>
       `);
 
@@ -53,10 +53,10 @@ describe('EmptyStateComponent with slotted buttons where the first has attention
             title="No items"
             subtitle="You don't have any items. Call support to add some items to your account."
         >
-            <button kirby-button attentionLevel='1'>Call support</button>
-            <button kirby-button attentionLevel='2'>Mail support</button>
-            <button kirby-button attentionLevel='3'>Get directions</button>
-            <button kirby-button attentionLevel='4'>Cancel</button>
+            <button kirby-button attentionLevel="1">Call support</button>
+            <button kirby-button attentionLevel="2">Mail support</button>
+            <button kirby-button attentionLevel="3">Get directions</button>
+            <button kirby-button attentionLevel="4">Cancel</button>
         </kirby-empty-state>
     `);
 

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.integration.spec.ts
@@ -1,0 +1,87 @@
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
+import { MockComponent } from 'ng-mocks';
+
+import { ButtonComponent } from '../button/button.component';
+import { IconComponent } from '../icon/icon.component';
+
+import { DesignTokenHelper } from './../../helpers/design-token-helper';
+import { EmptyStateComponent } from './empty-state.component';
+
+fdescribe('EmptyStateComponent with slotted buttons', () => {
+  let spectator: SpectatorHost<EmptyStateComponent>;
+  let element: HTMLElement;
+  let buttons: ButtonComponent[];
+
+  const createHost = createHostFactory({
+    component: EmptyStateComponent,
+    declarations: [MockComponent(IconComponent), ButtonComponent],
+  });
+
+  beforeEach(() => {
+    spectator = createHost(`
+          <kirby-empty-state
+              iconName="help"
+              title="No items"
+              subtitle="You don't have any items. Call support to add some items to your account."
+          >
+              <button kirby-button attentionLevel='1'>Call support</button>
+              <button kirby-button attentionLevel='2'>Mail support</button>
+              <button kirby-button attentionLevel='3'>Get directions </button>
+              <button kirby-button attentionLevel='4'>Mail support</button>
+          </kirby-empty-state>
+      `);
+
+    element = spectator.element;
+    buttons = spectator.queryAll(ButtonComponent);
+  });
+
+  it('should set the attention level of all buttons to 3', () => {
+    expect(buttons.every((button) => button.isAttentionLevel3)).toBeTrue();
+  });
+
+  it('should enforce attention level rules when a button is added', () => {
+    expect('implement me').toBeTrue();
+  });
+
+  it('should enforce attention level rules when a button is removed', () => {
+    expect('implement me').toBeTrue();
+  });
+});
+
+fdescribe('EmptyStateComponent with slotted buttons where the first has attention level 1', () => {
+  let spectator: SpectatorHost<EmptyStateComponent>;
+  let element: HTMLElement;
+  let buttons: ButtonComponent[];
+
+  const createHost = createHostFactory({
+    component: EmptyStateComponent,
+    declarations: [MockComponent(IconComponent), ButtonComponent],
+  });
+
+  beforeEach(() => {
+    spectator = createHost(`
+        <kirby-empty-state
+            iconName="help"
+            title="No items"
+            subtitle="You don't have any items. Call support to add some items to your account."
+        >
+            <button kirby-button attentionLevel='1'>Call support</button>
+            <button kirby-button attentionLevel='2'>Mail support</button>
+            <button kirby-button attentionLevel='3'>Get directions </button>
+            <button kirby-button attentionLevel='4'>Mail support</button>
+        </kirby-empty-state>
+    `);
+
+    element = spectator.element;
+    buttons = spectator.queryAll(ButtonComponent);
+  });
+
+  it('should not change the attention level of the first button', () => {
+    expect(buttons[0].isAttentionLevel1).toBeTrue();
+  });
+
+  it('should set the attention level of all buttons to 3 except the first one', () => {
+    const allButtonsButTheFirst = buttons.splice(1, buttons.length);
+    expect(allButtonsButTheFirst.every((button) => button.isAttentionLevel3)).toBeTrue();
+  });
+});

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.integration.spec.ts
@@ -24,10 +24,10 @@ fdescribe('EmptyStateComponent with slotted buttons', () => {
               title="No items"
               subtitle="You don't have any items. Call support to add some items to your account."
           >
-              <button kirby-button attentionLevel='1'>Call support</button>
-              <button kirby-button attentionLevel='2'>Mail support</button>
-              <button kirby-button attentionLevel='3'>Get directions </button>
-              <button kirby-button attentionLevel='4'>Mail support</button>
+              <button kirby-button attentionLevel='4'>Call support</button>
+              <button kirby-button attentionLevel='3'>Mail support</button>
+              <button kirby-button attentionLevel='2'>Get directions </button>
+              <button kirby-button attentionLevel='1'>Cancel</button>
           </kirby-empty-state>
       `);
 
@@ -38,19 +38,10 @@ fdescribe('EmptyStateComponent with slotted buttons', () => {
   it('should set the attention level of all buttons to 3', () => {
     expect(buttons.every((button) => button.isAttentionLevel3)).toBeTrue();
   });
-
-  it('should enforce attention level rules when a button is added', () => {
-    expect('implement me').toBeTrue();
-  });
-
-  it('should enforce attention level rules when a button is removed', () => {
-    expect('implement me').toBeTrue();
-  });
 });
 
 fdescribe('EmptyStateComponent with slotted buttons where the first has attention level 1', () => {
   let spectator: SpectatorHost<EmptyStateComponent>;
-  let element: HTMLElement;
   let buttons: ButtonComponent[];
 
   const createHost = createHostFactory({
@@ -67,12 +58,11 @@ fdescribe('EmptyStateComponent with slotted buttons where the first has attentio
         >
             <button kirby-button attentionLevel='1'>Call support</button>
             <button kirby-button attentionLevel='2'>Mail support</button>
-            <button kirby-button attentionLevel='3'>Get directions </button>
-            <button kirby-button attentionLevel='4'>Mail support</button>
+            <button kirby-button attentionLevel='3'>Get directions</button>
+            <button kirby-button attentionLevel='4'>Cancel</button>
         </kirby-empty-state>
     `);
 
-    element = spectator.element;
     buttons = spectator.queryAll(ButtonComponent);
   });
 

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.integration.spec.ts
@@ -7,7 +7,7 @@ import { IconComponent } from '../icon/icon.component';
 import { DesignTokenHelper } from './../../helpers/design-token-helper';
 import { EmptyStateComponent } from './empty-state.component';
 
-fdescribe('EmptyStateComponent with slotted buttons', () => {
+describe('EmptyStateComponent with slotted buttons', () => {
   let spectator: SpectatorHost<EmptyStateComponent>;
   let element: HTMLElement;
   let buttons: ButtonComponent[];
@@ -40,7 +40,7 @@ fdescribe('EmptyStateComponent with slotted buttons', () => {
   });
 });
 
-fdescribe('EmptyStateComponent with slotted buttons where the first has attention level 1', () => {
+describe('EmptyStateComponent with slotted buttons where the first has attention level 1', () => {
   let spectator: SpectatorHost<EmptyStateComponent>;
   let buttons: ButtonComponent[];
 

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.integration.spec.ts
@@ -24,7 +24,7 @@ describe('EmptyStateComponent with slotted buttons', () => {
           >
               <button kirby-button attentionLevel='4'>Call support</button>
               <button kirby-button attentionLevel='3'>Mail support</button>
-              <button kirby-button attentionLevel='2'>Get directions </button>
+              <button kirby-button attentionLevel='2'>Get directions</button>
               <button kirby-button attentionLevel='1'>Cancel</button>
           </kirby-empty-state>
       `);

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.integration.spec.ts
@@ -4,12 +4,10 @@ import { MockComponent } from 'ng-mocks';
 import { ButtonComponent } from '../button/button.component';
 import { IconComponent } from '../icon/icon.component';
 
-import { DesignTokenHelper } from './../../helpers/design-token-helper';
 import { EmptyStateComponent } from './empty-state.component';
 
 describe('EmptyStateComponent with slotted buttons', () => {
   let spectator: SpectatorHost<EmptyStateComponent>;
-  let element: HTMLElement;
   let buttons: ButtonComponent[];
 
   const createHost = createHostFactory({
@@ -31,7 +29,6 @@ describe('EmptyStateComponent with slotted buttons', () => {
           </kirby-empty-state>
       `);
 
-    element = spectator.element;
     buttons = spectator.queryAll(ButtonComponent);
   });
 

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.integration.spec.ts
@@ -22,6 +22,42 @@ describe('EmptyStateComponent with slotted buttons', () => {
               title="No items"
               subtitle="You don't have any items. Call support to add some items to your account."
           >
+              <button kirby-button>Call support</button>
+              <button kirby-button>Mail support</button>
+              <button kirby-button>Get directions</button>
+              <button kirby-button>Cancel</button>
+          </kirby-empty-state>
+      `);
+
+    buttons = spectator.queryAll(ButtonComponent);
+  });
+
+  it('should not change the attention level of the first button', () => {
+    expect(buttons[0].isAttentionLevel1).toBeTrue();
+  });
+
+  it('should set the attention level of all buttons to 3 except the first one', () => {
+    const allButtonsButTheFirst = buttons.splice(1, buttons.length);
+    expect(allButtonsButTheFirst.every((button) => button.isAttentionLevel3)).toBeTrue();
+  });
+});
+
+describe('EmptyStateComponent with slotted buttons configured with attention levels', () => {
+  let spectator: SpectatorHost<EmptyStateComponent>;
+  let buttons: ButtonComponent[];
+
+  const createHost = createHostFactory({
+    component: EmptyStateComponent,
+    declarations: [MockComponent(IconComponent), ButtonComponent],
+  });
+
+  beforeEach(() => {
+    spectator = createHost(`
+          <kirby-empty-state
+              iconName="help"
+              title="No items"
+              subtitle="You don't have any items. Call support to add some items to your account."
+          >
               <button kirby-button attentionLevel="4">Call support</button>
               <button kirby-button attentionLevel="3">Mail support</button>
               <button kirby-button attentionLevel="2">Get directions</button>
@@ -37,7 +73,7 @@ describe('EmptyStateComponent with slotted buttons', () => {
   });
 });
 
-describe('EmptyStateComponent with slotted buttons where the first has attention level 1', () => {
+describe('EmptyStateComponent with slotted buttons configured with attention levels where the first has attention level 1', () => {
   let spectator: SpectatorHost<EmptyStateComponent>;
   let buttons: ButtonComponent[];
 

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.spec.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.spec.ts
@@ -1,8 +1,10 @@
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
 import { MockComponent } from 'ng-mocks';
-import { SpectatorHost, createHostFactory } from '@ngneat/spectator';
+
+import { ButtonComponent } from '../button/button.component';
+import { IconComponent } from '../icon/icon.component';
 
 import { DesignTokenHelper } from './../../helpers/design-token-helper';
-import { IconComponent } from '../icon/icon.component';
 import { EmptyStateComponent } from './empty-state.component';
 
 describe('EmptyStateComponent', () => {
@@ -11,7 +13,7 @@ describe('EmptyStateComponent', () => {
 
   const createHost = createHostFactory({
     component: EmptyStateComponent,
-    declarations: [MockComponent(IconComponent)],
+    declarations: [MockComponent(IconComponent), ButtonComponent],
   });
 
   beforeEach(() => {
@@ -22,6 +24,9 @@ describe('EmptyStateComponent', () => {
       subtitle="You don't have any items. Call support to add some items to your account."
     >
       <button kirby-button>Call support</button>
+      <button kirby-button attentionLevel='2'> Mail support</button>
+      <button kirby-button attentionLevel='3'> Get directions </button>
+      <button kirby-button attentionLevel='1'> Mail support</button>
     </kirby-empty-state>
     `);
     element = spectator.element;
@@ -34,5 +39,33 @@ describe('EmptyStateComponent', () => {
   it('should render with the correct border width', () => {
     const outlineElement = element.getElementsByClassName('icon-outline')[0];
     expect(outlineElement).toHaveComputedStyle({ 'border-width': DesignTokenHelper.size('xxxs') });
+  });
+
+  describe('Attention level rules for buttons', () => {
+    let buttons: ButtonComponent[];
+
+    beforeEach(() => {
+      buttons = spectator.queryAll(ButtonComponent);
+    });
+
+    it('should change all buttons to attention level 3 except 1', () => {
+      const numberLvl3Buttons = buttons.filter((button) => button.isAttentionLevel3).length;
+      const numberLvl1Buttons = buttons.filter((button) => button.isAttentionLevel1).length;
+
+      expect(numberLvl1Buttons).toEqual(1);
+      expect(numberLvl3Buttons).toEqual(3);
+    });
+
+    it('should keep the attention level on the first button with attention level 1', () => {
+      expect(buttons.findIndex((button) => button.isAttentionLevel1)).toEqual(0);
+    });
+
+    it('should enforce attention level rules when a button is added', () => {
+      // TODO: implement test...
+    });
+
+    it('should enforce attention level rules when a button is removed', () => {
+      // TODO: implement test...
+    });
   });
 });

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.spec.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.spec.ts
@@ -24,9 +24,9 @@ describe('EmptyStateComponent', () => {
       subtitle="You don't have any items. Call support to add some items to your account."
     >
       <button kirby-button>Call support</button>
-      <button kirby-button attentionLevel='2'> Mail support</button>
-      <button kirby-button attentionLevel='3'> Get directions </button>
-      <button kirby-button attentionLevel='1'> Mail support</button>
+      <button kirby-button attentionLevel='2'>Mail support</button>
+      <button kirby-button attentionLevel='3'>Get directions </button>
+      <button kirby-button attentionLevel='1'>Mail support</button>
     </kirby-empty-state>
     `);
     element = spectator.element;

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.spec.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.spec.ts
@@ -1,9 +1,8 @@
-import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
 import { MockComponent } from 'ng-mocks';
-
-import { IconComponent } from '../icon/icon.component';
+import { SpectatorHost, createHostFactory } from '@ngneat/spectator';
 
 import { DesignTokenHelper } from './../../helpers/design-token-helper';
+import { IconComponent } from '../icon/icon.component';
 import { EmptyStateComponent } from './empty-state.component';
 
 describe('EmptyStateComponent', () => {

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.spec.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.spec.ts
@@ -1,7 +1,6 @@
 import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
 import { MockComponent } from 'ng-mocks';
 
-import { ButtonComponent } from '../button/button.component';
 import { IconComponent } from '../icon/icon.component';
 
 import { DesignTokenHelper } from './../../helpers/design-token-helper';
@@ -13,7 +12,7 @@ describe('EmptyStateComponent', () => {
 
   const createHost = createHostFactory({
     component: EmptyStateComponent,
-    declarations: [MockComponent(IconComponent), ButtonComponent],
+    declarations: [MockComponent(IconComponent)],
   });
 
   beforeEach(() => {
@@ -24,9 +23,6 @@ describe('EmptyStateComponent', () => {
       subtitle="You don't have any items. Call support to add some items to your account."
     >
       <button kirby-button>Call support</button>
-      <button kirby-button attentionLevel='2'>Mail support</button>
-      <button kirby-button attentionLevel='3'>Get directions </button>
-      <button kirby-button attentionLevel='1'>Mail support</button>
     </kirby-empty-state>
     `);
     element = spectator.element;
@@ -39,33 +35,5 @@ describe('EmptyStateComponent', () => {
   it('should render with the correct border width', () => {
     const outlineElement = element.getElementsByClassName('icon-outline')[0];
     expect(outlineElement).toHaveComputedStyle({ 'border-width': DesignTokenHelper.size('xxxs') });
-  });
-
-  describe('Attention level rules for buttons', () => {
-    let buttons: ButtonComponent[];
-
-    beforeEach(() => {
-      buttons = spectator.queryAll(ButtonComponent);
-    });
-
-    it('should change all buttons to attention level 3 except 1', () => {
-      const numberLvl3Buttons = buttons.filter((button) => button.isAttentionLevel3).length;
-      const numberLvl1Buttons = buttons.filter((button) => button.isAttentionLevel1).length;
-
-      expect(numberLvl1Buttons).toEqual(1);
-      expect(numberLvl3Buttons).toEqual(3);
-    });
-
-    it('should keep the attention level on the first button with attention level 1', () => {
-      expect(buttons.findIndex((button) => button.isAttentionLevel1)).toEqual(0);
-    });
-
-    it('should enforce attention level rules when a button is added', () => {
-      // TODO: implement test...
-    });
-
-    it('should enforce attention level rules when a button is removed', () => {
-      // TODO: implement test...
-    });
   });
 });

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.ts
@@ -1,13 +1,5 @@
-import {
-  AfterContentInit,
-  Component,
-  ContentChildren,
-  Input,
-  OnDestroy,
-  QueryList,
-} from '@angular/core';
-import { Subject } from 'rxjs';
-import { delay, takeUntil } from 'rxjs/operators';
+import { AfterContentInit, Component, ContentChildren, Input, QueryList } from '@angular/core';
+import { delay } from 'rxjs/operators';
 
 import { ButtonComponent } from '../button/button.component';
 
@@ -25,8 +17,6 @@ export class EmptyStateComponent implements AfterContentInit {
   @ContentChildren(ButtonComponent)
   private slottedButtons: QueryList<ButtonComponent>;
 
-  private ngUnsubscribe$ = new Subject<void>();
-
   ngAfterContentInit() {
     this.enforceAttentionLevelRules();
 
@@ -34,16 +24,14 @@ export class EmptyStateComponent implements AfterContentInit {
   }
 
   /** Enforces that all buttons will have their attention
-   * level set to 3 except the first encountered button
-   * with level 1
+   * level set to 3, except the first button if it has
+   * level 1.
    */
   private enforceAttentionLevelRules() {
-    let encounteredLvl1Button = false;
+    this.slottedButtons.forEach((button, index) => {
+      if (index === 0 && button.isAttentionLevel1) return;
 
-    this.slottedButtons.forEach((button) => {
-      if (button.isAttentionLevel1 && !encounteredLvl1Button) {
-        encounteredLvl1Button = true;
-      } else if (!button.isAttentionLevel3) {
+      if (!button.isAttentionLevel3) {
         button.attentionLevel = '3';
       }
     });

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.ts
@@ -23,7 +23,7 @@ export class EmptyStateComponent implements AfterContentInit {
     this.slottedButtons.changes.pipe(delay(0)).subscribe(() => this.enforceAttentionLevelRules());
   }
 
-  /** Enforces that all buttons will have their attention
+  /** Enforces that all slotted buttons will have their attention
    * level set to 3, except the first button if it has
    * level 1.
    */

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.ts
@@ -1,5 +1,4 @@
 import { AfterContentInit, Component, ContentChildren, Input, QueryList } from '@angular/core';
-import { delay } from 'rxjs/operators';
 
 import { ButtonComponent } from '../button/button.component';
 

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.ts
@@ -1,13 +1,58 @@
-import { Component, Input } from '@angular/core';
+import {
+  AfterContentInit,
+  Component,
+  ContentChildren,
+  Input,
+  OnDestroy,
+  QueryList,
+} from '@angular/core';
+import { Subject } from 'rxjs';
+import { delay, takeUntil } from 'rxjs/operators';
+
+import { ButtonComponent } from '../button/button.component';
 
 @Component({
   selector: 'kirby-empty-state',
   templateUrl: './empty-state.component.html',
   styleUrls: ['./empty-state.component.scss'],
 })
-export class EmptyStateComponent {
+export class EmptyStateComponent implements AfterContentInit, OnDestroy {
   @Input() iconName: string;
   @Input() customIconName: string;
   @Input() title: string;
   @Input() subtitle: string;
+
+  @ContentChildren(ButtonComponent)
+  private slottedButtons: QueryList<ButtonComponent>;
+
+  private ngUnsubscribe$ = new Subject<void>();
+
+  ngAfterContentInit() {
+    this.enforceAttentionLevelRules();
+
+    this.slottedButtons.changes
+      .pipe(takeUntil(this.ngUnsubscribe$), delay(0))
+      .subscribe(() => this.enforceAttentionLevelRules());
+  }
+
+  ngOnDestroy() {
+    this.ngUnsubscribe$.next();
+    this.ngUnsubscribe$.complete();
+  }
+
+  /** Enforces that all buttons will have their attention
+   * level set to 3 except the first encountered button
+   * with level 1
+   */
+  private enforceAttentionLevelRules() {
+    let encounteredLvl1Button = false;
+
+    this.slottedButtons.forEach((button) => {
+      if (button.isAttentionLevel1 && !encounteredLvl1Button) {
+        encounteredLvl1Button = true;
+      } else if (!button.isAttentionLevel3) {
+        button.attentionLevel = '3';
+      }
+    });
+  }
 }

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.ts
@@ -16,7 +16,7 @@ import { ButtonComponent } from '../button/button.component';
   templateUrl: './empty-state.component.html',
   styleUrls: ['./empty-state.component.scss'],
 })
-export class EmptyStateComponent implements AfterContentInit, OnDestroy {
+export class EmptyStateComponent implements AfterContentInit {
   @Input() iconName: string;
   @Input() customIconName: string;
   @Input() title: string;
@@ -30,14 +30,7 @@ export class EmptyStateComponent implements AfterContentInit, OnDestroy {
   ngAfterContentInit() {
     this.enforceAttentionLevelRules();
 
-    this.slottedButtons.changes
-      .pipe(takeUntil(this.ngUnsubscribe$), delay(0))
-      .subscribe(() => this.enforceAttentionLevelRules());
-  }
-
-  ngOnDestroy() {
-    this.ngUnsubscribe$.next();
-    this.ngUnsubscribe$.complete();
+    this.slottedButtons.changes.pipe(delay(0)).subscribe(() => this.enforceAttentionLevelRules());
   }
 
   /** Enforces that all buttons will have their attention

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.ts
@@ -20,9 +20,11 @@ export class EmptyStateComponent implements AfterContentInit {
   ngAfterContentInit() {
     this.enforceAttentionLevelRules();
 
-    /* as enforceAttentionLevelRules changes the attention level of slotted buttons, 
-    delay(0) is used to make these changes happen in a seperate cd cycle */
-    this.slottedButtons.changes.pipe(delay(0)).subscribe(() => this.enforceAttentionLevelRules());
+    /* setTimeout prevents ExpressionChangedAfterItHasBeenCheckedError when changing attention 
+    levels of slotted buttons in this.enforceAttentionLevelRules */
+    this.slottedButtons.changes.subscribe(() => {
+      setTimeout(() => this.enforceAttentionLevelRules());
+    });
   }
 
   /** Enforces that all slotted buttons will have their attention

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.ts
@@ -20,6 +20,7 @@ export class EmptyStateComponent implements AfterContentInit {
   ngAfterContentInit() {
     this.enforceAttentionLevelRules();
 
+    // delay(0) causes changes to happen in a seperate cd cycle
     this.slottedButtons.changes.pipe(delay(0)).subscribe(() => this.enforceAttentionLevelRules());
   }
 

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.ts
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.ts
@@ -20,7 +20,8 @@ export class EmptyStateComponent implements AfterContentInit {
   ngAfterContentInit() {
     this.enforceAttentionLevelRules();
 
-    // delay(0) causes changes to happen in a seperate cd cycle
+    /* as enforceAttentionLevelRules changes the attention level of slotted buttons, 
+    delay(0) is used to make these changes happen in a seperate cd cycle */
     this.slottedButtons.changes.pipe(delay(0)).subscribe(() => this.enforceAttentionLevelRules());
   }
 


### PR DESCRIPTION
This PR closes #1222. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1222 

## What is the new behavior?
When a `emptyStateComponent` has `button`-children all of them will have their attention level set to 3; except the first one with attention level 1. This also applies if buttons are dynamically added or removed from the `emptyStateComponent`. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
This is a draft as I still have to add tests for adding and removing button children from the emptyStateComponent. I however need a bit of help with this; see comments. 
