### PR TITLE
Enhancement/min width button

### DIFF
--- a/libs/designsystem/src/lib/components/button/button.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/button/button.component.integration.spec.ts
@@ -1,27 +1,28 @@
 import { RouterTestingModule } from '@angular/router/testing';
-import { SpectatorHost, createHostFactory } from '@ngneat/spectator';
 import { IonicModule, IonIcon } from '@ionic/angular';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
 import { MockComponent, MockComponents, MockDirectives } from 'ng-mocks';
 
+import { FitHeadingDirective } from '../../directives/fit-heading/fit-heading.directive';
+import { SizeDirective } from '../../directives/size/size.directive';
 import { DesignTokenHelper } from '../../helpers/design-token-helper';
 import { TestHelper } from '../../testing/test-helper';
+import { WindowRef } from '../../types/window-ref';
+import { CardComponent } from '../card/card.component';
+import { DropdownComponent } from '../dropdown/dropdown.component';
+import { EmptyStateComponent } from '../empty-state/empty-state.component';
+import { IconComponent } from '../icon/icon.component';
+import { ItemComponent } from '../item/item.component';
 import {
-  PageComponent,
-  PageContentComponent,
   PageActionsComponent,
   PageActionsDirective,
+  PageComponent,
+  PageContentComponent,
   PageTitleDirective,
   PageToolbarTitleDirective,
 } from '../page/page.component';
-import { FitHeadingDirective } from '../../directives/fit-heading/fit-heading.directive';
-import { SizeDirective } from '../../directives/size/size.directive';
+
 import { ButtonComponent } from './button.component';
-import { IconComponent } from '../icon/icon.component';
-import { EmptyStateComponent } from '../empty-state/empty-state.component';
-import { DropdownComponent } from '../dropdown/dropdown.component';
-import { CardComponent } from '../card/card.component';
-import { ItemComponent } from '../item/item.component';
-import { WindowRef } from '../../types/window-ref';
 
 const getColor = DesignTokenHelper.getColor;
 const size = DesignTokenHelper.size;
@@ -282,6 +283,10 @@ describe('ButtonComponent with size directive', () => {
     it('should render with correct height', () => {
       expect(element).toHaveComputedStyle({ height: size('l') });
     });
+
+    it('should render with correct min-width', () => {
+      expect(element).toHaveComputedStyle({ 'min-width': '44px' });
+    });
   });
 
   describe('when configured with size = MD', () => {
@@ -296,6 +301,10 @@ describe('ButtonComponent with size directive', () => {
 
     it('should render with correct height', () => {
       expect(element).toHaveComputedStyle({ height: size('xl') });
+    });
+
+    it('should render with correct min-width', () => {
+      expect(element).toHaveComputedStyle({ 'min-width': '88px' });
     });
   });
 
@@ -542,7 +551,7 @@ describe('ButtonComponent configured with text and icon', () => {
   });
 
   describe('and size directive with size = SM', () => {
-    it('should render with correct icon font-size', () => {
+    beforeEach(() => {
       spectator = createHost(
         `<button kirby-button size="sm">
           <span>Text</span>
@@ -552,13 +561,19 @@ describe('ButtonComponent configured with text and icon', () => {
 
       element = spectator.element as HTMLButtonElement;
       kirbyIcon = element.getElementsByTagName('kirby-icon')[0];
+    });
 
+    it('should render with correct icon font-size', () => {
       expect(kirbyIcon).toHaveComputedStyle({ 'font-size': size('s') });
+    });
+
+    it('should render with correct min-width', () => {
+      expect(element).toHaveComputedStyle({ 'min-width': '88px' });
     });
   });
 
   describe('and size directive with size = MD', () => {
-    it('should render with correct icon font-size', () => {
+    beforeEach(() => {
       spectator = createHost(
         `<button kirby-button size="md">
           <span>Text</span>
@@ -568,13 +583,19 @@ describe('ButtonComponent configured with text and icon', () => {
 
       element = spectator.element as HTMLButtonElement;
       kirbyIcon = element.getElementsByTagName('kirby-icon')[0];
+    });
 
+    it('should render with correct icon font-size', () => {
       expect(kirbyIcon).toHaveComputedStyle({ 'font-size': size('m') });
+    });
+
+    it('should render with correct min-width', () => {
+      expect(element).toHaveComputedStyle({ 'min-width': '88px' });
     });
   });
 
   describe('and size directive with size = LG', () => {
-    it('should render with correct icon font-size', () => {
+    beforeEach(() => {
       spectator = createHost(
         `<button kirby-button size="lg">
           <span>Text</span>
@@ -584,8 +605,14 @@ describe('ButtonComponent configured with text and icon', () => {
 
       element = spectator.element as HTMLButtonElement;
       kirbyIcon = element.getElementsByTagName('kirby-icon')[0];
+    });
 
+    it('should render with correct icon font-size', () => {
       expect(kirbyIcon).toHaveComputedStyle({ 'font-size': size('m') });
+    });
+
+    it('should render with correct min-width', () => {
+      expect(element).toHaveComputedStyle({ 'min-width': '220px' });
     });
   });
 });

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -3,6 +3,7 @@
 @mixin button-sm {
   font-size: font-size('xs');
   height: size('l');
+  min-width: 44px;
 
   &:not(.icon-only) {
     padding-left: size('s');
@@ -11,11 +12,13 @@
 
   &.icon-only {
     width: size('l');
+    min-width: unset;
   }
 
   &.icon-left,
   &.icon-right {
     --kirby-icon-font-size: #{size('s')};
+    min-width: 88px;
   }
 }
 
@@ -86,10 +89,11 @@
   white-space: nowrap;
 
   // we default to 'md' size.
-  margin: size('xxxs');
-  padding: 0 size('m');
   font-size: font-size('s');
   height: size('xl');
+  min-width: 88px;
+  padding: 0 size('m');
+  margin: size('xxxs');
   line-height: line-height('s');
 
   // Outline is applied on button border instead,
@@ -112,6 +116,7 @@
   &.icon-only {
     width: size('xl');
     padding: 0;
+    min-width: unset;
   }
 
   &.sm {

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -6,7 +6,7 @@ $button-width: (
   lg: 220px,
 ) !default;
 
-@function button-width($key: 'md') {
+@function button-width($key) {
   @return map-get($button-width, $key);
 }
 

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -1,9 +1,19 @@
 @import '../../scss/utils';
 
+$button-width: (
+  sm: 44px,
+  md: 88px,
+  lg: 220px,
+) !default;
+
+@function button-width($key: 'md') {
+  @return map-get($button-width, $key);
+}
+
 @mixin button-sm {
   font-size: font-size('xs');
   height: size('l');
-  min-width: 44px;
+  min-width: button-width('sm');
 
   &:not(.icon-only) {
     padding-left: size('s');
@@ -18,14 +28,14 @@
   &.icon-left,
   &.icon-right {
     --kirby-icon-font-size: #{size('s')};
-    min-width: 88px;
+    min-width: button-width('md');
   }
 }
 
 @mixin button-lg {
   font-size: font-size('n');
   height: size('xxl');
-  min-width: 220px;
+  min-width: button-width('lg');
 
   &.icon-only {
     width: size('xxl');
@@ -91,7 +101,7 @@
   // we default to 'md' size.
   font-size: font-size('s');
   height: size('xl');
-  min-width: 88px;
+  min-width: button-width('md');
   padding: 0 size('m');
   margin: size('xxxs');
   line-height: line-height('s');


### PR DESCRIPTION
This PR closes #1305 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [X] Enhancement (to existing content)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1305

## What is the new behavior?
A `min-width` property has been added to the styles for small and medium buttons. A small button will now have a minimum width of 44px when it has text only; 88px when it has text and an icon. Medium buttons will have a minimum width of 88px, except when used with an icon only. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->