### PR TITLE
[Enhancement] Replace 'NOT Tech refined' label with 'NOT Verified' for bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: "[BUG]"
-labels: NOT Prioritized, NOT Tech refined, bug
+labels: NOT Prioritized, NOT Verified, bug
 assignees: ''
 
 ---
@@ -41,10 +41,12 @@ Add any other context about the problem here.
 <!--*NOT Prioritized*-->
 <!--Consider urgency of the Bug and be specific if it is blocking for your project. Describe any deadlines for the issue - eg. X needs this done by Y date, to be used in Z sprint. Suggest a milestone for the issue. The Not Prioritized will be removed by the Kirby team. If the bug has "low" priority it will be solved eventually - typically when working with the effected component in a different context.-->
 
-<!--*NOT Tech Refined*-->
-<!--Sketch a solution in technical terms, that is how will the bug will be fixed. Call for a brief meeting or spend enough time with someone from @kirbydesign/kirby-guild to get a "go ahead". Remove NOT Tech Refined label. (Move issue from "Backlog" -> "Ready to do" on our [project board](https://github.com/kirbydesign/designsystem/projects/1)-->
+<!--*NOT Verified*-->
+<!--The reported bug might be inteded behaviour - the bug should therefore be verified before it is fixed. Ask a member of @kirbydesign/kirby-guild to verify the bug, before you begin fixing it. When the bug is verified the "NOT Verified" label will be removed.-->
+
 
 ## Tasks:
+- [ ] Have the bug report verified by contacting a member of @kirbydesign/kirby-guild
 - [ ] Move issue from "Ready to do" -> "in progress" on our [project board](https://github.com/kirbydesign/designsystem/projects/1)
 - [ ] Create Fix Branch
 - [ ] Create test reproducing the error


### PR DESCRIPTION
This PR closes #1362

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Enhancement (to existing content)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [X] Other... Please describe: Process and templates

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1362 

## What is the new behavior?
I have replaced the "NOT Tech refined" label with "NOT Verified" in `bug_report.md` template and updated tasks accordingly. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

