### PR TITLE
Fix/button active state

### DIFF
--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -163,8 +163,11 @@ $button-width: (
     --kirby-button-border-color: #{$focus-ring-color};
   }
 
-  &:hover,
-  &:focus {
+  @include hover() {
+    opacity: 0.8;
+  }
+
+  &:active {
     opacity: 0.8;
   }
 


### PR DESCRIPTION
This PR closes #1340

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement (to existing content)
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently the button will keep its reduced opacity/tint after being clicked, until you click outside the element. This actually happens on both mobile and desktop. 

## What is the new behavior?
On mobile the button is only momentarily tinted, when the button element is active (clicked). On desktop, you will see similar behavior, but with the same tint added on hover too.  

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
