### PR TITLE
Fix/calendar min date and max date null ref

### DIFF
--- a/libs/designsystem/src/lib/components/calendar/calendar.component.initialization.spec.ts
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.initialization.spec.ts
@@ -27,18 +27,56 @@ describe('CalendarComponent', () => {
     ],
   });
 
-  beforeEach(() => {
-    spectator = createHost('<kirby-calendar></kirby-calendar>', {
-      props: {
-        minDate: new Date(2017, 0, 1),
-        maxDate: new Date(2025, 11, 31),
-      },
-    });
-  });
+  type calendarProps = keyof CalendarComponent;
+  const testScenarios: { property: calendarProps; value: any }[] = [
+    { property: 'alwaysEnableToday', value: true },
+    { property: 'disableWeekends', value: true },
+    { property: 'disablePastDates', value: true },
+    { property: 'disableFutureDates', value: true },
+    {
+      property: 'disabledDates',
+      value: [new Date(2005, 6, 3), new Date(2007, 9, 29), new Date(2012, 0, 17)],
+    },
+    { property: 'minDate', value: new Date(2017, 0, 1) },
+    { property: 'maxDate', value: new Date(2025, 11, 31) },
+    { property: 'todayDate', value: new Date(2021, 3, 10) },
+    { property: 'timezone', value: 'UTC' },
+  ];
 
-  it('should create components with `minDate` and `maxDate` set', () => {
-    expect(spectator.component).toBeTruthy();
-    expect(spectator.component.minDate).toEqual(new Date(2017, 0, 1));
-    expect(spectator.component.maxDate).toEqual(new Date(2025, 11, 31));
+  testScenarios.forEach((scenario) => {
+    describe(`when configured with ${scenario.property}`, () => {
+      describe('through input properties', () => {
+        beforeEach(() => {
+          spectator = createHost(`<kirby-calendar></kirby-calendar>`, {
+            props: {
+              [scenario.property]: scenario.value,
+            },
+          });
+        });
+
+        it(`should create component with '${scenario.property}' set`, () => {
+          expect(spectator.component).toBeTruthy();
+          expect(spectator.component[scenario.property]).toEqual(scenario.value);
+        });
+      });
+
+      describe('through template property binding', () => {
+        beforeEach(() => {
+          spectator = createHost(
+            `<kirby-calendar [${scenario.property}]="${scenario.property}"></kirby-calendar>`,
+            {
+              hostProps: {
+                [scenario.property]: scenario.value,
+              },
+            }
+          );
+        });
+
+        it(`should create component with '${scenario.property}' set`, () => {
+          expect(spectator.component).toBeTruthy();
+          expect(spectator.component[scenario.property]).toEqual(scenario.value);
+        });
+      });
+    });
   });
 });

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.initialization.spec.ts
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.initialization.spec.ts
@@ -1,0 +1,44 @@
+import { LOCALE_ID } from '@angular/core';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
+import moment from 'moment';
+import { MockComponent } from 'ng-mocks';
+
+import { CalendarComponent, IconComponent } from '..';
+import { WindowRef } from '../../types/window-ref';
+
+import { CalendarYearNavigatorConfig } from './options/calendar-year-navigator-config';
+
+describe('CalendarComponent', () => {
+  let spectator: SpectatorHost<CalendarComponent>;
+
+  const createHost = createHostFactory({
+    component: CalendarComponent,
+    declarations: [CalendarComponent, MockComponent(IconComponent)],
+    providers: [
+      {
+        provide: LOCALE_ID,
+        // i.e. en-US. The week should start on Monday regardlessly
+        useValue: 'en',
+      },
+      {
+        provide: WindowRef,
+        useValue: window,
+      },
+    ],
+  });
+
+  beforeEach(() => {
+    spectator = createHost('<kirby-calendar></kirby-calendar>', {
+      props: {
+        minDate: new Date(2017, 0, 1),
+        maxDate: new Date(2025, 11, 31),
+      },
+    });
+  });
+
+  it('should create components with `minDate` and `maxDate` set', () => {
+    expect(spectator.component).toBeTruthy();
+    expect(spectator.component.minDate).toEqual(new Date(2017, 0, 1));
+    expect(spectator.component.maxDate).toEqual(new Date(2025, 11, 31));
+  });
+});

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.initialization.spec.ts
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.initialization.spec.ts
@@ -1,12 +1,9 @@
 import { LOCALE_ID } from '@angular/core';
 import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
-import moment from 'moment';
 import { MockComponent } from 'ng-mocks';
 
 import { CalendarComponent, IconComponent } from '..';
 import { WindowRef } from '../../types/window-ref';
-
-import { CalendarYearNavigatorConfig } from './options/calendar-year-navigator-config';
 
 describe('CalendarComponent', () => {
   let spectator: SpectatorHost<CalendarComponent>;

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.ts
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.ts
@@ -99,7 +99,7 @@ export class CalendarComponent implements OnInit, AfterViewInit, OnChanges {
   }
 
   @Input() set minDate(value: Date) {
-    if (value && this.activeMonth.toDate() < value) {
+    if (value && this.activeMonth && this.activeMonth.isBefore(value)) {
       this.setActiveMonth(value);
     }
     this._minDate = this.normalizeDate(value);
@@ -110,7 +110,7 @@ export class CalendarComponent implements OnInit, AfterViewInit, OnChanges {
   }
 
   @Input() set maxDate(value: Date) {
-    if (value && this.activeMonth.toDate() > value) {
+    if (value && this.activeMonth && this.activeMonth.isAfter(value)) {
       this.setActiveMonth(value);
     }
     this._maxDate = this.normalizeDate(value);

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.ts
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.ts
@@ -166,6 +166,7 @@ export class CalendarComponent implements OnInit, AfterViewInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
+    if (!this.activeMonth) return;
     if (
       changes.disableWeekends ||
       changes.disablePastDates ||
@@ -270,6 +271,7 @@ export class CalendarComponent implements OnInit, AfterViewInit, OnChanges {
   }
 
   refreshActiveMonth() {
+    if (!this.activeMonth) return;
     // IMPORTANT: Moment startOf|endOf functions mutates the date!
     // Clone the date before mutating:
     const monthStart = this.activeMonth.clone().startOf('month');


### PR DESCRIPTION
This PR closes #1385

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement (to existing content)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, minDate and maxDate can't resolve their setter if they are set before activeMonth due to a missing null check in minDate and maxDate setter (or missing default value for activeMonth).
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1228 

## What is the new behavior?
New behavior is essentially the old behavior but with a null check on both minDate and maxDate setters. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
