### PR TITLE
added slideIndex and activeSlideIndex, changing output to contain act…

### DIFF
--- a/apps/cookbook/src/app/examples/slides-example/example-card-content.ts
+++ b/apps/cookbook/src/app/examples/slides-example/example-card-content.ts
@@ -40,6 +40,7 @@ export class CookbookExampleCardContentComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges) {
+    // not in use in this example - but gives you access to the index of any slide from the component loaded inside the slide
     let activeSlide = changes.activeSlideIndex.currentValue || 0;
   }
 }

--- a/apps/cookbook/src/app/examples/slides-example/example-card-content.ts
+++ b/apps/cookbook/src/app/examples/slides-example/example-card-content.ts
@@ -40,7 +40,7 @@ export class CookbookExampleCardContentComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    let activeSlide = changes.activeSlideIndex.currentValue;
+    let activeSlide = changes.activeSlideIndex.currentValue || 0;
     activeSlide = activeSlide || 0;
   }
 }

--- a/apps/cookbook/src/app/examples/slides-example/example-card-content.ts
+++ b/apps/cookbook/src/app/examples/slides-example/example-card-content.ts
@@ -41,6 +41,5 @@ export class CookbookExampleCardContentComponent implements OnInit, OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {
     let activeSlide = changes.activeSlideIndex.currentValue || 0;
-    activeSlide = activeSlide || 0;
   }
 }

--- a/apps/cookbook/src/app/examples/slides-example/example-card-content.ts
+++ b/apps/cookbook/src/app/examples/slides-example/example-card-content.ts
@@ -42,5 +42,6 @@ export class CookbookExampleCardContentComponent implements OnInit, OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     // not in use in this example - but gives you access to the index of any slide from the component loaded inside the slide
     let activeSlide = changes.activeSlideIndex.currentValue || 0;
+    // doSomethingWithTheActiveSlideIndex(activeSlide);
   }
 }

--- a/apps/cookbook/src/app/examples/slides-example/example-card-content.ts
+++ b/apps/cookbook/src/app/examples/slides-example/example-card-content.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 
 @Component({
   selector: 'cookbook-example-card-content',
@@ -19,8 +19,10 @@ import { Component, Input, OnInit } from '@angular/core';
     </kirby-card>
   `,
 })
-export class CookbookExampleCardContentComponent implements OnInit {
+export class CookbookExampleCardContentComponent implements OnInit, OnChanges {
   @Input() data: any;
+  @Input() activeSlideIndex: number;
+  @Input() slideIndex: number;
 
   title: string;
   subtitle: string;
@@ -35,5 +37,10 @@ export class CookbookExampleCardContentComponent implements OnInit {
     this.title = this.data.title;
     this.subtitle = this.data.subtitle;
     this.cardContent = this.data.cardContent;
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    let activeSlide = changes.activeSlideIndex.currentValue;
+    activeSlide = activeSlide || 0;
   }
 }

--- a/apps/cookbook/src/app/examples/slides-example/slides-example.component.html
+++ b/apps/cookbook/src/app/examples/slides-example/slides-example.component.html
@@ -5,7 +5,9 @@
 >
   <cookbook-example-card-content
     [data]="slide"
-    *kirbySlide="let slide"
+    *kirbySlide="let slide; let i = index"
+    [slideIndex]="i"
+    [activeSlideIndex]="selectedSlideIndex"
   ></cookbook-example-card-content>
 </kirby-slides>
 <br />

--- a/apps/cookbook/src/app/examples/slides-example/slides-example.component.ts
+++ b/apps/cookbook/src/app/examples/slides-example/slides-example.component.ts
@@ -1,7 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
+import { Observable, of } from 'rxjs';
 
 import { SlidesComponent } from '@kirbydesign/designsystem';
-import { Observable, of } from 'rxjs';
 
 @Component({
   selector: 'cookbook-slides-example',

--- a/apps/cookbook/src/app/examples/slides-example/slides-example.component.ts
+++ b/apps/cookbook/src/app/examples/slides-example/slides-example.component.ts
@@ -1,5 +1,4 @@
 import { Component, ViewChild } from '@angular/core';
-import { Observable, of } from 'rxjs';
 
 import { SlidesComponent } from '@kirbydesign/designsystem';
 
@@ -55,11 +54,11 @@ export class SlidesExampleComponent {
     },
   ];
 
-  data$: Observable<any>;
+  data: any;
   selectedSlideIndex: number;
 
   getDataFromActiveSlide(activeSlide: { selectedData: any; selectedSlideIndex: number }) {
-    this.data$ = of(activeSlide.selectedData);
+    this.data = activeSlide.selectedData;
     this.selectedSlideIndex = activeSlide.selectedSlideIndex;
 
     console.log('Output: ', activeSlide);

--- a/apps/cookbook/src/app/examples/slides-example/slides-example.component.ts
+++ b/apps/cookbook/src/app/examples/slides-example/slides-example.component.ts
@@ -1,6 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
 
 import { SlidesComponent } from '@kirbydesign/designsystem';
+import { Observable, of } from 'rxjs';
 
 @Component({
   selector: 'cookbook-slides-example',
@@ -54,11 +55,14 @@ export class SlidesExampleComponent {
     },
   ];
 
-  activeSlide = this.slides[0];
+  data$: Observable<any>;
+  selectedSlideIndex: number;
 
-  getDataFromActiveSlide(e: any) {
-    // Output onSlideDidChange
-    console.log('Output: ', e);
+  getDataFromActiveSlide(activeSlide: { selectedData: any; selectedSlideIndex: number }) {
+    this.data$ = of(activeSlide.selectedData);
+    this.selectedSlideIndex = activeSlide.selectedSlideIndex;
+
+    console.log('Output: ', activeSlide);
   }
 
   changeSlide() {

--- a/apps/cookbook/src/app/showcase/slides-showcase/slides-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/slides-showcase/slides-showcase.component.html
@@ -1,4 +1,10 @@
 <div class="example">
+  <p>
+    <em
+      ><strong>Please note:</strong>The slides do not like beeing switched between mobile- and
+      webview. Please refresh your browser after changing from web to mobile and visa versa</em
+    >
+  </p>
   <cookbook-slides-example></cookbook-slides-example>
   <cookbook-code-viewer [html]="exampleHtml"></cookbook-code-viewer>
   <cookbook-code-viewer [ts]="exampleTS"></cookbook-code-viewer>

--- a/apps/cookbook/src/app/showcase/slides-showcase/slides-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/slides-showcase/slides-showcase.component.html
@@ -1,8 +1,9 @@
 <div class="example">
   <p>
     <em
-      ><strong>Please note:</strong>The slides do not like beeing switched between mobile- and
-      webview. Please refresh your browser after changing from web to mobile and visa versa</em
+      ><strong>Please note:</strong>The slides do not like beeing switched between chrome-devtools
+      mobileview and standard webview. Please refresh your browser after changing from web to mobile
+      and visa versa</em
     >
   </p>
   <cookbook-slides-example></cookbook-slides-example>

--- a/apps/cookbook/src/app/showcase/slides-showcase/slides-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/slides-showcase/slides-showcase.component.ts
@@ -30,12 +30,6 @@ export class SlidesShowcaseComponent {
       type: ['DataArray'],
     },
     {
-      name: 'slideIndex',
-      description: 'The index of any given slide',
-      defaultValue: '',
-      type: ['number'],
-    },
-    {
       name: 'activeSlideIndex',
       description: 'The index of the active slide',
       defaultValue: '0',

--- a/apps/cookbook/src/app/showcase/slides-showcase/slides-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/slides-showcase/slides-showcase.component.ts
@@ -29,11 +29,23 @@ export class SlidesShowcaseComponent {
       defaultValue: '',
       type: ['DataArray'],
     },
+    {
+      name: 'slideIndex',
+      description: 'The index of any given slide',
+      defaultValue: '',
+      type: ['number'],
+    },
+    {
+      name: 'activeSlideIndex',
+      description: 'The index of the active slide',
+      defaultValue: '0',
+      type: ['number'],
+    },
   ];
   events: ApiDescriptionEvent[] = [
     {
       name: 'selectedSlide',
-      description: 'Emits active slide',
+      description: 'Emits active slide´s data and index',
       signature: 'func',
     },
   ];

--- a/libs/designsystem/src/lib/components/slides/slides.component.ts
+++ b/libs/designsystem/src/lib/components/slides/slides.component.ts
@@ -45,7 +45,7 @@ export class SlidesComponent implements AfterViewInit {
   onSlideChanged(e: any) {
     this.ionSlides.getActiveIndex().then((selectedIndex) => {
       this.selectedSlide.emit({
-        selectedData: this.slides[selectedIndex],
+        slide: this.slides[selectedIndex],
         index: selectedIndex,
       });
     });

--- a/libs/designsystem/src/lib/components/slides/slides.component.ts
+++ b/libs/designsystem/src/lib/components/slides/slides.component.ts
@@ -46,7 +46,7 @@ export class SlidesComponent implements AfterViewInit {
     this.ionSlides.getActiveIndex().then((selectedIndex) => {
       this.selectedSlide.emit({
         selectedData: this.slides[selectedIndex],
-        selectedSlideIndex: selectedIndex,
+        index: selectedIndex,
       });
     });
   }

--- a/libs/designsystem/src/lib/components/slides/slides.component.ts
+++ b/libs/designsystem/src/lib/components/slides/slides.component.ts
@@ -20,9 +20,9 @@ export class SlideDirective {}
   selector: 'kirby-slides',
   template: `
     <ion-slides [options]="slidesOptions" #ionslides (ionSlideDidChange)="onSlideChanged($event)">
-      <ion-slide *ngFor="let slide of slides">
+      <ion-slide *ngFor="let slide of slides; let i = index">
         <ng-container
-          *ngTemplateOutlet="slideTemplate; context: { $implicit: slide }"
+          *ngTemplateOutlet="slideTemplate; context: { $implicit: slide, index: i }"
         ></ng-container>
       </ion-slide>
     </ion-slides>
@@ -44,7 +44,10 @@ export class SlidesComponent implements AfterViewInit {
 
   onSlideChanged(e: any) {
     this.ionSlides.getActiveIndex().then((selectedIndex) => {
-      this.selectedSlide.emit(this.slides[selectedIndex]);
+      this.selectedSlide.emit({
+        selectedData: this.slides[selectedIndex],
+        selectedSlideIndex: selectedIndex,
+      });
     });
   }
 


### PR DESCRIPTION
This PR closes #1437 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

The slides component now outputs the index of the active slide, and each slide is aware of its index



- [ ] Bugfix
- [ ] Feature
- [x] Enhancement (to existing content)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## Which issue documents the current behaviour?

<!-- Please link to a relevant issue that documents the current behaviour . -->

Issue Number: #1437

## What is the new behavior?

<!-- Please describe the new behaviour after your pull-request is comitted -->

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

the output of the eventEmitter has changed from containing only the data of the selected slide to also contain the index of the selected slide

## Other information
As mentioned in issue, at present - only team-living is using the slides-component
