### PR TITLE
Enhancement/Even spacing on calendar dates

### DIFF
--- a/apps/cookbook/src/app/examples/calendar-example/calendar-card-example.component.scss
+++ b/apps/cookbook/src/app/examples/calendar-example/calendar-card-example.component.scss
@@ -4,6 +4,7 @@ kirby-card {
   z-index: 3; // Ensure dropdown opens over configuration checkboxes
   overflow: visible; // Ensure dropdown isn't cut off
 
+  width: 320px;
   margin-bottom: 20px;
 
   kirby-card-footer {

--- a/apps/cookbook/src/app/examples/calendar-example/calendar-card-example.component.scss
+++ b/apps/cookbook/src/app/examples/calendar-example/calendar-card-example.component.scss
@@ -4,7 +4,6 @@ kirby-card {
   z-index: 3; // Ensure dropdown opens over configuration checkboxes
   overflow: visible; // Ensure dropdown isn't cut off
 
-  width: 320px;
   margin-bottom: 20px;
 
   kirby-card-footer {

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.html
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.html
@@ -25,7 +25,9 @@
 
 <table class="calendar-table">
   <thead class="calendar-table-header">
-    <th *ngFor="let weekDay of weekDays">{{ weekDay }}</th>
+    <tr>
+      <th *ngFor="let weekDay of weekDays">{{ weekDay }}</th>
+    </tr>
   </thead>
 
   <tbody>

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.html
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.html
@@ -23,8 +23,8 @@
   </kirby-dropdown>
 </div>
 
-<table class="calendar-table">
-  <thead class="calendar-table-header">
+<table>
+  <thead>
     <tr>
       <th *ngFor="let weekDay of weekDays">{{ weekDay }}</th>
     </tr>

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -23,9 +23,6 @@ table.calendar-table {
   td {
     border-style: none;
     padding: 0;
-    line-height: 2em;
-    height: 0;
-    text-align: center;
   }
 }
 
@@ -37,8 +34,6 @@ td {
 
 .header {
   display: flex;
-  flex-direction: row;
-  align-items: center;
   justify-content: space-between;
   margin: size('xxs');
   margin-bottom: 0;
@@ -46,8 +41,8 @@ td {
 
 .month-navigator {
   display: flex;
-  flex-direction: row;
   flex-grow: 1;
+  align-items: center;
   justify-content: space-between;
 
   button {
@@ -55,6 +50,9 @@ td {
     outline: none;
     border: none;
     cursor: pointer;
+    height: size('xl');
+    width: size('xl');
+    padding: 0;
   }
 
   button:disabled {
@@ -64,7 +62,6 @@ td {
 }
 
 .month-and-year {
-  line-height: line-height('xl');
   user-select: none;
 
   .month {
@@ -90,13 +87,13 @@ td {
 }
 
 .day {
-  display: inline-block;
-  $dayWidth: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  $dayWidth: size('xl');
   border-radius: $dayWidth / 2;
   width: $dayWidth;
   height: $dayWidth;
-  line-height: $dayWidth;
-  text-align: center;
   margin-top: 4px;
   margin-bottom: 4px;
 }

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -11,17 +11,12 @@ table.calendar-table {
   margin-top: 0;
 
   thead {
-    padding: 0.5em;
     border-bottom: 1px solid get-color('background-color');
 
     th {
       height: 50px;
       text-align: center;
     }
-  }
-
-  tbody {
-    padding: 0.5em;
   }
 
   tr,

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -1,44 +1,30 @@
 @import '../../scss/utils';
 $month-navigator-width: 80px;
 
-table.calendar-table {
+table {
   width: 100%;
   border-collapse: collapse;
   user-select: none;
-  outline: none !important;
-  border-spacing: 0;
   margin-bottom: size('xxs');
+}
 
-  thead {
-    border-bottom: 1px solid get-color('background-color');
+th,
+td {
+  text-align: center;
+  padding: 0;
 
-    th {
-      height: 50px;
-      text-align: center;
-
-      &:first-child {
-        padding-left: size('xxs');
-      }
-
-      &:last-child {
-        padding-right: size('xxs');
-      }
-    }
+  &:first-child {
+    padding-left: size('xxs');
   }
 
-  tr,
-  td {
-    border-style: none;
-    padding: 0;
-    text-align: center;
-
-    td:first-child {
-      padding-left: size('xxs');
-    }
-    td:last-child {
-      padding-right: size('xxs');
-    }
+  &:last-child {
+    padding-right: size('xxs');
   }
+}
+
+th {
+  height: 50px;
+  border-bottom: 1px solid get-color('background-color');
 }
 
 .header,

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -44,8 +44,7 @@ td {
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5em;
-  margin: size('xxxs') size('xxxs') 0 size('xxxs');
+  margin: size('xxs') size('xxs') 0 size('xxs');
 }
 
 .month-navigator {

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -2,13 +2,12 @@
 $month-navigator-width: 80px;
 
 table.calendar-table {
-  width: calc(100% - 2 * #{size('xxxs')});
+  width: 100%;
   border-collapse: collapse;
   user-select: none;
   outline: none !important;
   border-spacing: 0;
-  margin: size('xxxs');
-  margin-top: 0;
+  margin-bottom: size('xxs');
 
   thead {
     border-bottom: 1px solid get-color('background-color');
@@ -16,6 +15,14 @@ table.calendar-table {
     th {
       height: 50px;
       text-align: center;
+
+      &:first-child {
+        padding-left: size('xxs');
+      }
+
+      &:last-child {
+        padding-right: size('xxs');
+      }
     }
   }
 
@@ -23,6 +30,14 @@ table.calendar-table {
   td {
     border-style: none;
     padding: 0;
+    text-align: center;
+
+    td:first-child {
+      padding-left: size('xxs');
+    }
+    td:last-child {
+      padding-right: size('xxs');
+    }
   }
 }
 
@@ -87,15 +102,14 @@ td {
 }
 
 .day {
+  $dayWidth: size('xl');
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  $dayWidth: size('xl');
   border-radius: $dayWidth / 2;
   width: $dayWidth;
   height: $dayWidth;
-  margin-top: 4px;
-  margin-bottom: 4px;
+  margin: size('xxxs') 0;
 }
 
 .day.selectable,

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -7,7 +7,7 @@ table.calendar-table {
   user-select: none;
   outline: none !important;
   border-spacing: 0;
-  margin: 0 size('xxxs') size('xxxs') size('xxxs');
+  margin: 0 size('xxxs') size('xxxs');
 
   thead {
     padding: 0.5em;
@@ -44,7 +44,7 @@ td {
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  margin: size('xxs') size('xxs') 0 size('xxs');
+  margin: size('xxs') size('xxs') 0;
 }
 
 .month-navigator {

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -2,11 +2,12 @@
 $month-navigator-width: 80px;
 
 table.calendar-table {
-  width: 100%;
+  width: calc(100% - 2 * #{size('xxxs')});
   border-collapse: collapse;
   user-select: none;
   outline: none !important;
   border-spacing: 0;
+  margin: 0 size('xxxs') size('xxxs') size('xxxs');
 
   thead {
     padding: 0.5em;
@@ -28,6 +29,7 @@ table.calendar-table {
     padding: 0;
     line-height: 2em;
     height: 0;
+    text-align: center;
   }
 }
 
@@ -43,6 +45,7 @@ td {
   align-items: center;
   justify-content: space-between;
   padding: 0.5em;
+  margin: size('xxxs') size('xxxs') 0 size('xxxs');
 }
 
 .month-navigator {
@@ -91,13 +94,14 @@ td {
 }
 
 .day {
+  display: inline-block;
   $dayWidth: 40px;
   border-radius: $dayWidth / 2;
   width: $dayWidth;
   height: $dayWidth;
   line-height: $dayWidth;
   text-align: center;
-  margin: 0 auto;
+  margin: size('xxxs');
 }
 
 .day.selectable,

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -7,7 +7,8 @@ table.calendar-table {
   user-select: none;
   outline: none !important;
   border-spacing: 0;
-  margin: 0 size('xxxs') size('xxxs');
+  margin: size('xxxs');
+  margin-top: 0;
 
   thead {
     padding: 0.5em;
@@ -44,7 +45,8 @@ td {
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  margin: size('xxs') size('xxs') 0;
+  margin: size('xxs');
+  margin-bottom: 0;
 }
 
 .month-navigator {

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -102,7 +102,8 @@ td {
   height: $dayWidth;
   line-height: $dayWidth;
   text-align: center;
-  margin: size('xxxs');
+  margin-top: 4px;
+  margin-bottom: 4px;
 }
 
 .day.selectable,

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.spec.ts
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.spec.ts
@@ -65,7 +65,7 @@ describe('CalendarComponent', () => {
 
     verifyMonthAndYear('August 1997');
 
-    const headerTexts = trimmedTexts('.calendar-table-header th');
+    const headerTexts = trimmedTexts('th');
     expect(headerTexts).toEqual(['M', 'T', 'W', 'T', 'F', 'S', 'S']);
 
     const dayTexts = trimmedTexts('.day.current-month');
@@ -275,7 +275,7 @@ describe('CalendarComponent', () => {
   it('should render days from Monday to Sunday', () => {
     expect(
       spectator
-        .queryAll('.calendar-table-header th')
+        .queryAll('th')
         .map((_) => _.textContent)
         .join(' ')
     ).toEqual('M T W T F S S');


### PR DESCRIPTION
This PR closes #1396 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Enhancement (to existing content)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## Which issue documents the current behaviour?

<!-- Please link to a relevant issue that documents the current behaviour . -->

Issue Number: n/a

## What is the new behavior?

<!-- Please describe the new behaviour after your pull-request is comitted -->
Each of the selectable dates in the calendar has a `xxxs` margin, amounting to `xxs` (8px) between two selectable dates. 

Furthermore, the header padding has been replaced with a margin, an should better match the original design. The date-table also has an `xxxs` margin, so the dates also have the required spacing to the edges of the calendar. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
