### PR TITLE
Housekeeping/'New' label on GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: "[BUG]"
-labels: NOT Prioritized, NOT Verified, bug
+labels: New, NOT Prioritized, NOT Verified, bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/component-request.md
+++ b/.github/ISSUE_TEMPLATE/component-request.md
@@ -9,7 +9,10 @@ assignees: ''
 
 <!--**Mandatory steps to ensure alignment between stakeholders and the progression of Kirby**-->
 
-<!--In order to ensure steady progress and quality of Kirby, please follow our outlined process. By default three labels are added to new component issues and enhancements. To help Kirby please follow these steps, and remove the labels from the issue when done.-->
+<!--In order to ensure steady progress and quality of Kirby, please follow our outlined process. By default four labels are added to new component issues and enhancements. To help Kirby please follow these steps, and remove the labels from the issue when done.-->
+
+<!--*New*-->
+<!--Indicates that this is a new issue that has not yet been addressed by the Kirby team. The `New` label will be removed by the Kirby team. -->
 
 <!--*NOT Prioritized*-->
 <!--Describe any deadlines for the issue - eg. X needs this done by Y date, to be used in Z sprint. Suggest a milestone for the issue. The `Not Prioritized` label will be removed by the Kirby team. -->

--- a/.github/ISSUE_TEMPLATE/component-request.md
+++ b/.github/ISSUE_TEMPLATE/component-request.md
@@ -2,7 +2,7 @@
 name: Component request
 about: Suggest a new component for Kirby Design System
 title: "[COMPONENT] "
-labels: NOT Prioritized, NOT Tech refined, NOT UX refined, component
+labels: New, NOT Prioritized, NOT Tech refined, NOT UX refined, component
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -9,7 +9,10 @@ assignees: ''
 
 <!--**Mandatory steps to ensure alignment between stakeholders and the progression of Kirby**-->
 
-<!--In order to ensure steady progress and quality of Kirby, please follow our outlined process. By default three labels are added to new component issues and enhancements. To help Kirby please follow these steps, and remove the labels from the issue when done.-->
+<!--In order to ensure steady progress and quality of Kirby, please follow our outlined process. By default four labels are added to new component issues and enhancements. To help Kirby please follow these steps, and remove the labels from the issue when done.-->
+
+<!--*New*-->
+<!--Indicates that this is a new issue that has not yet been addressed by the Kirby team. The `New` label will be removed by the Kirby team. -->
 
 <!--*NOT Prioritized*-->
 <!--Describe any deadlines for the issue - eg. X needs this done by Y date, to be used in Z sprint. Suggest a milestone for the issue. The `Not Prioritized` label will be removed by the Kirby team. -->

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -2,7 +2,7 @@
 name: Enhancement request
 about: Suggest an idea for this project
 title: "[Enhancement]"
-labels: NOT Prioritized, NOT Tech refined, NOT UX refined, enhancement
+labels: New, NOT Prioritized, NOT Tech refined, NOT UX refined, enhancement
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/housekeeping-request.md
+++ b/.github/ISSUE_TEMPLATE/housekeeping-request.md
@@ -2,7 +2,7 @@
 name: Housekeeping request
 about: Suggestions for improving code quality
 title: "[Housekeeping]"
-labels: NOT Prioritized, NOT Tech refined, housekeeping
+labels: New, NOT Prioritized, NOT Tech refined, housekeeping
 assignees: ''
 ---
 


### PR DESCRIPTION
This PR closes #1446 
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
Added the existing 'New' label on all the issue tempaltes (Inquiry already had 'New' label).
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Enhancement (to existing content)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [x] Other... Please describe:
Github Templates addition!

## Which issue documents the current behaviour?

<!-- Please link to a relevant issue that documents the current behaviour . -->

Issue Number: .

## What is the new behavior?
The 'new' label gets added by default now on all issues.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
