### PR TITLE
Fix wrong colour (Skjern Bank brand)

### DIFF
--- a/libs/designsystem/src/lib/components/button/button.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/button/button.component.integration.spec.ts
@@ -102,7 +102,7 @@ describe('ButtonComponent in Kirby Page', () => {
     it('should render with correct color', async () => {
       await TestHelper.whenReady(ionToolbar);
       expect(actionButtonInHeader).toHaveComputedStyle({
-        color: getColor('primary', 'contrast'),
+        color: getColor('black'),
       });
     });
 

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -75,11 +75,6 @@ $button-width: (
 }
 
 @mixin button-attentionlevel4 {
-  // TODO: Remove declarations or set --kirby-button-color to currentColor
-  --kirby-button-background-color: transparent;
-  --kirby-button-color: #{get-color('primary-contrast')};
-  // --kirby-button-color: currentColor;
-
   &.destructive {
     --kirby-button-color: #{get-color('danger')};
   }
@@ -87,12 +82,8 @@ $button-width: (
 
 :host {
   font-family: var(--kirby-font-family);
-  // TODO: Set fallback to "unset"
-  // background-color: var(--kirby-button-background-color, unset);
-  background-color: var(--kirby-button-background-color, get-color('primary'));
-  // TODO: Set fallback to "currentColor"
-  // color: var(--kirby-button-color, currentColor);
-  color: var(--kirby-button-color, get-color('primary-contrast'));
+  background-color: var(--kirby-button-background-color, initial);
+  color: var(--kirby-button-color, inherit);
   border-radius: $border-radius-round;
   box-sizing: border-box; // Ensure border is not added to button height
   cursor: pointer;

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -64,6 +64,9 @@ $button-width: (
 }
 
 @mixin button-attentionlevel3 {
+  // Expect canvas underneath to be a light color
+  --kirby-button-background-color: transparent;
+  --kirby-button-color: #{get-color('black')};
   --kirby-button-border-color: #{get-color('medium')};
 
   &.destructive {
@@ -72,6 +75,10 @@ $button-width: (
 }
 
 @mixin button-attentionlevel4 {
+  // Expect canvas underneath to be a light color
+  --kirby-button-background-color: transparent;
+  --kirby-button-color: #{get-color('black')};
+
   &.destructive {
     --kirby-button-color: #{get-color('danger')};
   }

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -64,6 +64,7 @@ $button-width: (
 }
 
 @mixin button-attentionlevel3 {
+  // TODO: Remove background and color declarations
   --kirby-button-background-color: transparent;
   --kirby-button-color: #{get-color('medium-contrast')};
   --kirby-button-border-color: #{get-color('medium')};
@@ -74,8 +75,10 @@ $button-width: (
 }
 
 @mixin button-attentionlevel4 {
+  // TODO: Remove declarations or set --kirby-button-color to currentColor
   --kirby-button-background-color: transparent;
   --kirby-button-color: #{get-color('primary-contrast')};
+  // --kirby-button-color: currentColor;
 
   &.destructive {
     --kirby-button-color: #{get-color('danger')};
@@ -84,7 +87,11 @@ $button-width: (
 
 :host {
   font-family: var(--kirby-font-family);
+  // TODO: Set fallback to "unset"
+  // background-color: var(--kirby-button-background-color, unset);
   background-color: var(--kirby-button-background-color, get-color('primary'));
+  // TODO: Set fallback to "currentColor"
+  // color: var(--kirby-button-color, currentColor);
   color: var(--kirby-button-color, get-color('primary-contrast'));
   border-radius: $border-radius-round;
   box-sizing: border-box; // Ensure border is not added to button height

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -64,9 +64,6 @@ $button-width: (
 }
 
 @mixin button-attentionlevel3 {
-  // TODO: Remove background and color declarations
-  --kirby-button-background-color: transparent;
-  --kirby-button-color: #{get-color('medium-contrast')};
   --kirby-button-border-color: #{get-color('medium')};
 
   &.destructive {

--- a/libs/designsystem/src/lib/components/button/button.component.spec.ts
+++ b/libs/designsystem/src/lib/components/button/button.component.spec.ts
@@ -267,6 +267,24 @@ describe('ButtonComponent', () => {
   });
 
   describe('when configured with attentionlevel 4', () => {
+    const canvasColor = 'background-color';
+
+    beforeAll(() => {
+      window.document.documentElement.style.setProperty(
+        'color',
+        getColor(canvasColor, 'contrast').value
+      );
+      window.document.documentElement.style.setProperty(
+        'background-color',
+        getColor(canvasColor).value
+      );
+    });
+
+    afterAll(() => {
+      window.document.documentElement.style.removeProperty('color');
+      window.document.documentElement.style.removeProperty('background-color');
+    });
+
     beforeEach(() => {
       spectator.component.attentionLevel = '4';
       spectator.detectChanges();
@@ -286,7 +304,7 @@ describe('ButtonComponent', () => {
 
     it('should render with correct color', () => {
       expect(element).toHaveComputedStyle({
-        color: getColor('primary', 'contrast'),
+        color: getColor(canvasColor, 'contrast'),
       });
     });
 

--- a/libs/designsystem/src/lib/components/button/button.component.spec.ts
+++ b/libs/designsystem/src/lib/components/button/button.component.spec.ts
@@ -205,6 +205,24 @@ describe('ButtonComponent', () => {
   });
 
   describe('when configured with attentionlevel 3', () => {
+    const canvasColor = 'background-color';
+
+    beforeAll(() => {
+      window.document.documentElement.style.setProperty(
+        'color',
+        getColor(canvasColor, 'contrast').value
+      );
+      window.document.documentElement.style.setProperty(
+        'background-color',
+        getColor(canvasColor).value
+      );
+    });
+
+    afterAll(() => {
+      window.document.documentElement.style.removeProperty('color');
+      window.document.documentElement.style.removeProperty('background-color');
+    });
+
     beforeEach(() => {
       spectator.component.attentionLevel = '3';
       spectator.detectChanges();
@@ -223,9 +241,8 @@ describe('ButtonComponent', () => {
     });
 
     it('should render with correct color', () => {
-      // TODO: Fix this test - should expect canvas contrast since bg is transparent
       expect(element).toHaveComputedStyle({
-        color: getColor('medium', 'contrast'),
+        color: getColor(canvasColor, 'contrast'),
       });
     });
 

--- a/libs/designsystem/src/lib/components/button/button.component.spec.ts
+++ b/libs/designsystem/src/lib/components/button/button.component.spec.ts
@@ -109,6 +109,7 @@ describe('ButtonComponent', () => {
     });
 
     it('should render with correct color', () => {
+      // TODO: Fix this test - should expect primary-contrast, not white-contrast
       expect(element).toHaveComputedStyle({
         color: getColor('white', 'contrast'),
       });
@@ -223,6 +224,7 @@ describe('ButtonComponent', () => {
     });
 
     it('should render with correct color', () => {
+      // TODO: Fix this test - should expect canvas contrast since bg is transparent
       expect(element).toHaveComputedStyle({
         color: getColor('medium', 'contrast'),
       });

--- a/libs/designsystem/src/lib/components/button/button.component.spec.ts
+++ b/libs/designsystem/src/lib/components/button/button.component.spec.ts
@@ -19,6 +19,24 @@ describe('ButtonComponent', () => {
     declarations: [MockComponent(IconComponent)],
   });
 
+  const canvasColor = 'background-color';
+
+  beforeAll(() => {
+    window.document.documentElement.style.setProperty(
+      'color',
+      getColor(canvasColor, 'contrast').value
+    );
+    window.document.documentElement.style.setProperty(
+      'background-color',
+      getColor(canvasColor).value
+    );
+  });
+
+  afterAll(() => {
+    window.document.documentElement.style.removeProperty('color');
+    window.document.documentElement.style.removeProperty('background-color');
+  });
+
   beforeEach(() => {
     spectator = createHost('<button kirby-button>Test</button>');
     element = spectator.element as HTMLButtonElement;
@@ -205,24 +223,6 @@ describe('ButtonComponent', () => {
   });
 
   describe('when configured with attentionlevel 3', () => {
-    const canvasColor = 'background-color';
-
-    beforeAll(() => {
-      window.document.documentElement.style.setProperty(
-        'color',
-        getColor(canvasColor, 'contrast').value
-      );
-      window.document.documentElement.style.setProperty(
-        'background-color',
-        getColor(canvasColor).value
-      );
-    });
-
-    afterAll(() => {
-      window.document.documentElement.style.removeProperty('color');
-      window.document.documentElement.style.removeProperty('background-color');
-    });
-
     beforeEach(() => {
       spectator.component.attentionLevel = '3';
       spectator.detectChanges();
@@ -285,24 +285,6 @@ describe('ButtonComponent', () => {
   });
 
   describe('when configured with attentionlevel 4', () => {
-    const canvasColor = 'background-color';
-
-    beforeAll(() => {
-      window.document.documentElement.style.setProperty(
-        'color',
-        getColor(canvasColor, 'contrast').value
-      );
-      window.document.documentElement.style.setProperty(
-        'background-color',
-        getColor(canvasColor).value
-      );
-    });
-
-    afterAll(() => {
-      window.document.documentElement.style.removeProperty('color');
-      window.document.documentElement.style.removeProperty('background-color');
-    });
-
     beforeEach(() => {
       spectator.component.attentionLevel = '4';
       spectator.detectChanges();

--- a/libs/designsystem/src/lib/components/button/button.component.spec.ts
+++ b/libs/designsystem/src/lib/components/button/button.component.spec.ts
@@ -109,9 +109,8 @@ describe('ButtonComponent', () => {
     });
 
     it('should render with correct color', () => {
-      // TODO: Fix this test - should expect primary-contrast, not white-contrast
       expect(element).toHaveComputedStyle({
-        color: getColor('white', 'contrast'),
+        color: getColor('primary', 'contrast'),
       });
     });
 

--- a/libs/designsystem/src/lib/components/button/button.component.spec.ts
+++ b/libs/designsystem/src/lib/components/button/button.component.spec.ts
@@ -19,24 +19,6 @@ describe('ButtonComponent', () => {
     declarations: [MockComponent(IconComponent)],
   });
 
-  const canvasColor = 'background-color';
-
-  beforeAll(() => {
-    window.document.documentElement.style.setProperty(
-      'color',
-      getColor(canvasColor, 'contrast').value
-    );
-    window.document.documentElement.style.setProperty(
-      'background-color',
-      getColor(canvasColor).value
-    );
-  });
-
-  afterAll(() => {
-    window.document.documentElement.style.removeProperty('color');
-    window.document.documentElement.style.removeProperty('background-color');
-  });
-
   beforeEach(() => {
     spectator = createHost('<button kirby-button>Test</button>');
     element = spectator.element as HTMLButtonElement;
@@ -242,7 +224,7 @@ describe('ButtonComponent', () => {
 
     it('should render with correct color', () => {
       expect(element).toHaveComputedStyle({
-        color: getColor(canvasColor, 'contrast'),
+        color: getColor('black'),
       });
     });
 
@@ -304,7 +286,7 @@ describe('ButtonComponent', () => {
 
     it('should render with correct color', () => {
       expect(element).toHaveComputedStyle({
-        color: getColor(canvasColor, 'contrast'),
+        color: getColor('black'),
       });
     });
 

--- a/libs/designsystem/src/lib/components/list/list.component.scss
+++ b/libs/designsystem/src/lib/components/list/list.component.scss
@@ -116,7 +116,9 @@ ion-item-divider {
 
 .swipe-action {
   display: flex;
-  color: #{get-color('primary-contrast')};
+  color: #{get-color('black')};
+  background-color: transparent;
+
   @each $color-name, $color-value in $main-colors {
     .#{$color-name} {
       background-color: #{get-color($color-name)};

--- a/libs/designsystem/src/lib/components/slide-button/slide-button.component.scss
+++ b/libs/designsystem/src/lib/components/slide-button/slide-button.component.scss
@@ -31,6 +31,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    color: $slide-button-text-color;
     background-color: $slide-button-container-bg-color;
     height: $slide-button-container-height;
     border-radius: $slide-button-container-radius;
@@ -45,7 +46,6 @@
 
   .slide-button-text {
     position: absolute;
-    color: $slide-button-text-color;
     font-size: font-size('n');
     margin: 0;
     line-height: 1;

--- a/libs/designsystem/src/lib/scss/themes/_colors.scss
+++ b/libs/designsystem/src/lib/scss/themes/_colors.scss
@@ -1,7 +1,7 @@
 $brand-colors: (
-  'primary': #910008,
-  'secondary': #757575,
-  'tertiary': #363636,
+  'primary': #00e89a,
+  'secondary': #005c3c,
+  'tertiary': #01352c,
 );
 
 $notification-colors: (

--- a/libs/designsystem/src/lib/scss/themes/_colors.scss
+++ b/libs/designsystem/src/lib/scss/themes/_colors.scss
@@ -1,7 +1,7 @@
 $brand-colors: (
-  'primary': #00e89a,
-  'secondary': #005c3c,
-  'tertiary': #01352c,
+  'primary': #910008,
+  'secondary': #757575,
+  'tertiary': #363636,
 );
 
 $notification-colors: (


### PR DESCRIPTION
This PR closes #1395

## PR Checklist

Please check if your PR fulfils the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

Attention level 3 and 4 buttons have transparent background color (not part of change). They are expected to be displayed on a light background color, so this change makes their (text) color `black` instead of `primary-contrast`. With Skjern Bank brand colors `primary-contrast` is `white`. For all other brands `primary-contrast` is `black`.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement (to existing content)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## Which issue documents the current behaviour?

<!-- Please link to a relevant issue that documents the current behaviour . -->

Issue Number: #1395

## What is the new behavior?

<!-- Please describe the new behaviour after your pull-request is comitted -->

Text color for attention level 3 and 4 buttons will be `black` regardless of brand colors.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
