### PR TITLE
Fixed Progress Circle showing full progress on values close to 100

### DIFF
--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.spec.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.spec.ts
@@ -52,6 +52,7 @@ describe('ProgressCircleRingComponent', () => {
         value,
         upperBound,
       });
+
       expect(spectator.component.offset).toBe(
         spectator.component.centerCircumference -
           spectator.component.centerCircumference * (value / 100)
@@ -67,6 +68,7 @@ describe('ProgressCircleRingComponent', () => {
         value,
         upperBound,
       });
+
       expect(spectator.component.offset).toBe(
         spectator.component.centerCircumference -
           spectator.component.centerCircumference * (upperBound / 100)
@@ -85,7 +87,9 @@ describe('ProgressCircleRingComponent', () => {
       const radius = 33;
       const expectedSize = `${2 * radius}px`;
       spectator.setInput({ radius });
+      //width and height are set via hostbinding. Apparently we need to run a change detection cycle.
       spectator.detectChanges();
+
       expect(spectator.element).toHaveComputedStyle({
         width: expectedSize,
         height: expectedSize,
@@ -97,6 +101,7 @@ describe('ProgressCircleRingComponent', () => {
       spectator.element.classList.add(themeColor);
       spectator.element.style.transition = 'none';
       spectator.detectChanges();
+
       expect(spectator.query('circle.progress')).toHaveComputedStyle({
         stroke: getColor(themeColor),
       });
@@ -107,14 +112,12 @@ describe('ProgressCircleRingComponent', () => {
     });
 
     it('should render background stroke in semi-light', () => {
-      spectator.detectChanges();
       expect(spectator.query('circle.circle')).toHaveComputedStyle({
         stroke: getColor('semi-light'),
       });
     });
 
     it('should render progress stroke with the correct width', () => {
-      spectator.detectChanges();
       expect(spectator.query('circle.progress')).toHaveAttribute(
         'stroke-width',
         '' + spectator.component.strokeWidth

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.spec.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.spec.ts
@@ -24,7 +24,7 @@ describe('ProgressCircleRingComponent', () => {
 
   describe('centerRadius', () => {
     it('should return distance from center to middle of stroke', () => {
-      expect(spectator.component.centerRadius).toBe(
+      expect(spectator.component._centerRadius).toBe(
         spectator.component.radius - spectator.component.strokeWidth / 2
       );
     });
@@ -32,15 +32,15 @@ describe('ProgressCircleRingComponent', () => {
 
   describe('centerCircumference', () => {
     it('should return circumference in middle of stroke', () => {
-      expect(spectator.component.centerCircumference).toBe(
-        spectator.component.centerRadius * 2 * Math.PI
+      expect(spectator.component._centerCircumference).toBe(
+        spectator.component._centerRadius * 2 * Math.PI
       );
     });
   });
 
   describe('diameter', () => {
     it('should calculate diameter as 2*radius', () => {
-      expect(spectator.component.diameter).toBe(spectator.component.radius * 2);
+      expect(spectator.component._diameter).toBe(spectator.component.radius * 2);
     });
   });
 
@@ -53,9 +53,9 @@ describe('ProgressCircleRingComponent', () => {
         upperBound,
       });
 
-      expect(spectator.component.offset).toBe(
-        spectator.component.centerCircumference -
-          spectator.component.centerCircumference * (value / 100)
+      expect(spectator.component._offset).toBe(
+        spectator.component._centerCircumference -
+          spectator.component._centerCircumference * (value / 100)
       );
     });
   });
@@ -69,9 +69,9 @@ describe('ProgressCircleRingComponent', () => {
         upperBound,
       });
 
-      expect(spectator.component.offset).toBe(
-        spectator.component.centerCircumference -
-          spectator.component.centerCircumference * (upperBound / 100)
+      expect(spectator.component._offset).toBe(
+        spectator.component._centerCircumference -
+          spectator.component._centerCircumference * (upperBound / 100)
       );
     });
   });
@@ -87,7 +87,7 @@ describe('ProgressCircleRingComponent', () => {
       const radius = 33;
       const expectedSize = `${2 * radius}px`;
       spectator.setInput({ radius });
-      //width and height are set via hostbinding. Apparently we need to run a change detection cycle.
+      // As width and height are set via hostbinding, it is necessary to run a change detection cycle.
       spectator.detectChanges();
 
       expect(spectator.element).toHaveComputedStyle({
@@ -136,7 +136,7 @@ describe('ProgressCircleRingComponent', () => {
       spectator.detectChanges();
       expect(spectator.query('circle.progress')).toHaveAttribute(
         'r',
-        '' + spectator.component.centerRadius
+        '' + spectator.component._centerRadius
       );
     });
   });

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.spec.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.spec.ts
@@ -44,15 +44,32 @@ describe('ProgressCircleRingComponent', () => {
     });
   });
 
-  describe('offset (progress)', () => {
-    it('should return the non-progress circumference (1-progress) as offset', () => {
+  describe('offset (progress) within upperBound', () => {
+    it('should return the non-progress circumference (1 - progress) as offset', () => {
       const value = 33;
+      const upperBound = 96;
       spectator.setInput({
         value,
+        upperBound,
       });
       expect(spectator.component.offset).toBe(
         spectator.component.centerCircumference -
           spectator.component.centerCircumference * (value / 100)
+      );
+    });
+  });
+
+  describe('offset (progress) larger than upperBound', () => {
+    it('should return the non-progress circumference (1 - upperBound) as offset', () => {
+      const value = 99;
+      const upperBound = 96;
+      spectator.setInput({
+        value,
+        upperBound,
+      });
+      expect(spectator.component.offset).toBe(
+        spectator.component.centerCircumference -
+          spectator.component.centerCircumference * (upperBound / 100)
       );
     });
   });

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.spec.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.spec.ts
@@ -14,7 +14,7 @@ describe('ProgressCircleRingComponent', () => {
   });
 
   beforeEach(() => {
-    spectator = createHost({ props: { radius: 50 } });
+    spectator = createHost({ props: { radius: 50, strokeWidth: 4 } });
   });
 
   it('should create', () => {

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.spec.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.spec.ts
@@ -1,8 +1,8 @@
-import { Spectator, createComponentFactory } from '@ngneat/spectator';
+import { createComponentFactory, Spectator } from '@ngneat/spectator';
 
-import { ProgressCircleRingComponent } from './progress-circle-ring.component';
 import { DesignTokenHelper } from './../../helpers/design-token-helper';
 import { ThemeColor } from './../../helpers/theme-color.type';
+import { ProgressCircleRingComponent } from './progress-circle-ring.component';
 
 const getColor = DesignTokenHelper.getColor;
 
@@ -106,7 +106,7 @@ describe('ProgressCircleRingComponent', () => {
 
     it('should render background stroke with the defined stroke width', () => {
       spectator.detectChanges();
-      expect(spectator.query('circle.progress')).toHaveAttribute(
+      expect(spectator.query('circle.circle')).toHaveAttribute(
         'stroke-width',
         '' + spectator.component.strokeWidth
       );

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.svg
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.svg
@@ -1,10 +1,10 @@
-<svg [attr.width]="diameter" [attr.height]="diameter">
+<svg [attr.width]="_diameter" [attr.height]="_diameter">
   <circle
     shape-rendering="geometricPrecision"
     class="circle"
     fill="transparent"
     [attr.stroke-width]="strokeWidth"
-    [attr.r]="centerRadius"
+    [attr.r]="_centerRadius"
     [attr.cx]="radius"
     [attr.cy]="radius"
   />
@@ -14,10 +14,10 @@
     fill="transparent"
     stroke-linecap="round"
     [attr.stroke-width]="strokeWidth"
-    [attr.r]="centerRadius"
+    [attr.r]="_centerRadius"
     [attr.cx]="radius"
     [attr.cy]="radius"
-    [attr.stroke-dashoffset]="offset"
-    [attr.stroke-dasharray]="centerCircumference"
+    [attr.stroke-dashoffset]="_offset"
+    [attr.stroke-dasharray]="_centerCircumference"
   />
 </svg>

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.ts
@@ -7,7 +7,7 @@ import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProgressCircleRingComponent {
-  readonly STROKE_MAP = {
+  private STROKE_MAP = {
     sm: 3,
     md: 4,
     lg: 6,

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.ts
@@ -7,16 +7,10 @@ import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProgressCircleRingComponent {
-  private STROKE_MAP = {
-    sm: 3,
-    md: 4,
-    lg: 6,
-  };
-
   @Input() radius: number; // The desired outer radius of the SVG circle
   @Input() value: number = 0;
   @Input() themeColor: 'success' | 'warning' | 'danger' = 'success';
-  @Input() size: 'sm' | 'md' | 'lg' = 'md';
+  @Input() strokeWidth: number;
 
   get offset(): number {
     return this.centerCircumference - this.centerCircumference * (this.value / 100);
@@ -34,9 +28,5 @@ export class ProgressCircleRingComponent {
 
   get centerCircumference(): number {
     return this.centerRadius * 2 * Math.PI;
-  }
-
-  get strokeWidth(): number {
-    return this.STROKE_MAP[this.size];
   }
 }

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.ts
@@ -13,25 +13,25 @@ export class ProgressCircleRingComponent {
   @Input() strokeWidth: number;
   @Input() upperBound: number;
 
-  get offset(): number {
+  get _offset(): number {
     if (this.value < this.upperBound || this.value > 99) {
-      return this.centerCircumference - this.centerCircumference * (this.value / 100);
+      return this._centerCircumference - this._centerCircumference * (this.value / 100);
     } else {
-      return this.centerCircumference - this.centerCircumference * (this.upperBound / 100);
+      return this._centerCircumference - this._centerCircumference * (this.upperBound / 100);
     }
   }
 
   @HostBinding('style.width.px')
   @HostBinding('style.height.px')
-  get diameter(): number {
+  get _diameter(): number {
     return this.radius * 2;
   }
 
-  get centerRadius(): number {
+  get _centerRadius(): number {
     return this.radius - this.strokeWidth / 2;
   }
 
-  get centerCircumference(): number {
-    return this.centerRadius * 2 * Math.PI;
+  get _centerCircumference(): number {
+    return this._centerRadius * 2 * Math.PI;
   }
 }

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.ts
@@ -11,9 +11,14 @@ export class ProgressCircleRingComponent {
   @Input() value: number = 0;
   @Input() themeColor: 'success' | 'warning' | 'danger' = 'success';
   @Input() strokeWidth: number;
+  @Input() upperBound: number;
 
   get offset(): number {
-    return this.centerCircumference - this.centerCircumference * (this.value / 100);
+    if (this.value < this.upperBound || this.value > 99) {
+      return this.centerCircumference - this.centerCircumference * (this.value / 100);
+    } else {
+      return this.centerCircumference - this.centerCircumference * (this.upperBound / 100);
+    }
   }
 
   @HostBinding('style.width.px')

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.ts
@@ -14,10 +14,11 @@ export class ProgressCircleRingComponent {
   @Input() upperBound: number;
 
   get _offset(): number {
-    if (this.value < this.upperBound || this.value > 99) {
-      return this._centerCircumference - this._centerCircumference * (this.value / 100);
+    const valueWithinBounds = this.value < this.upperBound || this.value > 99;
+    if (valueWithinBounds) {
+      return this.calculateOffset(this.value);
     } else {
-      return this._centerCircumference - this._centerCircumference * (this.upperBound / 100);
+      return this.calculateOffset(this.upperBound);
     }
   }
 
@@ -33,5 +34,9 @@ export class ProgressCircleRingComponent {
 
   get _centerCircumference(): number {
     return this._centerRadius * 2 * Math.PI;
+  }
+
+  private calculateOffset(value: number) {
+    return this._centerCircumference - this._centerCircumference * (value / 100);
   }
 }

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.ts
@@ -1,6 +1,4 @@
-import { Component, Input, ChangeDetectionStrategy, HostBinding } from '@angular/core';
-
-import { ThemeColor } from '../../helpers/theme-color.type';
+import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular/core';
 
 @Component({
   selector: 'kirby-progress-circle-ring',
@@ -9,11 +7,16 @@ import { ThemeColor } from '../../helpers/theme-color.type';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProgressCircleRingComponent {
+  readonly STROKE_MAP = {
+    sm: 3,
+    md: 4,
+    lg: 6,
+  };
+
   @Input() radius: number; // The desired outer radius of the SVG circle
   @Input() value: number = 0;
   @Input() themeColor: 'success' | 'warning' | 'danger' = 'success';
-
-  readonly strokeWidth = 4;
+  @Input() size: 'sm' | 'md' | 'lg' = 'md';
 
   get offset(): number {
     return this.centerCircumference - this.centerCircumference * (this.value / 100);
@@ -31,5 +34,9 @@ export class ProgressCircleRingComponent {
 
   get centerCircumference(): number {
     return this.centerRadius * 2 * Math.PI;
+  }
+
+  get strokeWidth(): number {
+    return this.STROKE_MAP[this.size];
   }
 }

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.ts
@@ -36,7 +36,7 @@ export class ProgressCircleRingComponent {
     return this._centerRadius * 2 * Math.PI;
   }
 
-  private calculateOffset(value: number) {
+  private calculateOffset(value: number): number {
     return this._centerCircumference - this._centerCircumference * (value / 100);
   }
 }

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.html
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.html
@@ -6,5 +6,6 @@
   [value]="shownValue"
   [radius]="radius"
   [strokeWidth]="strokeWidth"
+  [upperBound]="upperBound"
 >
 </kirby-progress-circle-ring>

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.html
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.html
@@ -1,5 +1,10 @@
 <div class="transcluded-content">
   <ng-content></ng-content>
 </div>
-<kirby-progress-circle-ring [themeColor]="themeColor" [value]="shownValue" [radius]="radius">
+<kirby-progress-circle-ring
+  [themeColor]="themeColor"
+  [value]="shownValue"
+  [radius]="radius"
+  [size]="size"
+>
 </kirby-progress-circle-ring>

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.html
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.html
@@ -5,6 +5,6 @@
   [themeColor]="themeColor"
   [value]="shownValue"
   [radius]="radius"
-  [size]="size"
+  [strokeWidth]="strokeWidth"
 >
 </kirby-progress-circle-ring>

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.html
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.html
@@ -3,9 +3,9 @@
 </div>
 <kirby-progress-circle-ring
   [themeColor]="themeColor"
-  [value]="shownValue"
-  [radius]="radius"
-  [strokeWidth]="strokeWidth"
-  [upperBound]="upperBound"
+  [value]="_shownValue"
+  [radius]="_radius"
+  [strokeWidth]="_strokeWidth"
+  [upperBound]="_upperBound"
 >
 </kirby-progress-circle-ring>

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.spec.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.spec.ts
@@ -45,43 +45,43 @@ describe('ProgressCircleComponent', () => {
 
     describe('diameter', () => {
       it('should default to md', () => {
-        expect(spectator.component.diameter).toBe(56);
+        expect(spectator.component._diameter).toBe(56);
       });
 
       it('should map sm to correct value', () => {
         spectator.setInput({ size: 'sm' });
-        expect(spectator.component.diameter).toBe(40);
+        expect(spectator.component._diameter).toBe(40);
       });
 
       it('should map md to correct value', () => {
         spectator.setInput({ size: 'md' });
-        expect(spectator.component.diameter).toBe(56);
+        expect(spectator.component._diameter).toBe(56);
       });
 
       it('should map lg to correct value', () => {
         spectator.setInput({ size: 'lg' });
-        expect(spectator.component.diameter).toBe(96);
+        expect(spectator.component._diameter).toBe(96);
       });
     });
 
     describe('strokeWidth', () => {
       it('should default to md', () => {
-        expect(spectator.component.strokeWidth).toBe(4);
+        expect(spectator.component._strokeWidth).toBe(4);
       });
 
       it('should map sm to correct value', () => {
         spectator.setInput({ size: 'sm' });
-        expect(spectator.component.strokeWidth).toBe(3);
+        expect(spectator.component._strokeWidth).toBe(3);
       });
 
       it('should map md to correct value', () => {
         spectator.setInput({ size: 'md' });
-        expect(spectator.component.strokeWidth).toBe(4);
+        expect(spectator.component._strokeWidth).toBe(4);
       });
 
       it('should map lg to correct value', () => {
         spectator.setInput({ size: 'lg' });
-        expect(spectator.component.strokeWidth).toBe(6);
+        expect(spectator.component._strokeWidth).toBe(6);
       });
     });
 
@@ -90,21 +90,23 @@ describe('ProgressCircleComponent', () => {
         spectator.setInput({ value: 50 });
         spectator.component['hasElementBeenVisible'] = false;
 
-        expect(spectator.component.shownValue).toBe(0);
+        expect(spectator.component._shownValue).toBe(0);
       });
 
       it('should return value after element has been visible', () => {
         spectator.setInput({ value: 50 });
         spectator.component['hasElementBeenVisible'] = true;
 
-        expect(spectator.component.shownValue).toBe(50);
+        expect(spectator.component._shownValue).toBe(50);
       });
     });
 
     describe('radius', () => {
       it('should calculate radius as diameter / 2', () => {
         spectator.setInput({ size: 'sm' });
-        expect(spectator.component.radius).toBe(spectator.component.SIZE_CONFIG['sm'].diameter / 2);
+        expect(spectator.component._radius).toBe(
+          spectator.component.SIZE_CONFIG['sm'].diameter / 2
+        );
       });
     });
 

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.spec.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.spec.ts
@@ -1,14 +1,15 @@
+import { ChangeDetectorRef } from '@angular/core';
 import {
   createComponentFactory,
   createHostFactory,
   Spectator,
   SpectatorHost,
 } from '@ngneat/spectator';
-import { ChangeDetectorRef } from '@angular/core';
 
 import { TestHelper } from '../../testing/test-helper';
-import { ProgressCircleComponent } from './progress-circle.component';
+
 import { ProgressCircleRingComponent } from './progress-circle-ring.component';
+import { ProgressCircleComponent } from './progress-circle.component';
 
 describe('ProgressCircleComponent', () => {
   describe('with stubbed IntersectionObserver', () => {
@@ -45,22 +46,22 @@ describe('ProgressCircleComponent', () => {
     describe('diameter', () => {
       it('should default to md (56px)', () => {
         spectator.detectChanges();
-        expect(spectator.component.diameter).toBe(ProgressCircleComponent.DIAMETER_MAP.md);
+        expect(spectator.component.diameter).toBe(spectator.component.SIZE_CONFIG['md'].diameter);
       });
       it('should map sm to 40px', () => {
         spectator.setInput({ size: 'sm' });
         spectator.detectChanges();
-        expect(spectator.component.diameter).toBe(ProgressCircleComponent.DIAMETER_MAP.sm);
+        expect(spectator.component.diameter).toBe(spectator.component.SIZE_CONFIG['sm'].diameter);
       });
       it('should map md to 56px', () => {
         spectator.setInput({ size: 'md' });
         spectator.detectChanges();
-        expect(spectator.component.diameter).toBe(ProgressCircleComponent.DIAMETER_MAP.md);
+        expect(spectator.component.diameter).toBe(spectator.component.SIZE_CONFIG['md'].diameter);
       });
       it('should map lg to 96px', () => {
         spectator.setInput({ size: 'lg' });
         spectator.detectChanges();
-        expect(spectator.component.diameter).toBe(ProgressCircleComponent.DIAMETER_MAP.lg);
+        expect(spectator.component.diameter).toBe(spectator.component.SIZE_CONFIG['lg'].diameter);
       });
     });
 
@@ -82,7 +83,7 @@ describe('ProgressCircleComponent', () => {
     describe('radius', () => {
       it('should calculate radius as diameter / 2', () => {
         spectator.setInput({ size: 'sm' });
-        expect(spectator.component.radius).toBe(ProgressCircleComponent.DIAMETER_MAP.sm / 2);
+        expect(spectator.component.radius).toBe(spectator.component.SIZE_CONFIG['sm'].diameter / 2);
       });
     });
 

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.ts
@@ -1,11 +1,11 @@
 import {
-  Component,
-  Input,
-  ChangeDetectionStrategy,
-  HostBinding,
-  ElementRef,
   AfterViewInit,
+  ChangeDetectionStrategy,
   ChangeDetectorRef,
+  Component,
+  ElementRef,
+  HostBinding,
+  Input,
   OnDestroy,
 } from '@angular/core';
 
@@ -16,10 +16,10 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProgressCircleComponent implements AfterViewInit, OnDestroy {
-  static readonly DIAMETER_MAP = {
-    sm: 40,
-    md: 56,
-    lg: 96,
+  private SIZE_CONFIG = {
+    sm: { diameter: 40, strokeWidth: 3 },
+    md: { diameter: 56, strokeWidth: 4 },
+    lg: { diameter: 96, strokeWidth: 6 },
   };
 
   @Input() value: number = 0;
@@ -73,7 +73,7 @@ export class ProgressCircleComponent implements AfterViewInit, OnDestroy {
   @HostBinding('style.width.px')
   @HostBinding('style.height.px')
   get diameter(): number {
-    return ProgressCircleComponent.DIAMETER_MAP[this.size];
+    return this.SIZE_CONFIG[this.size].diameter;
   }
 
   get shownValue() {
@@ -83,5 +83,9 @@ export class ProgressCircleComponent implements AfterViewInit, OnDestroy {
 
   get radius() {
     return this.diameter / 2;
+  }
+
+  get strokeWidth() {
+    return this.SIZE_CONFIG[this.size].strokeWidth;
   }
 }

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.ts
@@ -72,24 +72,24 @@ export class ProgressCircleComponent implements AfterViewInit, OnDestroy {
 
   @HostBinding('style.width.px')
   @HostBinding('style.height.px')
-  get diameter(): number {
+  get _diameter(): number {
     return this.SIZE_CONFIG[this.size].diameter;
   }
 
-  get shownValue() {
+  get _shownValue() {
     // This is needed to make an animation [0 -> value] when element is shown to the user
     return this.hasElementBeenVisible ? this.value : 0;
   }
 
-  get radius() {
-    return this.diameter / 2;
+  get _radius() {
+    return this._diameter / 2;
   }
 
-  get strokeWidth() {
+  get _strokeWidth() {
     return this.SIZE_CONFIG[this.size].strokeWidth;
   }
 
-  get upperBound() {
+  get _upperBound() {
     // This is needed to make sure that an input value close to 100 is not shown as 100
     return this.SIZE_CONFIG[this.size].upperBound;
   }

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.ts
@@ -16,7 +16,7 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProgressCircleComponent implements AfterViewInit, OnDestroy {
-  private SIZE_CONFIG = {
+  readonly SIZE_CONFIG = {
     sm: { diameter: 40, strokeWidth: 3 },
     md: { diameter: 56, strokeWidth: 4 },
     lg: { diameter: 96, strokeWidth: 6 },

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.ts
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.ts
@@ -17,9 +17,9 @@ import {
 })
 export class ProgressCircleComponent implements AfterViewInit, OnDestroy {
   readonly SIZE_CONFIG = {
-    sm: { diameter: 40, strokeWidth: 3 },
-    md: { diameter: 56, strokeWidth: 4 },
-    lg: { diameter: 96, strokeWidth: 6 },
+    sm: { diameter: 40, strokeWidth: 3, upperBound: 95 },
+    md: { diameter: 56, strokeWidth: 4, upperBound: 96 },
+    lg: { diameter: 96, strokeWidth: 6, upperBound: 97 },
   };
 
   @Input() value: number = 0;
@@ -87,5 +87,10 @@ export class ProgressCircleComponent implements AfterViewInit, OnDestroy {
 
   get strokeWidth() {
     return this.SIZE_CONFIG[this.size].strokeWidth;
+  }
+
+  get upperBound() {
+    // This is needed to make sure that an input value close to 100 is not shown as 100
+    return this.SIZE_CONFIG[this.size].upperBound;
   }
 }


### PR DESCRIPTION
This PR closes #1468
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement (to existing content)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## Which issue documents the current behaviour?

<!-- Please link to a relevant issue that documents the current behaviour . -->

Issue Number: #1468

## What is the new behavior?

<!-- Please describe the new behaviour after your pull-request is comitted -->

Now the progress circle value respects an upper bound for each size (sm: 95, md: 96, lg:97). Values between the upper bound and 99 will show as the upper bound value, so the start and end line cap of the stroke does not merge and show like 100.  

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
