### PR TITLE
Bug/1619 add empty decimal mask placeholder

### DIFF
--- a/libs/designsystem/src/lib/components/form-field/directives/decimal-mask/decimal-mask.directive.spec.ts
+++ b/libs/designsystem/src/lib/components/form-field/directives/decimal-mask/decimal-mask.directive.spec.ts
@@ -197,7 +197,7 @@ describe('NumberInputDirective', () => {
         `<input kirby-input kirby-decimal-mask type="number" min="-100" [allowMinus]="false" />`
       );
       spectator.typeInElement('-', spectator.element);
-      expect(spectator.element).toHaveValue('-0');
+      expect(spectator.element).toHaveValue('-');
     });
 
     it('should allow negative numbers, if "allowMinus" is set to true', () => {
@@ -205,7 +205,7 @@ describe('NumberInputDirective', () => {
         `<input kirby-input kirby-decimal-mask type="number" [allowMinus]="true" />`
       );
       spectator.typeInElement('-', spectator.element);
-      expect(spectator.element).toHaveValue('-0');
+      expect(spectator.element).toHaveValue('-');
     });
   });
 

--- a/libs/designsystem/src/lib/components/form-field/directives/decimal-mask/decimal-mask.directive.ts
+++ b/libs/designsystem/src/lib/components/form-field/directives/decimal-mask/decimal-mask.directive.ts
@@ -91,6 +91,7 @@ export class DecimalMaskDirective implements ControlValueAccessor, OnInit {
       SetMaxOnOverflow: this.setMaxOnOverflow,
       showMaskOnFocus: false,
       showMaskOnHover: false,
+      placeholder: '',
       onBeforeWrite: () => {
         if (!this.inputmask) return;
         const unmaskedValue = this.inputmask.unmaskedvalue();


### PR DESCRIPTION
This PR closes #1619 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Enhancement (to existing content)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] cookbook application / infrastructure changes
- [ ] Other... Please describe:

## Which issue documents the current behaviour?

<!-- Please link to a relevant issue that documents the current behaviour . -->

Issue Number: #1619 

## What is the new behavior?

Before, on an input field with numeric inputmask, a '0' was always shown when all digits had been deleted.

Now, when the last digits is deleted, and the input field will just be empty. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
