### PR TITLE
🔧 Remove no unused locals and no unused params check

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,8 +12,6 @@
     "typeRoots": ["node_modules/@types"],
     "lib": ["es2017", "dom", "es6", "es2015.iterable"],
     "baseUrl": ".",
-    "resolveJsonModule": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?
This PR closes N/A.

## What is the new behavior?
Removed the checks for unused params and variables, because they were interfering with auto-generated files. 
Once we move to eslint (#1317), we can have this as a linting step `no-unused-vars` instead of a compile time check, so it is less obstructive.  

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](../CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


