### PR TITLE
Correct card documentation to say hasPadding defaults to false 

### DIFF
--- a/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.ts
@@ -34,7 +34,7 @@ export class CardShowcaseComponent {
     {
       name: 'hasPadding',
       description: '',
-      defaultValue: 'true',
+      defaultValue: 'false',
       type: ['boolean'],
     },
     {


### PR DESCRIPTION
## Which issue does this PR close?

No issue has been created for this - I went rouge and just submitted a PR 🥷

## What is the new behavior?
The cookbook API description for Card used to say `hasPadding` defaults to `true`. This is not the case as it is undefined by default - and hence falsy. 

From `libs/desingsystem/src/lib/components/card/card.component.ts`:
```javascript
export class CardComponent implements OnInit, OnDestroy {
  @Input() title: string;
  @Input() subtitle: string;

  @Input()
  hasPadding: boolean;
...
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](../CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [X] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [X] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [X] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] ~~Request that the changes are [UX reviewed](./CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


