### PR TITLE
Apply spacing to kirby-list-item when hasItemSpacing is true

### DIFF
--- a/libs/designsystem/src/lib/components/item/item.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/item/item.component.integration.spec.ts
@@ -82,6 +82,7 @@ describe('ItemComponent', () => {
         spectator.detectChanges();
         const kirbyItemsInList = spectator.queryAll('kirby-list-item:not(:last-child)');
 
+        expect(kirbyItemsInList).not.toBeEmpty();
         kirbyItemsInList.forEach((item) => {
           expect(item).toHaveComputedStyle({ 'margin-bottom': size('s') });
         });
@@ -92,6 +93,7 @@ describe('ItemComponent', () => {
         spectator.detectChanges();
         const kirbyItemsInList = spectator.queryAll('kirby-list-item:last-child');
 
+        expect(kirbyItemsInList).not.toBeEmpty();
         kirbyItemsInList.forEach((item) => {
           expect(item).toHaveComputedStyle({ 'margin-bottom': '0px' });
         });
@@ -104,6 +106,7 @@ describe('ItemComponent', () => {
         spectator.detectChanges();
         const kirbyItemsInList = spectator.queryAll('kirby-list-item');
 
+        expect(kirbyItemsInList).not.toBeEmpty();
         kirbyItemsInList.forEach((item) => {
           expect(item).toHaveComputedStyle({ 'margin-bottom': '0px' });
         });

--- a/libs/designsystem/src/lib/components/item/item.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/item/item.component.integration.spec.ts
@@ -44,7 +44,7 @@ describe('ItemComponent', () => {
     ],
   });
 
-  describe('inside Kirby List', () => {
+  describe('inside kirby-list', () => {
     beforeEach(async () => {
       spectator = createHost<ListComponent>(
         `
@@ -97,6 +97,7 @@ describe('ItemComponent', () => {
         });
       });
     });
+
     describe('with hasItemSpacing set to false', () => {
       it('should not apply spacing to items', () => {
         spectator.setInput('hasItemSpacing', false);
@@ -110,7 +111,7 @@ describe('ItemComponent', () => {
     });
   });
 
-  describe('inside list with cards', () => {
+  describe('inside kirby-list with cards', () => {
     beforeEach(async () => {
       spectator = createHost<ListComponent>(
         `

--- a/libs/designsystem/src/lib/components/item/item.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/item/item.component.integration.spec.ts
@@ -18,7 +18,7 @@ import { ItemComponent } from './item.component';
 
 const size = DesignTokenHelper.size;
 
-describe('ItemComponent in Kirby List', () => {
+describe('ItemComponent', () => {
   let ionList: HTMLElement;
   let itemsInList: HTMLElement[];
 
@@ -44,7 +44,7 @@ describe('ItemComponent in Kirby List', () => {
     ],
   });
 
-  describe('inside list', () => {
+  describe('inside Kirby List', () => {
     beforeEach(async () => {
       spectator = createHost<ListComponent>(
         `
@@ -74,6 +74,39 @@ describe('ItemComponent in Kirby List', () => {
       const lastItem = itemsInList[itemsInList.length - 1].shadowRoot.querySelector('.item-native');
       expect(firstItem).toHaveComputedStyle({ 'padding-top': size('xxs') });
       expect(lastItem).toHaveComputedStyle({ 'padding-bottom': size('xxs') });
+    });
+
+    describe('with hasItemSpacing set to true', () => {
+      it('should apply spacing to all but the last item', () => {
+        spectator.setInput('hasItemSpacing', true);
+        spectator.detectChanges();
+        const kirbyItemsInList = spectator.queryAll('kirby-list-item:not(:last-child)');
+
+        kirbyItemsInList.forEach((item) => {
+          expect(item).toHaveComputedStyle({ 'margin-bottom': size('s') });
+        });
+      });
+
+      it('should not apply spacing to the last item', () => {
+        spectator.setInput('hasItemSpacing', true);
+        spectator.detectChanges();
+        const kirbyItemsInList = spectator.queryAll('kirby-list-item:last-child');
+
+        kirbyItemsInList.forEach((item) => {
+          expect(item).toHaveComputedStyle({ 'margin-bottom': '0px' });
+        });
+      });
+    });
+    describe('with hasItemSpacing set to false', () => {
+      it('should not apply spacing to items', () => {
+        spectator.setInput('hasItemSpacing', false);
+        spectator.detectChanges();
+        const kirbyItemsInList = spectator.queryAll('kirby-list-item');
+
+        kirbyItemsInList.forEach((item) => {
+          expect(item).toHaveComputedStyle({ 'margin-bottom': '0px' });
+        });
+      });
     });
   });
 

--- a/libs/designsystem/src/lib/components/list/list.component.scss
+++ b/libs/designsystem/src/lib/components/list/list.component.scss
@@ -251,8 +251,7 @@ ion-item-options[side='end'] {
 
 :host-context(.item-spacing) {
   .list {
-    ion-item,
-    ion-item-sliding {
+    kirby-list-item {
       margin-bottom: size('s');
 
       & > ion-item,


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #1678

## What is the new behavior?

Padding is now added to the surrounding kirby-list-item wrapper component that was introduced with virtual scrolling in lists #1497.  

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](../CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](./CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


