### PR TITLE
WindowRef is now injected through a wrapper class

### DIFF
--- a/apps/cookbook/src/app/examples/examples.component.ts
+++ b/apps/cookbook/src/app/examples/examples.component.ts
@@ -1,7 +1,6 @@
 import { Component, HostListener } from '@angular/core';
 
 import { DesignTokenHelper } from '@kirbydesign/designsystem';
-
 import { WindowRef } from '@kirbydesign/designsystem/types/window-ref';
 
 @Component({
@@ -10,12 +9,14 @@ import { WindowRef } from '@kirbydesign/designsystem/types/window-ref';
   styleUrls: ['./examples.component.scss'],
 })
 export class ExamplesComponent {
-  showDummyKeyboard = !!this.window.sessionStorage.getItem('kirby-cookbook-show-dummy-keyboard');
+  showDummyKeyboard = !!this.windowRef.nativeWindow.sessionStorage.getItem(
+    'kirby-cookbook-show-dummy-keyboard'
+  );
   keyboardIsShowing = false;
   keyboardHeight: number;
   keyCount = 40;
 
-  constructor(private window: WindowRef) {
+  constructor(private windowRef: WindowRef) {
     this.setKeyboardSize();
   }
 
@@ -35,8 +36,8 @@ export class ExamplesComponent {
       },
     };
     const query = `(min-width: ${DesignTokenHelper.breakpoints.medium})`;
-    const device = this.window.matchMedia(query).matches ? 'tablet' : 'phone';
-    const orientation = this.window.matchMedia('(orientation: landscape)').matches
+    const device = this.windowRef.nativeWindow.matchMedia(query).matches ? 'tablet' : 'phone';
+    const orientation = this.windowRef.nativeWindow.matchMedia('(orientation: landscape)').matches
       ? 'landscape'
       : 'portrait';
     this.keyboardHeight = keyboardHeights[device][orientation];
@@ -70,7 +71,7 @@ export class ExamplesComponent {
       });
       const keyboardDidShowDelayInMs = 100;
       setTimeout(
-        () => this.window.dispatchEvent(ionKeyboardDidShowEvent),
+        () => this.windowRef.nativeWindow.dispatchEvent(ionKeyboardDidShowEvent),
         keyboardDidShowDelayInMs
       );
     }
@@ -81,7 +82,7 @@ export class ExamplesComponent {
     if (!this.showDummyKeyboard) return;
     if (input.tagName === 'INPUT' || input.tagName === 'TEXTAREA') {
       const ionKeyboardDidHideEvent = new CustomEvent('ionKeyboardDidHide');
-      this.window.dispatchEvent(ionKeyboardDidHideEvent);
+      this.windowRef.nativeWindow.dispatchEvent(ionKeyboardDidHideEvent);
     }
   }
 

--- a/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.ts
@@ -9,19 +9,21 @@ import { WindowRef } from '@kirbydesign/designsystem/types';
   styleUrls: ['./form-field-example.component.scss'],
 })
 export class FormFieldExampleComponent {
-  constructor(private window: WindowRef) {}
+  constructor(private windowRef: WindowRef) {}
   size: InputSize;
-  showDummyKeyboard = !!this.window.sessionStorage.getItem('kirby-cookbook-show-dummy-keyboard');
+  showDummyKeyboard = !!this.windowRef.nativeWindow.sessionStorage.getItem(
+    'kirby-cookbook-show-dummy-keyboard'
+  );
 
   toggleDummyKeyboard(show: boolean) {
     const sessionKey = 'kirby-cookbook-show-dummy-keyboard';
     this.showDummyKeyboard = show;
     this.showDummyKeyboard
-      ? this.window.sessionStorage.setItem(sessionKey, 'true')
-      : this.window.sessionStorage.removeItem(sessionKey);
+      ? this.windowRef.nativeWindow.sessionStorage.setItem(sessionKey, 'true')
+      : this.windowRef.nativeWindow.sessionStorage.removeItem(sessionKey);
     // Timeout prevents ExpressionChangedAfterItHasBeenCheckedError:
     setTimeout(() =>
-      this.window.dispatchEvent(
+      this.windowRef.nativeWindow.dispatchEvent(
         new CustomEvent('kirbyToggleDummyKeyboard', { detail: this.showDummyKeyboard })
       )
     );

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.ts
@@ -46,17 +46,17 @@ export class ModalExampleConfigurationComponent {
   // Use this flag in checkbox change event handlers to prevent ExpressionChangedAfterItHasBeenCheckedError
   private preventChangeEvent = false;
 
-  constructor(private window: WindowRef) {}
+  constructor(private windowRef: WindowRef) {}
 
   toggleDummyKeyboard(show: boolean) {
     const sessionKey = 'kirby-cookbook-show-dummy-keyboard';
     this.showDummyKeyboard = show;
     this.showDummyKeyboard
-      ? this.window.sessionStorage.setItem(sessionKey, 'true')
-      : this.window.sessionStorage.removeItem(sessionKey);
+      ? this.windowRef.nativeWindow.sessionStorage.setItem(sessionKey, 'true')
+      : this.windowRef.nativeWindow.sessionStorage.removeItem(sessionKey);
     // Timeout prevents ExpressionChangedAfterItHasBeenCheckedError:
     setTimeout(() =>
-      this.window.dispatchEvent(
+      this.windowRef.nativeWindow.dispatchEvent(
         new CustomEvent('kirbyToggleDummyKeyboard', { detail: this.showDummyKeyboard })
       )
     );

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-default.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-default.component.ts
@@ -202,7 +202,9 @@ export class ModalExampleDefaultComponent {
   embeddedCodeSnippet = config.embeddedCodeSnippet;
   closeModalCodeSnippet = config.closeModalCodeSnippet;
 
-  showDummyKeyboard = !!this.window.sessionStorage.getItem('kirby-cookbook-show-dummy-keyboard');
+  showDummyKeyboard = !!this.windowRef.nativeWindow.sessionStorage.getItem(
+    'kirby-cookbook-show-dummy-keyboard'
+  );
   showPageProgress = false;
   showFooter = false;
   showDummyContent = true;
@@ -214,7 +216,7 @@ export class ModalExampleDefaultComponent {
   dummyBackgroundTexts = new Array(100).map(() => '');
   preventInteraction = false;
 
-  constructor(private modalController: ModalController, private window: WindowRef) {}
+  constructor(private modalController: ModalController, private windowRef: WindowRef) {}
 
   private async showOverlay(flavor: 'modal' | 'drawer') {
     let title = flavor === 'modal' ? 'Modal Title' : 'Drawer Title';

--- a/libs/designsystem/src/lib/components/button/button.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/button/button.component.integration.spec.ts
@@ -45,7 +45,7 @@ describe('ButtonComponent in Kirby Page', () => {
     providers: [
       {
         provide: WindowRef,
-        useValue: window,
+        useValue: <WindowRef>{ nativeWindow: window },
       },
     ],
   });

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.initialization.spec.ts
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.initialization.spec.ts
@@ -33,7 +33,7 @@ describe('CalendarComponent', () => {
       },
       {
         provide: WindowRef,
-        useValue: window,
+        useValue: <WindowRef>{ nativeWindow: window },
       },
     ],
   });

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.spec.ts
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.spec.ts
@@ -39,7 +39,7 @@ describe('CalendarComponent', () => {
       },
       {
         provide: WindowRef,
-        useValue: window,
+        useValue: <WindowRef>{ nativeWindow: window },
       },
     ],
     imports: [TestHelper.ionicModuleForTest],

--- a/libs/designsystem/src/lib/components/calendar/helpers/calendar.helper.ts
+++ b/libs/designsystem/src/lib/components/calendar/helpers/calendar.helper.ts
@@ -9,7 +9,7 @@ export class CalendarHelper {
   private embeddedView: Window;
   private embeddedViewReady = false;
 
-  constructor(private window: WindowRef) {}
+  constructor(private windowRef: WindowRef) {}
 
   public init(
     calendarContainer: ElementRef,
@@ -25,7 +25,7 @@ export class CalendarHelper {
       };
       this.embeddedView = iframe.contentWindow;
 
-      this.window.addEventListener('message', (event: MessageEvent) =>
+      this.windowRef.nativeWindow.addEventListener('message', (event: MessageEvent) =>
         this.handleMessageEvent(event, onDaySelected, onChangeMonth)
       );
     }

--- a/libs/designsystem/src/lib/components/form-field/form-field.component.spec.ts
+++ b/libs/designsystem/src/lib/components/form-field/form-field.component.spec.ts
@@ -33,7 +33,7 @@ describe('FormFieldComponent', () => {
     providers: [
       {
         provide: WindowRef,
-        useValue: window,
+        useValue: <WindowRef>{ nativeWindow: window },
       },
     ],
   });

--- a/libs/designsystem/src/lib/components/form-field/form-field.component.ts
+++ b/libs/designsystem/src/lib/components/form-field/form-field.component.ts
@@ -51,7 +51,7 @@ export class FormFieldComponent
     elementRef: ElementRef<HTMLElement>,
     private platform: PlatformService,
     private renderer: Renderer2,
-    private window: WindowRef
+    private windowRef: WindowRef
   ) {
     this.element = elementRef.nativeElement;
   }
@@ -64,7 +64,7 @@ export class FormFieldComponent
     // Dispatch an `ionInputDidLoad` event to register
     // form field + input/textarea with Ionic input shims
     // See: https://github.com/ionic-team/ionic-framework/blob/master/core/src/utils/input-shims/input-shims.ts
-    this.window.document.dispatchEvent(
+    this.windowRef.nativeWindow.document.dispatchEvent(
       new CustomEvent('ionInputDidLoad', {
         detail: this.element,
       })
@@ -132,7 +132,7 @@ export class FormFieldComponent
     // Dispatch an `ionInputDidUnload` event to unregister
     // form field + input/textarea from Ionic input shims
     // See: https://github.com/ionic-team/ionic-framework/blob/master/core/src/utils/input-shims/input-shims.ts
-    this.window.document.dispatchEvent(
+    this.windowRef.nativeWindow.document.dispatchEvent(
       new CustomEvent('ionInputDidUnload', {
         detail: this.element,
       })

--- a/libs/designsystem/src/lib/components/item/item.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/item/item.component.integration.spec.ts
@@ -29,7 +29,7 @@ describe('ItemComponent', () => {
     providers: [
       {
         provide: WindowRef,
-        useValue: window,
+        useValue: <WindowRef>{ nativeWindow: window },
       },
     ],
     declarations: [

--- a/libs/designsystem/src/lib/components/list/directives/infinite-scroll.directive.spec.ts
+++ b/libs/designsystem/src/lib/components/list/directives/infinite-scroll.directive.spec.ts
@@ -32,7 +32,7 @@ describe('InfiniteScrollDirective', () => {
 
     const directive = new InfiniteScrollDirective(
       { nativeElement } as ElementRef,
-      { innerHeight: viewHeight, document: document as Document } as WindowRef,
+      { nativeWindow: { innerHeight: viewHeight, document: document as Document } } as WindowRef,
       mockNgZone
     );
     spyOn(directive.scrollEnd, 'emit');

--- a/libs/designsystem/src/lib/components/list/directives/infinite-scroll.directive.ts
+++ b/libs/designsystem/src/lib/components/list/directives/infinite-scroll.directive.ts
@@ -52,7 +52,7 @@ export class InfiniteScrollDirective implements AfterViewInit, OnDestroy {
    */
   private offset = 0.8;
 
-  constructor(private elementRef: ElementRef, private window: WindowRef, private zone: NgZone) {}
+  constructor(private elementRef: ElementRef, private windowRef: WindowRef, private zone: NgZone) {}
 
   ngAfterViewInit(): void {
     /**
@@ -130,7 +130,7 @@ export class InfiniteScrollDirective implements AfterViewInit, OnDestroy {
 
     const distanceToViewBottom = boundindClientRect.bottom;
     const elementHeight = boundindClientRect.height;
-    const viewHeight = this.window.innerHeight;
+    const viewHeight = this.windowRef.nativeWindow.innerHeight;
 
     return { distanceToViewBottom, elementHeight, viewHeight };
   }

--- a/libs/designsystem/src/lib/components/list/list.component.spec.ts
+++ b/libs/designsystem/src/lib/components/list/list.component.spec.ts
@@ -75,7 +75,7 @@ describe('ListComponent', () => {
       GroupByPipe,
       {
         provide: WindowRef,
-        useValue: window,
+        useValue: <WindowRef>{ nativeWindow: window },
       },
     ],
     schemas: [CUSTOM_ELEMENTS_SCHEMA],

--- a/libs/designsystem/src/lib/components/modal/alert/alert.component.spec.ts
+++ b/libs/designsystem/src/lib/components/modal/alert/alert.component.spec.ts
@@ -22,7 +22,7 @@ describe('AlertComponent', () => {
         providers: [
           {
             provide: WindowRef,
-            useValue: window,
+            useValue: <WindowRef>{ nativeWindow: window },
           },
         ],
         schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -123,7 +123,7 @@ describe('AlertComponent with okBtn', () => {
     providers: [
       {
         provide: WindowRef,
-        useValue: window,
+        useValue: <WindowRef>{ nativeWindow: window },
       },
     ],
   });

--- a/libs/designsystem/src/lib/components/modal/alert/alert.component.ts
+++ b/libs/designsystem/src/lib/components/modal/alert/alert.component.ts
@@ -13,7 +13,7 @@ import { WindowRef } from '../../../types/window-ref';
 export class AlertComponent implements AfterViewInit {
   readonly BLUR_WRAPPER_DELAY_IN_MS = 50;
   @ViewChild('alertWrapper', { static: true }) private alertWrapper: ElementRef;
-  private scrollY: number = Math.abs(this.window.scrollY);
+  private scrollY: number = Math.abs(this.windowRef.nativeWindow.scrollY);
 
   title$: Observable<string>;
   @Input()
@@ -33,7 +33,7 @@ export class AlertComponent implements AfterViewInit {
   @Input() okBtnIsDestructive: boolean;
   @Input() cancelBtnText: string;
 
-  constructor(private elementRef: ElementRef<HTMLElement>, private window: WindowRef) {}
+  constructor(private elementRef: ElementRef<HTMLElement>, private windowRef: WindowRef) {}
 
   ngAfterViewInit(): void {
     setTimeout(() => {
@@ -44,7 +44,7 @@ export class AlertComponent implements AfterViewInit {
 
   onFocusChange() {
     // This fixes an undesired scroll behaviour occurring on keyboard-tabbing
-    this.window.scrollTo({ top: this.scrollY });
+    this.windowRef.nativeWindow.scrollTo({ top: this.scrollY });
   }
 
   onCancel() {

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/compact/modal-compact-wrapper.component.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/compact/modal-compact-wrapper.component.ts
@@ -15,7 +15,7 @@ import { COMPONENT_PROPS } from '../config/modal-config.helper';
   host: { '[class.ion-page]': 'false' }, //Ensure ion-page class doesn't get applied by Ionic Modal Controller
 })
 export class ModalCompactWrapperComponent implements Modal, OnInit {
-  scrollY: number = Math.abs(this.window.scrollY);
+  scrollY: number = Math.abs(this.windowRef.nativeWindow.scrollY);
   scrollDisabled = false;
   @Input() config: ModalConfig;
   componentPropsInjector: Injector;
@@ -29,7 +29,7 @@ export class ModalCompactWrapperComponent implements Modal, OnInit {
   constructor(
     private injector: Injector,
     private elementRef: ElementRef<HTMLElement>,
-    private window: WindowRef
+    private windowRef: WindowRef
   ) {}
 
   ngOnInit(): void {
@@ -74,6 +74,6 @@ export class ModalCompactWrapperComponent implements Modal, OnInit {
   @HostListener('window:focusout')
   onFocusChange() {
     // This fixes an undesired scroll behaviour occurring on keyboard-tabbing backwards (with shift+tab):
-    this.window.scrollTo({ top: this.scrollY });
+    this.windowRef.nativeWindow.scrollTo({ top: this.scrollY });
   }
 }

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
@@ -42,7 +42,7 @@ import { COMPONENT_PROPS } from './config/modal-config.helper';
 export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDestroy {
   static readonly KEYBOARD_HIDE_DELAY_IN_MS = 100;
 
-  scrollY: number = Math.abs(this.windowRef.scrollY);
+  scrollY: number = Math.abs(this.windowRef.nativeWindow.scrollY);
   private readonly VIEWPORT_RESIZE_DEBOUNCE_TIME = 100;
 
   set scrollDisabled(disabled: boolean) {
@@ -143,7 +143,7 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
           // wait for template to render
           setTimeout(() => {
             const domRect = this.elementRef.nativeElement.getBoundingClientRect();
-            const document = this.windowRef.document.documentElement;
+            const document = this.windowRef.nativeWindow.document.documentElement;
             const right = document.clientWidth - domRect.right;
             this.renderer.setStyle(this.ionModalElement, 'top', `${domRect.top}px`);
             this.renderer.setStyle(this.ionModalElement, 'left', `${domRect.left}px`);
@@ -295,7 +295,7 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
   @HostListener('window:focusout')
   onFocusChange() {
     // This fixes an undesired scroll behaviour occurring on keyboard-tabbing backwards (with shift+tab):
-    this.windowRef.scrollTo({ top: this.scrollY });
+    this.windowRef.nativeWindow.scrollTo({ top: this.scrollY });
   }
 
   @HostListener('window:ionKeyboardDidShow', ['$event.detail.keyboardHeight'])
@@ -338,7 +338,7 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
   private getKeyboardOverlap(keyboardHeight: number, element: Element) {
     if (keyboardHeight <= 0 || !element) return 0;
     const distanceFromViewportBottomToElement = Math.floor(
-      this.windowRef.innerHeight - element.getBoundingClientRect().bottom
+      this.windowRef.nativeWindow.innerHeight - element.getBoundingClientRect().bottom
     );
     return Math.max(keyboardHeight - distanceFromViewportBottomToElement, 0);
   }
@@ -394,12 +394,12 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
   }
 
   private setViewportHeight() {
-    const vh = (this.windowRef.innerHeight * 0.01).toFixed(2);
+    const vh = (this.windowRef.nativeWindow.innerHeight * 0.01).toFixed(2);
     this.setCssVar(this.elementRef.nativeElement, '--vh', `${vh}px`);
   }
 
   private observeViewportResize() {
-    this.resizeObserverService.observe(this.windowRef.document.body, (entry) =>
+    this.resizeObserverService.observe(this.windowRef.nativeWindow.document.body, (entry) =>
       this.onViewportResize(entry)
     );
   }
@@ -520,8 +520,8 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
     };
 
     // Set explicit viewport root if within iframe:
-    const root = this.windowRef.frameElement
-      ? (this.windowRef.document as any) // Cast to `any` as Typescript lib.d.ts doesnt support Document type yet
+    const root = this.windowRef.nativeWindow.frameElement
+      ? (this.windowRef.nativeWindow.document as any) // Cast to `any` as Typescript lib.d.ts doesnt support Document type yet
       : undefined;
     const options: IntersectionObserverInit = {
       rootMargin: '0px 0px -1px 0px', // `bottom: -1px` allows checking when the modal bottom is touching the viewport
@@ -542,7 +542,7 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
     this.intersectionObserver.disconnect();
     delete this._intersectionObserver;
     if (this.resizeObserverService) {
-      this.resizeObserverService.unobserve(this.windowRef.document.body);
+      this.resizeObserverService.unobserve(this.windowRef.nativeWindow.document.body);
       this.resizeObserverService.unobserve(this.ionHeaderElement.nativeElement);
       this.resizeObserverService.unobserve(this.getEmbeddedFooterElement());
     }

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.testbuilder.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.testbuilder.ts
@@ -32,7 +32,7 @@ export class ModalWrapperTestBuilder {
     providers: [
       {
         provide: WindowRef,
-        useValue: window,
+        useValue: <WindowRef>{ nativeWindow: window },
       },
     ],
     declarations: [

--- a/libs/designsystem/src/lib/components/modal/services/alert.helper.spec.ts
+++ b/libs/designsystem/src/lib/components/modal/services/alert.helper.spec.ts
@@ -27,7 +27,7 @@ describe('AlertHelper', () => {
     providers: [
       {
         provide: WindowRef,
-        useValue: window,
+        useValue: <WindowRef>{ nativeWindow: window },
       },
     ],
   });

--- a/libs/designsystem/src/lib/components/modal/services/modal.helper.spec.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal.helper.spec.ts
@@ -91,7 +91,7 @@ describe('ModalHelper', () => {
     providers: [
       {
         provide: WindowRef,
-        useValue: window,
+        useValue: <WindowRef>{ nativeWindow: window },
       },
     ],
     declarations: [

--- a/libs/designsystem/src/lib/components/modal/services/modal.helper.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal.helper.ts
@@ -45,7 +45,7 @@ export class ModalHelper {
     }
 
     if (config.interactWithBackground) {
-      this.windowRef.document.body.classList.add(allow_scroll_class);
+      this.windowRef.nativeWindow.document.body.classList.add(allow_scroll_class);
     }
 
     const ionModal = await this.ionicModalController.create({
@@ -71,7 +71,7 @@ export class ModalHelper {
 
     if (config.interactWithBackground) {
       ionModal.onDidDismiss().then(() => {
-        this.windowRef.document.body.classList.remove(allow_scroll_class);
+        this.windowRef.nativeWindow.document.body.classList.remove(allow_scroll_class);
       });
     }
 

--- a/libs/designsystem/src/lib/components/page/page.component.spec.ts
+++ b/libs/designsystem/src/lib/components/page/page.component.spec.ts
@@ -59,7 +59,7 @@ describe('PageComponent', () => {
     providers: [
       {
         provide: WindowRef,
-        useValue: window,
+        useValue: <WindowRef>{ nativeWindow: window },
       },
       mockProvider(TabsComponent, { tabBarBottomHidden: false }),
       mockProvider(ModalNavigationService),

--- a/libs/designsystem/src/lib/components/page/page.component.ts
+++ b/libs/designsystem/src/lib/components/page/page.component.ts
@@ -216,7 +216,7 @@ export class PageComponent
     private renderer: Renderer2,
     private router: Router,
     private changeDetectorRef: ChangeDetectorRef,
-    private window: WindowRef,
+    private windowRef: WindowRef,
     private modalNavigationService: ModalNavigationService,
     @Optional() @SkipSelf() private tabsComponent: TabsComponent
   ) {}
@@ -251,7 +251,7 @@ export class PageComponent
       }
     });
 
-    this.window.addEventListener(selectedTabClickEvent, () => {
+    this.windowRef.nativeWindow.addEventListener(selectedTabClickEvent, () => {
       this.content.scrollToTop(KirbyAnimation.Duration.LONG);
     });
   }
@@ -273,7 +273,7 @@ export class PageComponent
     this.ngOnDestroy$.complete();
 
     this.pageTitleIntersectionObserverRef.disconnect();
-    this.window.removeEventListener(selectedTabClickEvent, () => {
+    this.windowRef.nativeWindow.removeEventListener(selectedTabClickEvent, () => {
       this.content.scrollToTop(KirbyAnimation.Duration.LONG);
     });
   }

--- a/libs/designsystem/src/lib/helpers/platform.service.ts
+++ b/libs/designsystem/src/lib/helpers/platform.service.ts
@@ -1,21 +1,22 @@
 import { Injectable } from '@angular/core';
 
 import { WindowRef } from '../types/window-ref';
+
 import { DesignTokenHelper } from './design-token-helper';
 
 @Injectable({
   providedIn: 'root',
 })
 export class PlatformService {
-  constructor(private window: WindowRef) {}
+  constructor(private windowRef: WindowRef) {}
 
   isTouch() {
     const isTouchDeviceQuery = '(pointer: coarse)'; // No check for `hover: none`, as Samsung Galaxy will return false on `hover: none` media query
-    return this.window.matchMedia(isTouchDeviceQuery).matches;
+    return this.windowRef.nativeWindow.matchMedia(isTouchDeviceQuery).matches;
   }
 
   isPhabletOrBigger() {
     const query = `(min-width: ${DesignTokenHelper.breakpoints.medium})`;
-    return this.window.matchMedia(query).matches;
+    return this.windowRef.nativeWindow.matchMedia(query).matches;
   }
 }

--- a/libs/designsystem/src/lib/kirby.module.ts
+++ b/libs/designsystem/src/lib/kirby.module.ts
@@ -71,7 +71,6 @@ import { ToggleComponent } from './components/toggle/toggle.component';
 import { KeyHandlerDirective } from './directives/key-handler/key-handler.directive';
 import { ModalRouterLinkDirective } from './directives/modal-router-link/modal-router-link.directive';
 import { ThemeColorDirective } from './directives/theme-color/theme-color.directive';
-import { WindowRef } from './types/window-ref';
 
 const exportedDeclarations = [
   CardComponent,
@@ -156,10 +155,6 @@ const providers = [
   LoadingOverlayService,
   ResizeObserverFactory,
   ResizeObserverService,
-  {
-    provide: WindowRef,
-    useValue: window,
-  },
 ];
 
 const entryComponents = [

--- a/libs/designsystem/src/lib/types/window-ref.ts
+++ b/libs/designsystem/src/lib/types/window-ref.ts
@@ -1,1 +1,10 @@
-export class WindowRef extends Window {}
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class WindowRef {
+  get nativeWindow(): any {
+    return window;
+  }
+}


### PR DESCRIPTION
This fixes the issue of WindowRef injection being broken when using KirbyModule in (jest based) DRB integration tests, which in turn has prevented the integration tests from using non-mocked Kirby components.

## Which issue does this PR close?

This PR closes #1624 

## What is the new behavior?

KirbyModule can now be injected and used in jest test without errors caused by to broken WindowRef injection.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](../CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

**NOTE: No changes to the functionality are introduced. I've run the test spec and I've spun up the cookbook to verify that both still work, and I've also verified that the change fixes the DI problem when using KirbyModule from a DRB test.**

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](./CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


