### PR TITLE
Hotfix CI/CD pipeline by adding Helm charts to repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,8 +236,6 @@ jobs:
           echo "pushing docker image $DOCKER_REPO:$DOCKER_TAG"
           echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin drbstaging.azurecr.io
           docker push $DOCKER_REPO:$DOCKER_TAG
-      - name: Clone charts repo
-        run: git clone https://github.com/Bankdata/charts.git charts
       - name: Decrypt Kubernetes config
         env:
           KEY: ${{secrets.ENCRYPTED_09E556D51FDC_KEY}}
@@ -249,7 +247,7 @@ jobs:
           DOCKER_REPO: 'drbstaging.azurecr.io/kirbydesign/designsystem'
           DOCKER_TAG: git${{github.sha}}
           HELM_CONFIG: ${{ github.ref == 'refs/heads/master' && 'config/helm/staging.yaml' || 'config/helm/branch.yaml' }}
-        run: /usr/bin/helm upgrade --kubeconfig kube.config -i "${RELEASENAME}" charts/spa --set image.repository=$DOCKER_REPO --set image.tag=$DOCKER_TAG --set ingress.host="${HOSTNAME}".$DOMAIN -f $HELM_CONFIG
+        run: /usr/bin/helm upgrade --kubeconfig kube.config -i "${RELEASENAME}" config/helm/charts/spa --set image.repository=$DOCKER_REPO --set image.tag=$DOCKER_TAG --set ingress.host="${HOSTNAME}".$DOMAIN -f $HELM_CONFIG
       - name: Deploy the pull request
         run: |
           # deployment logic goes here

--- a/config/helm/charts/spa/Chart.yaml
+++ b/config/helm/charts/spa/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+name: spa
+version: 1.0.0

--- a/config/helm/charts/spa/README.md
+++ b/config/helm/charts/spa/README.md
@@ -1,0 +1,4 @@
+# Single Page Application Chart
+
+This is meant as a generic chart to support a very simple deployment
+of single page applications.

--- a/config/helm/charts/spa/templates/_helpers.tpl
+++ b/config/helm/charts/spa/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "spa.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "spa.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/config/helm/charts/spa/templates/deployment.yaml
+++ b/config/helm/charts/spa/templates/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "spa.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "spa.name" . }}
+{{- if .Values.git }}	
+    git.repo: {{ .Values.git.repo }}	
+    git.branch: {{ .Values.git.branch | replace "/" "__" }}	
+{{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "25%"
+      maxSurge: "25%"
+  template:
+    metadata:
+      labels:
+        release: {{ .Release.Name }}
+        app: {{ template "spa.name" . }}
+    spec:
+      containers:
+      - name: {{ template "spa.name" . }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        ports:
+        - name: web
+          containerPort: 80
+        resources:
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 1m
+            memory: 20Mi
+        livenessProbe:
+          httpGet:
+            path: /index.html
+            port: web
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: web
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+{{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecret }}
+{{- end }}

--- a/config/helm/charts/spa/templates/ingress.yaml
+++ b/config/helm/charts/spa/templates/ingress.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "spa.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "spa.name" . }}
+{{- if .Values.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+{{- end }}
+spec:
+  rules:
+  - host: {{ .Values.ingress.host | quote }}
+    http:
+      paths:
+      - backend:
+          serviceName: {{ template "spa.fullname" . }}
+          servicePort: web
+{{- if .Values.ingress.tls.enable }}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.host | quote }}
+{{- if .Values.ingress.tls.secret }}
+    secretName: {{ .Values.ingress.tls.secret }}
+{{ else }}
+    secretName: {{ template "spa.fullname" . }}
+{{- end }}
+{{- end }}

--- a/config/helm/charts/spa/templates/service.yaml
+++ b/config/helm/charts/spa/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "spa.fullname" . }}
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "spa.name" . }}
+spec:
+  selector:
+    app: {{ template "spa.name" . }}
+    release: {{ .Release.Name }}
+  ports:
+  - name: web
+    port: 80
+    targetPort: web

--- a/config/helm/charts/spa/values.yaml
+++ b/config/helm/charts/spa/values.yaml
@@ -1,0 +1,4 @@
+# Default values for generic spa
+
+replicaCount: 2
+configPath: "/usr/share/nginx/html/config"


### PR DESCRIPTION
## Which issue does this PR close?

None - the CI/CD pipeline is down. This is a hot fix. 

## What is the new behavior?

Before we acquired helm charts from a remote repository which has now been made private. The files we were dependent on from this repository has been included in the `config/helm` folder as part of the Kirby repository.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->


## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](../CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Review  
- [X] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [X] Request that the changes are code-reviewed 

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


