### PR TITLE
Fixed bug causing an error to be thrown when updating customOptions in the ChartComponent

### DIFF
--- a/libs/designsystem/src/lib/components/chart/chart-js/chart-js.service.ts
+++ b/libs/designsystem/src/lib/components/chart/chart-js/chart-js.service.ts
@@ -86,11 +86,12 @@ export class ChartJSService {
     this.chart.data.datasets = this.createDatasets(oldDatasets, highlightedElements);
   }
 
-  private getExistingChartAnnotations(): AnnotationOptions[] | undefined {
-    /* Plugin options type uses a utility type to mark all members as optional. 
-       To not have to import this from the utility-types npm package, return as 
-       AnnotationOptions[]; that is what we get in the end anyways */
-    return this.chart.options.plugins?.annotation?.annotations as AnnotationOptions[];
+  private getExistingChartAnnotations(): AnnotationOptions[] {
+    const annotations = this.chart.options.plugins?.annotation?.annotations;
+    /* In browser chart.js might return annotations as a Proxy object; force it to be an array.
+       Each annotationOption in the resulting array  will also be a Proxy object. 
+       But internally chart.js will just work with them as normal values */
+    return Object.keys(annotations).map((key) => annotations[key]);
   }
 
   private destructivelyUpdateType(type: ChartType, customOptions?: ChartOptions) {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #1709

## What is the new behavior?

The `getExistingChartAnnotations` function in the `ChartJSService` has been updated to always return an array. 

In the browser (and not when running tests!) chart.js uses [Proxy objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) for plugins to pass internal attributes & data as to not unintentionally leak potentially sensitive data (as far as I understand). 

The consequence was that whenever the following line was executed in a browser that neither `undefined` or an array of annotations would be returned; it would instead return an object with type `Proxy` no matter if there's any annotations or not. 
``` typescript
this.chart.options.plugins?.annotation?.annotations;
``` 

Causing the `annotations.map` in `applyDefaultsToAnnotations` to fail as map does not exist on Proxy objects. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](../CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [ ] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [X] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [X] Request that the changes are code-reviewed 
- [ ]~~Request that the changes are [UX reviewed](./CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


