### PR TITLE
Fixed issue where removing last item in list with sections did not update list view to be empty

### DIFF
--- a/libs/designsystem/src/lib/components/list/list.component.spec.ts
+++ b/libs/designsystem/src/lib/components/list/list.component.spec.ts
@@ -117,6 +117,19 @@ describe('ListComponent', () => {
 
       expect(spectator.component._isSectionsEnabled).toBeTruthy();
     });
+
+    it('should have no groupedItems when last item in items input is removed', () => {
+      spectator.setInput({
+        items: [TEST_ITEMS[0]],
+        getSectionName: (_item: any) => 'this is a test',
+      });
+
+      expect(spectator.component._groupedItems).toHaveLength(1);
+
+      spectator.setInput({ items: [] });
+
+      expect(spectator.component._groupedItems).toHaveLength(0);
+    });
   });
 
   describe('divider', () => {

--- a/libs/designsystem/src/lib/components/list/list.component.ts
+++ b/libs/designsystem/src/lib/components/list/list.component.ts
@@ -197,8 +197,6 @@ export class ListComponent implements OnInit, AfterViewInit, OnChanges {
 
   ngOnChanges(): void {
     this._isSectionsEnabled = !!this.getSectionName;
-    if (this.items?.length === 0) return;
-
     this._groupedItems = this._isSectionsEnabled
       ? this.groupBy.transform(this.items, this.getSectionName)
       : null;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #1725 

## What is the new behavior?
This PR is a fix to a regression introduced when implementing virtual scroll in #853, more specifically [this line in list.component.ts](https://github.com/kirbydesign/designsystem/blob/master/libs/designsystem/src/lib/components/list/list.component.ts#L200), introduced by 4bf824da3cd7e1f49310fc8465b6f53f0d8368ea. 

Previously, this check had been limited to guard for `this.items` being null, but now it was changed to return if the `items` input had length 0. Naturally, `ngOnChanges` fires when the `items` input is changed, also if it is set to an empty array. 

So in the specific case when the last item is removed and `items` gets length 0, the `_groupedItems` which the UI looks at when rendering the sections and their respective items, never gets updated, and `_groupedItems` will still have that last item, and therefore render a section header.

[This line in list.component.ts](https://github.com/kirbydesign/designsystem/blob/master/libs/designsystem/src/lib/components/list/list.component.ts#L200) has therefore been completely removed, because the `groupBy` pipe that is called next already handles checking for `this.items` not being null. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](../CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](./CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


