### PR TITLE
Fix wrong spacing between items in kirby-list

### DIFF
--- a/libs/designsystem/src/lib/components/item/item.component.scss
+++ b/libs/designsystem/src/lib/components/item/item.component.scss
@@ -82,26 +82,21 @@
 }
 
 /* clean-css ignore:start */
-:host-context(kirby-list ion-item-sliding:first-of-type) {
-  ion-item {
+// Fixes https://github.com/kirbydesign/designsystem/issues/1745
+ion-item {
+  :host-context(kirby-list-item:first-of-type) & {
     --padding-top: #{size('xxs')};
   }
-}
 
-:host-context(kirby-list ion-item-sliding:first-of-type kirby-card) {
-  ion-item {
+  :host-context(kirby-list-item:first-of-type kirby-card) & {
     --padding-top: 0;
   }
-}
 
-:host-context(kirby-list ion-item-sliding:last-of-type) {
-  ion-item {
+  :host-context(kirby-list-item:last-of-type) & {
     --padding-bottom: #{size('xxs')};
   }
-}
 
-:host-context(kirby-list ion-item-sliding:last-of-type kirby-card) {
-  ion-item {
+  :host-context(kirby-list-item:last-of-type kirby-card) & {
     --padding-bottom: 0;
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #1745 

## What is the new behavior?

There is no longer extra space between list items.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

In https://github.com/kirbydesign/designsystem/pull/1497 the markup structure for lists were modified which introduced extra space between list items.

**❌ Before**

<img width="591" alt="1 before" src="https://user-images.githubusercontent.com/150451/133602109-943c7166-4071-43c5-8420-722bf45e0c05.png">

**✅ After**

<img width="591" alt="2 after" src="https://user-images.githubusercontent.com/150451/133602123-23616747-843c-413e-b103-8a82117f6848.png">

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](../CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](./CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


