### PR TITLE
Remove link to https://kirby.design from cookbook navigation menu

### DIFF
--- a/apps/cookbook/src/app/page/header/header.component.ts
+++ b/apps/cookbook/src/app/page/header/header.component.ts
@@ -13,7 +13,6 @@ export const navigationItems: HeaderLink[] = [
   { text: 'Changelog', route: '/home/changelog' },
   { text: 'Component Status', route: '/home/component-status' },
   { text: 'Layout Recipes', route: '/home/layout-recipes' },
-  { text: 'Design', externalUrl: 'https://kirby.design/' },
   { text: 'GitHub', externalUrl: 'https://github.com/kirbydesign/designsystem' },
 ];
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #1757 

## What is the new behavior?

There is no longer a "Design" link in the cookbook navigation menu.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

When we moved to Github Pages https://kirby.design was redirected to https://cookbook.kirby.design.

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](../CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [x] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](./CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


