### PR TITLE
Fix visual bug where rounded corners were missing from top corners in first item in list section

### DIFF
--- a/libs/designsystem/src/lib/components/item/item.component.scss
+++ b/libs/designsystem/src/lib/components/item/item.component.scss
@@ -133,3 +133,11 @@ ion-item {
     border-bottom-right-radius: 0;
   }
 }
+
+// Fixes https://github.com/kirbydesign/designsystem/issues/1711
+:host-context(.shape-rounded.has-sections .list-items kirby-list-item:first-of-type) {
+  ion-item::part(native) {
+    border-top-left-radius: $border-radius;
+    border-top-right-radius: $border-radius;
+  }
+}


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #1711 

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

### Before

![image](https://user-images.githubusercontent.com/150451/134393510-d5348fa1-85f4-439b-b9e1-05bdcab6c8d2.png)

### After

![image](https://user-images.githubusercontent.com/150451/134393297-afd319e5-cce4-4ee2-b4ce-85145b872af4.png)

This PR is related to #1752.

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](../CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](./CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


