### PR TITLE
Added :host to _global-styles for encapsulation in WEB Components

### DIFF
--- a/libs/designsystem/src/lib/scss/_global-styles.scss
+++ b/libs/designsystem/src/lib/scss/_global-styles.scss
@@ -3,7 +3,8 @@
 @import './base/typography';
 @import './base/line-clamp';
 
-:root {
+:root,
+:host {
   --kirby-font-family: 'Roboto';
   font-family: var(--kirby-font-family);
   @each $color, $color-name in $kirby-colors {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #1770

## What is the new behavior?

Global styles is initialized on the shadow root of my web component when I import them in a WEB Component

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](../CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](./CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


