### PR TITLE
Add slotted badge to segmented control

### DIFF
--- a/apps/cookbook/src/app/examples/segmented-control-example/default/default.ts
+++ b/apps/cookbook/src/app/examples/segmented-control-example/default/default.ts
@@ -9,7 +9,12 @@ const config = {
   [mode]="mode"
   [size]="size"
   (segmentSelect)="onSegmentSelect($event)"
-></kirby-segmented-control>
+>
+<kirby-badge themeColor="warning">
+  <kirby-icon name="attach"></kirby-icon>
+</kirby-badge>
+
+</kirby-segmented-control>
 
 <kirby-card hasPadding="true">
   <h2>Content for {{ selectedSegment.text }} segment</h2>

--- a/libs/core/src/components/badge/badge.component.scss
+++ b/libs/core/src/components/badge/badge.component.scss
@@ -35,6 +35,14 @@
   }
 }
 
+:host-context(.segment-btn-wrapper) {
+  --kirby-badge-elevation: #{get-elevation(2)};
+  position: absolute;
+  top: -#{size('xxs')};
+  right: #{size('xxs')};
+  z-index: z('segmentBadge');
+}
+
 @each $color-name, $color-value in $notification-colors {
   $text-color: get-color($color-name + '-contrast');
   @if ($color-name == 'danger') {

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
@@ -13,6 +13,7 @@
       [themeColor]="item.badge.themeColor"
       >{{ item.badge.content }}</kirby-badge
     >
+    <ng-content></ng-content>
   </div>
 </ion-segment>
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #815

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->
Instead of supplying the badge as an item to the `SegmentedControl` it is now possible to _slot_ the badge component instead. This opens up for using icons in the badge, when used in the context of the `SegmentedControl`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](../CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](./CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


