### PR TITLE
Re-export IonRouterOutlet

### DIFF
--- a/libs/designsystem/src/lib/components/tabs/index.ts
+++ b/libs/designsystem/src/lib/components/tabs/index.ts
@@ -2,4 +2,4 @@ export { TabsComponent } from './tabs.component';
 export { TabButtonComponent } from './tab-button/tab-button.component';
 export { selectedTabClickEvent } from './tab-button/tab-button.events';
 export { TabsModule } from './tabs.module';
-export { TabsService } from './tabs.service';
+export { TabsService, IonRouterOutlet } from './tabs.service';

--- a/libs/designsystem/src/lib/components/tabs/tabs.service.ts
+++ b/libs/designsystem/src/lib/components/tabs/tabs.service.ts
@@ -13,3 +13,5 @@ export class TabsService {
     this.outletSubject$.next(outlet);
   }
 }
+
+export { IonRouterOutlet };


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #1789

## What is the new behavior?

With TypeScript 4.3 we can't import types from derived dependencies. `IonRouterOutlet` is part of `@ionic/angular` and we get that through Kirby. So when we update to TypeScript 4.3, we need to have `@ionic/angular` as part of our `package.json`, which is not desirable.

This pull requests re-exports `IonRouterOutlet` through Kirby, so we don't need to have `@ionic/angular` as part of the `package.json` in our project.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


