### PR TITLE
Update mocks for button, popover and calendar

### DIFF
--- a/libs/designsystem/testing-base/src/lib/components/mock.button.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.button.component.ts
@@ -19,7 +19,6 @@ export class MockButtonComponent {
   @Input() isDestructive: boolean;
   @Input() themeColor: NotificationColor;
   @Input() expand: 'full' | 'block';
-  @Input() text: string;
   @Input() isFloating: boolean;
   @Input() size: ButtonSize;
 }

--- a/libs/designsystem/testing-base/src/lib/components/mock.calendar.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.calendar.component.ts
@@ -17,6 +17,7 @@ import { CalendarComponent, CalendarYearNavigatorConfig } from '@kirbydesign/des
 export class MockCalendarComponent {
   @Output() dateChange = new EventEmitter<Date>();
   @Output() dateSelect = new EventEmitter<Date>();
+  @Output() yearSelect = new EventEmitter<number>();
   @Input() timezone: 'local' | 'UTC';
   @Input() disableWeekends: boolean;
   @Input() disablePastDates: boolean;
@@ -29,8 +30,6 @@ export class MockCalendarComponent {
   @Input() todayDate: Date;
   @Input() minDate: Date;
   @Input() maxDate: Date;
-
-  changeYear() {}
 }
 
 // #endregion

--- a/libs/designsystem/testing-base/src/lib/components/mock.popover.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.popover.component.ts
@@ -14,9 +14,9 @@ import { HorizontalDirection, PopoverComponent } from '@kirbydesign/designsystem
   ],
 })
 export class MockPopoverComponent {
+  @Input() popout: HorizontalDirection;
   @Input() target: HTMLElement | ElementRef<HTMLElement>;
   @Output() willHide = new EventEmitter<void>();
-  @Input() popout: HorizontalDirection;
 }
 
 // #endregion


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes _no issue_. 

I went rogue on this one 🥷

## What is the new behavior?

The mocks for calendar, popover and button were out of date. 
I've just ran `npm run generate-mocks` to update them and committed the results.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

Nope 🙅‍♂️

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [ ] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [X] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [X] Request that the changes are code-reviewed 
- [ ] ~~Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


