### PR TITLE
Add new MockFitHeadingDirective

### DIFF
--- a/libs/designsystem/testing-base/src/lib/directives/mock.fit-heading.directive.ts
+++ b/libs/designsystem/testing-base/src/lib/directives/mock.fit-heading.directive.ts
@@ -1,0 +1,19 @@
+import { Directive, forwardRef, Input } from '@angular/core';
+
+import { FitHeadingConfig, FitHeadingDirective } from '@kirbydesign/designsystem';
+
+@Directive({
+  selector: `h1[kirbyFitHeading],
+             h2[kirbyFitHeading],
+             h3[kirbyFitHeading]`,
+  providers: [
+    {
+      provide: FitHeadingDirective,
+      useExisting: forwardRef(() => MockFitHeadingDirective),
+    },
+  ],
+})
+export class MockFitHeadingDirective {
+  // tslint:disable-next-line:no-input-rename
+  @Input('kirbyFitHeading') config?: FitHeadingConfig;
+}

--- a/libs/designsystem/testing-base/src/lib/mock-directives.ts
+++ b/libs/designsystem/testing-base/src/lib/mock-directives.ts
@@ -1,3 +1,4 @@
+import { MockFitHeadingDirective } from './directives/mock.fit-heading.directive';
 import { MockThemeColorDirective } from './directives/mock.theme-color.directive';
 
-export const MOCK_DIRECTIVES = [MockThemeColorDirective];
+export const MOCK_DIRECTIVES = [MockThemeColorDirective, MockFitHeadingDirective];


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #1642

## What is the new behavior?

A mock has been created and exposed for the fit heading directive. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

Nope 🙅‍♂️

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [ ] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [X] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [X] Request that the changes are code-reviewed 
- [ ] ~~Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


