### PR TITLE
Fix version bumping for new lib structure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,7 +64,7 @@ jobs:
           cd ../../ 
           echo $(jq --arg version "$NEW_VERSION" '.dependencies["@kirbydesign/core"]=$version' libs/designsystem/package.json) > libs/designsystem/package.json
           npx prettier --write libs/designsystem/package.json
-          git add libs/core/package.json libs/designsystem/package.json 
+          git add libs/core/package.json libs/core/package-lock.json libs/designsystem/package.json 
           GIT_MESSAGE=":bookmark:Bumping version to $NEW_VERSION (core)"
           git commit -m "$GIT_MESSAGE" 
       - name: Publish core package to npm

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kirbydesign/core",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Core web-components for the Kirby Design System.",
   "module": "dist/index.js",
   "main": "dist/index.cjs.js",

--- a/libs/designsystem/package.json
+++ b/libs/designsystem/package.json
@@ -5,7 +5,7 @@
     "chart.js": "3.3.2",
     "chartjs-plugin-annotation": "1.0.2",
     "@ionic/angular": "5.5.2",
-    "@kirbydesign/core": "0.0.8",
+    "@kirbydesign/core": "0.0.9",
     "date-fns": "2.21.1",
     "date-fns-tz": "1.1.4",
     "highcharts": "8.0.4",


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?

We did not add `package-lock.json` and thus npm publish complains that the git repo is not clean.
This fails in the CI environment and blocks new build of cookbook. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.
