### PR TITLE
Fix bug causing no animations to be played on first draw of the chart component

### DIFF
--- a/libs/designsystem/src/lib/components/chart/chart.component.spec.ts
+++ b/libs/designsystem/src/lib/components/chart/chart.component.spec.ts
@@ -1,3 +1,4 @@
+import { fakeAsync, tick } from '@angular/core/testing';
 import { createHostFactory, Spectator } from '@ngneat/spectator';
 import { MockProvider } from 'ng-mocks';
 
@@ -34,13 +35,14 @@ describe('ChartComponent', () => {
     });
   });
 
-  it('should render chart once after view init', () => {
+  it('should render chart once after view init', fakeAsync(() => {
     const renderChartSpy = spyOn<any>(component, 'renderChart');
 
     component.ngAfterViewInit();
+    tick();
 
     expect(renderChartSpy).toHaveBeenCalledTimes(1);
-  });
+  }));
 
   it("should be possible to set the height with the '--kirby-chart-height' CSS custom property", () => {
     const customHeight = '600px';

--- a/libs/designsystem/src/lib/components/chart/chart.component.ts
+++ b/libs/designsystem/src/lib/components/chart/chart.component.ts
@@ -11,6 +11,8 @@ import {
 import { ChartOptions } from 'chart.js';
 import { AnnotationOptions } from 'chartjs-plugin-annotation';
 
+import { ResizeObserverFactory, ResizeObserverService } from '../shared';
+
 import { ChartJSService } from './chart-js/chart-js.service';
 import { ChartDataset, ChartHighlightedElements, ChartType } from './chart.types';
 
@@ -40,7 +42,32 @@ export class ChartComponent implements AfterViewInit, OnChanges {
   constructor(private chartJSService: ChartJSService) {}
 
   ngAfterViewInit() {
-    this.renderChart();
+    /* 
+       A chart is not rendered until it has both a height and a width. 
+       If ChartComponent has an ionic component as ancestor it will 
+       not have any height or width on afterViewInit. This will cause 
+       the animation to not be played on first draw. 
+    */
+    const canvasElement = this.canvasElement.nativeElement;
+    this.whenElementHasHeightAndWidth(canvasElement).then(() => this.renderChart());
+  }
+
+  private whenElementHasHeightAndWidth(element: HTMLElement): Promise<void> {
+    const rectIs2D = ({ width, height }) => height > 0 && width > 0;
+
+    return new Promise((resolve) => {
+      const initialClientRect = element.getBoundingClientRect();
+      if (rectIs2D(initialClientRect)) resolve();
+
+      const resizeObserver = new ResizeObserverFactory().create(([resizeObserverEntry]) => {
+        if (rectIs2D(resizeObserverEntry.contentRect)) {
+          resizeObserver.unobserve(element);
+          resolve();
+        }
+      });
+
+      resizeObserver.observe(element);
+    });
   }
 
   ngOnChanges(simpleChanges: SimpleChanges) {

--- a/libs/designsystem/src/lib/components/chart/chart.component.ts
+++ b/libs/designsystem/src/lib/components/chart/chart.component.ts
@@ -44,7 +44,7 @@ export class ChartComponent implements AfterViewInit, OnChanges {
   ngAfterViewInit() {
     /* 
        A chart is not rendered until it has both a height and a width. 
-       If ChartComponent has an ionic component as ancestor it will 
+       If ChartComponent is slotted in an ionic component it will
        not have any height or width on afterViewInit. This will cause 
        the animation to not be played on first draw. 
     */


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #1880

## What is the new behavior?

The ChartComponent now waits for the canvas element to have a non-zero width and height before calling `renderChart`.

The bug stemmed from the canvas having no width or height when afterViewInit is called, when inside an ionic component. For example when slotted in a Kirby-page. 

This caused the chart to be rendered with no width and height but the initial animation still played (albeit not visibly). When the ionic elements then are hydrated and ready to go the canvas element is resized and the chart is visible. But no animation is played as it has already been played once when it had no width or height. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?
I've had a hard time testing this and I've added no test as of now. It is not possible to see if animations are in progress. 
Any suggestions for how to test this without the tests becoming too implementation specific would be appreciated.

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [X] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [X] Request that the changes are code-reviewed 
- [ ] ~~Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


