### PR TITLE
Make custom icon name usable in Segmented Control badge

### DIFF
--- a/libs/designsystem/src/lib/components/segmented-control/segment-item.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segment-item.ts
@@ -14,7 +14,7 @@ export interface SegmentItem {
    * @deprecated Will be removed in next major version. Use `selectedIndex` or `value` on `<kirby-segmented-control>` instead.
    */
   checked?: boolean;
-  badge?: Omit<SegmentItemBadge, 'isCustomIcon'>; // we do not expose the isCustom ...
+  badge?: Omit<SegmentItemBadge, 'isCustomIcon'>; // we do not expose the isCustomIcon for the external type
 }
 
 export interface SegmentItemInternal extends SegmentItem {

--- a/libs/designsystem/src/lib/components/segmented-control/segment-item.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segment-item.ts
@@ -1,5 +1,12 @@
 import { ThemeColor } from '@kirbydesign/core';
 
+type SegmentItemBadge = {
+  content?: string;
+  icon?: string;
+  isCustomIcon?: boolean;
+  description?: string;
+  themeColor: ThemeColor;
+};
 export interface SegmentItem {
   id: string;
   text: string;
@@ -7,10 +14,9 @@ export interface SegmentItem {
    * @deprecated Will be removed in next major version. Use `selectedIndex` or `value` on `<kirby-segmented-control>` instead.
    */
   checked?: boolean;
-  badge?: {
-    content?: string;
-    icon?: string;
-    description?: string;
-    themeColor: ThemeColor;
-  };
+  badge?: Omit<SegmentItemBadge, 'isCustomIcon'>; // we do not expose the isCustom ...
+}
+
+export interface SegmentItemInternal extends SegmentItem {
+  badge?: SegmentItemBadge;
 }

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
@@ -13,8 +13,13 @@
       [themeColor]="item.badge.themeColor"
     >
       <ng-container *ngIf="item.badge.icon; else badgeContent">
-        <kirby-icon *ngIf="!item.badge.isCustomIcon" [name]="item.badge.icon"></kirby-icon>
-        <kirby-icon *ngIf="item.badge.isCustomIcon" [customName]="item.badge.icon"></kirby-icon>
+        <kirby-icon
+          *ngIf="item.badge.isCustomIcon; else defaultIconName"
+          [customName]="item.badge.icon"
+        ></kirby-icon>
+        <ng-template #defaultIconName>
+          <kirby-icon [name]="item.badge.icon"></kirby-icon>
+        </ng-template>
       </ng-container>
       <ng-template #badgeContent>
         {{ item.badge.content }}

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
@@ -12,11 +12,10 @@
       [attr.aria-label]="item.badge.description"
       [themeColor]="item.badge.themeColor"
     >
-      <kirby-icon
-        *ngIf="item.badge.icon; else badgeContent"
-        [customName]="item.badge.icon"
-        [name]="item.badge.icon"
-      ></kirby-icon>
+      <ng-container *ngIf="item.badge.icon; else badgeContent">
+        <kirby-icon *ngIf="!item.badge.isCustomIcon" [name]="item.badge.icon"></kirby-icon>
+        <kirby-icon *ngIf="item.badge.isCustomIcon" [customName]="item.badge.icon"></kirby-icon>
+      </ng-container>
       <ng-template #badgeContent>
         {{ item.badge.content }}
       </ng-template>

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.spec.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.spec.ts
@@ -233,7 +233,6 @@ describe('SegmentedControl with Badge', () => {
       .componentInstance;
 
     expect(iconComponent.name).toBe(item.badge.icon);
-    expect(iconComponent.customName).toBe(item.badge.icon);
   });
 
   it('should render badge with icon if both icon and content is provided', () => {

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, HostBinding, Input, Output } from '@angular/core';
 
-import { IconRegistryService } from '../icon';
+import { IconRegistryService } from '../icon/icon-registry.service';
 
 import { SegmentItem, SegmentItemInternal } from './segment-item';
 

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
@@ -1,6 +1,8 @@
 import { Component, EventEmitter, HostBinding, Input, Output } from '@angular/core';
 
-import { SegmentItem } from './segment-item';
+import { IconRegistryService } from '../icon';
+
+import { SegmentItem, SegmentItemInternal } from './segment-item';
 
 export enum SegmentedControlMode {
   chip = 'chip',
@@ -16,6 +18,8 @@ export enum SegmentedControlMode {
   host: { role: 'group' },
 })
 export class SegmentedControlComponent {
+  constructor(private iconRegistryService: IconRegistryService) {}
+
   preventWrapperClick(event: Event) {
     if (event.target instanceof HTMLElement) {
       if (event.target.classList.contains('segment-btn-wrapper')) {
@@ -35,13 +39,20 @@ export class SegmentedControlComponent {
     }[this.mode];
   }
 
-  private _items: SegmentItem[] = [];
+  private _items: SegmentItemInternal[] = [];
   get items(): SegmentItem[] {
     return this._items;
   }
 
   @Input() set items(value: SegmentItem[]) {
     this._items = value || [];
+    this._items.forEach((item) => {
+      // We need to verify whether badges icon is custom or default, so we can check for it in the template
+      if (item.badge?.icon && this.iconRegistryService.getIcon(item.badge.icon)) {
+        item.badge.isCustomIcon = true;
+      }
+    });
+
     const checkedItemIndex = this.items.findIndex((item) => item.checked);
     if (checkedItemIndex > -1) {
       console.warn(

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
@@ -48,7 +48,10 @@ export class SegmentedControlComponent {
     this._items = value || [];
     this._items.forEach((item) => {
       // We need to verify whether badges icon is custom or default, so we can check for it in the template
-      if (item.badge?.icon && this.iconRegistryService.getIcon(item.badge.icon)) {
+      if (
+        item.badge?.icon !== undefined &&
+        this.iconRegistryService.getIcon(item.badge.icon) !== undefined
+      ) {
         item.badge.isCustomIcon = true;
       }
     });

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
@@ -48,12 +48,9 @@ export class SegmentedControlComponent {
     this._items = value || [];
     this._items.forEach((item) => {
       // We need to verify whether badges icon is custom or default, so we can check for it in the template
-      if (
+      item.badge.isCustomIcon =
         item.badge?.icon !== undefined &&
-        this.iconRegistryService.getIcon(item.badge.icon) !== undefined
-      ) {
-        item.badge.isCustomIcon = true;
-      }
+        this.iconRegistryService.getIcon(item.badge.icon) !== undefined;
     });
 
     const checkedItemIndex = this.items.findIndex((item) => item.checked);

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
@@ -47,9 +47,10 @@ export class SegmentedControlComponent {
   @Input() set items(value: SegmentItem[]) {
     this._items = value || [];
     this._items.forEach((item) => {
+      if (item.badge === undefined) return;
       // We need to verify whether badges icon is custom or default, so we can check for it in the template
       item.badge.isCustomIcon =
-        item.badge?.icon !== undefined &&
+        item.badge.icon !== undefined &&
         this.iconRegistryService.getIcon(item.badge.icon) !== undefined;
     });
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #1890
## What is the new behavior?
It is now possible to specify an icon with a custom name for the Segmented Control badge. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


