### PR TITLE
Adjust position for small badge in tabs

### DIFF
--- a/libs/designsystem/src/lib/components/tabs/tab-button/tab-button.component.scss
+++ b/libs/designsystem/src/lib/components/tabs/tab-button/tab-button.component.scss
@@ -9,8 +9,19 @@ ion-tab-button {
   --color-selected: get-color('black');
 
   --kirby-badge-position: absolute;
-  --kirby-badge-left: calc(50% + 5px);
   --kirby-badge-top: 0;
+  --kirby-badge-right: 0;
+
+  @include slotted(div kirby-badge) {
+    &.md {
+      --kirby-badge-top: -5px;
+      --kirby-badge-right: -5px;
+    }
+  }
+
+  .icon-container {
+    position: relative;
+  }
 
   @include media('>=medium') {
     flex: none;
@@ -24,12 +35,7 @@ ion-tab-button {
     font-size: font-size('s');
     flex-direction: row;
 
-    --kirby-badge-top: -5px;
-    --kirby-badge-left: auto;
-    --kirby-badge-right: -5px;
-
     .icon-container {
-      position: relative;
       margin-right: size('xxs');
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?
This PR closes #1892 

## What is the new behavior?
The small badge should be positioned differently from the medium size badge in the Tabs component, and now it is 🎉 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] ~~Request that the changes are [UX reviewed] (https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


