### PR TITLE
Fix error when badge is null in Segmented Control

### DIFF
--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
@@ -47,7 +47,7 @@ export class SegmentedControlComponent {
   @Input() set items(value: SegmentItem[]) {
     this._items = value || [];
     this._items.forEach((item) => {
-      if (item.badge === undefined) return;
+      if (!item.badge) return;
       // We need to verify whether badges icon is custom or default, so we can check for it in the template
       item.badge.isCustomIcon =
         item.badge.icon !== undefined &&


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue. It is a quickfix.

## What is the new behavior?
Segmented Item badge set to `null` would throw an error. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


