### PR TITLE
Bugfix: Feedback on re-order list with OnPush-detection

### DIFF
--- a/libs/designsystem/src/lib/components/reorder-list/reorder-list.component.ts
+++ b/libs/designsystem/src/lib/components/reorder-list/reorder-list.component.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectorRef,
   Component,
   ContentChild,
   ElementRef,
@@ -13,6 +14,7 @@ import {
 } from '@angular/core';
 
 import { ListItemTemplateDirective } from '../list/list.directive';
+
 import { ReorderEvent } from './reorder-event';
 
 @Component({
@@ -36,6 +38,8 @@ export class ReorderListComponent implements OnChanges, OnDestroy {
   private observer: MutationObserver;
   reorderActive: boolean = false;
 
+  constructor(private cdr: ChangeDetectorRef) {}
+
   ngOnChanges(): void {
     if (this.items && this.items.length > 0) {
       setTimeout(() => {
@@ -51,6 +55,7 @@ export class ReorderListComponent implements OnChanges, OnDestroy {
           this.reorderActive = mutation.target['className'].includes('reorder-list-active');
         }
       }
+      this.cdr.detectChanges();
     };
     this.observer = new MutationObserver(callback);
 


### PR DESCRIPTION
## Which issue does this PR close?

Oh crap, do I need to create one?

## What is the new behavior?

This fixes a bug, that the "feedback" layer of a Re-order list appears "too late" (and then doesn't disappear) when Component (containing re-order list) is configured with change-detection being `ChangeDetection.OnPush`. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

To test this, replace the contents of: `apps/cookbook/src/app/examples/modal-example/modal-route-example/modal-route-page1-example.component.ts` with the following code:
```typescript
import { ChangeDetectionStrategy, Component } from '@angular/core';
import { ActivatedRoute } from '@angular/router';
import { ReorderEvent } from '@kirbydesign/designsystem';

@Component({
  selector: 'cookbook-modal-route-page-1-example',
  template: `
    <kirby-page-title>Modal Page 1/2</kirby-page-title>
    <kirby-reorder-list
      (itemReorder)="doReorderItem($event)"
      (subItemReorder)="doReorderShadowAccount($event)"
      subItemsName="shadowAccounts"
      [items]="items"
    >
      <kirby-item
        *kirbyListItemTemplate="let reorderItem; let isSubItem = isSubItem"
        reorderable="true"
      >
        <kirby-label>
          <h3 [ngClass]="{ 'kirby-text-bold': !isSubItem }">{{ reorderItem.title }}</h3>
          <p *ngIf="!reorderItem.isOwnAccount" detail>{{ reorderItem.ownerName }}</p>
        </kirby-label>
        <kirby-toggle slot="end" checked="true"></kirby-toggle>
      </kirby-item>
    </kirby-reorder-list>
    <kirby-modal-footer *ngIf="showFooter">
      <button kirby-button class="nav" routerLink="../page2">
        Next
        <kirby-icon name="arrow-more"></kirby-icon>
      </button>
    </kirby-modal-footer>
  `,
  styles: [
    'kirby-modal-footer { --kirby-modal-footer-justify-content: flex-end; }',
    'h4 { margin-top: 24px; } ',
  ],
  changeDetection: ChangeDetectionStrategy.OnPush
})
export class ModalRoutePage1ExampleComponent {
  showFooter: boolean = true;
  queryParams$ = this.route.queryParams;

  constructor(private route: ActivatedRoute) {}

  toggleFooter() {
    this.showFooter = !this.showFooter;
  }

  items: any[] = [
    {
      title: '1',
      ownerName: 'xyz',
      isOwnAccount: false,
      shadowAccounts: [
        {
          title: '1a',
        },
        {
          title: '1b',
        },
        {
          title: '1c',
        },
        {
          title: '1d',
        },
        {
          title: '1e',
        },
        {
          title: '1f',
        },
      ],
    },
    {
      title: '2',
    },
    {
      title: '3',
    },
    {
      title: '4',
      ownerName: 'John',
      isOwnAccount: true,
      shadowAccounts: [
        {
          title: '4a',
        },
      ],
    },
    {
      title: '5',
      isOwnAccount: true,
      shadowAccounts: [
        {
          title: '5a',
        },
      ],
    },
  ];
  headerTexts = ['skjul/vis', 'flyt'];

  doReorderItem(ev: ReorderEvent) {
    ev.complete(this.items);
  }

  doReorderShadowAccount(ev: ReorderEvent) {
    ev.complete(ev.parentItem.shadowAccounts);
  }
}

```

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

(I'm not sure it makes sense to create an example identical to that of re-order list, where change detection is set to `OnPush`? - nor am I sure how I would create a unit test for this?)

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


