### PR TITLE
Fix calendar buttons being blue in Safari on iOS 15

### DIFF
--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -50,6 +50,7 @@ td {
     background-color: transparent;
     outline: none;
     border: none;
+    color: unset;
     cursor: pointer;
     height: size('xl');
     width: size('xl');

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -50,7 +50,7 @@ td {
     background-color: transparent;
     outline: none;
     border: none;
-    color: unset;
+    color: inherit;
     cursor: pointer;
     height: size('xl');
     width: size('xl');


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #1914

## What is the new behavior?

We're unsetting the color on button in order to remove the one provided as default by safari. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [ ] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [X] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [X] Request that the changes are code-reviewed 
- [ ]~~Request that the changes are [UX reviewed]~~(https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


