### PR TITLE
Fix wrong docs for font size in medium text

### DIFF
--- a/apps/cookbook/src/app/showcase/fonts-showcase/fonts-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/fonts-showcase/fonts-showcase.component.html
@@ -48,7 +48,7 @@
 
     <h3 class="sample-header-3 kirby-text-medium">h3 - Heading 3</h3>
     <div class="info-box">
-      <code>font-size: font-size("n");</code>
+      <code>font-size: font-size("m");</code>
       <code>font-weight: font-weight("bold");</code>
       <code class="highlight">CLASS: h3 or kirby-text-medium</code>
     </div>


### PR DESCRIPTION
## Which issue does this PR close?

No issue for this smol fix!

## What is the new behavior?
I corrected the documentation for the font size that is applied when using h3/kirby-text-medium class.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


