### PR TITLE
Automatic migration away from slash as division

### DIFF
--- a/apps/cookbook/src/app/examples/checkbox-radio-sizes-example.scss
+++ b/apps/cookbook/src/app/examples/checkbox-radio-sizes-example.scss
@@ -42,7 +42,7 @@ kirby-radio::after {
   font-size: utils.font-size('xs');
   color: utils.get-color('danger');
   padding-right: utils.size('xxs');
-  margin-right: utils.size('xxs') / 2;
+  margin-right: utils.size('xxs') * 0.5;
   vertical-align: center;
 }
 

--- a/apps/cookbook/src/app/examples/grid-layout-example/grid-layout-extended-example/grid-layout-extended-example.component.scss
+++ b/apps/cookbook/src/app/examples/grid-layout-example/grid-layout-extended-example/grid-layout-extended-example.component.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @use '~@kirbydesign/core/src/scss/utils';
 
 /* Configure grid properties */
@@ -19,18 +21,18 @@ $gap: utils.size('m');
 /* Tablet size and above */
 @include utils.media('>=medium') {
   .half-at-tablet-up {
-    grid-column: span ($columns / 2);
+    grid-column: span ($columns * 0.5);
   }
 }
 
 /* Desktop size and above */
 @include utils.media('>=large') {
   .half-at-desktop-up {
-    grid-column: span ($columns / 2);
+    grid-column: span ($columns * 0.5);
   }
 
   .third-at-desktop-up {
-    grid-column: span ($columns / 3);
+    grid-column: span math.div($columns, 3);
   }
 }
 

--- a/apps/cookbook/src/app/examples/grid-layout-example/grid-layout-multiple-containers-example/grid-layout-multiple-containers-example.component.scss
+++ b/apps/cookbook/src/app/examples/grid-layout-example/grid-layout-multiple-containers-example/grid-layout-multiple-containers-example.component.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @use '~@kirbydesign/core/src/scss/utils';
 
 /* Configure grid properties */
@@ -19,18 +21,18 @@ $gap: utils.size('m');
 /* Tablet size and above */
 @include utils.media('>=medium') {
   .half-at-tablet-up {
-    grid-column: span ($columns / 2);
+    grid-column: span ($columns * 0.5);
   }
 }
 
 /* Desktop size and above */
 @include utils.media('>=large') {
   .half-at-desktop-up {
-    grid-column: span ($columns / 2);
+    grid-column: span ($columns * 0.5);
   }
 
   .third-at-desktop-up {
-    grid-column: span ($columns / 3);
+    grid-column: span math.div($columns, 3);
   }
 }
 

--- a/apps/cookbook/src/app/examples/grid-layout-example/grid-layout-single-container-example/grid-layout-single-container-example.component.scss
+++ b/apps/cookbook/src/app/examples/grid-layout-example/grid-layout-single-container-example/grid-layout-single-container-example.component.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @use '~@kirbydesign/core/src/scss/utils';
 
 /* Configure grid properties */
@@ -19,18 +21,18 @@ $gap: utils.size('m');
 /* Tablet size and above */
 @include utils.media('>=medium') {
   .half-at-tablet-up {
-    grid-column: span ($columns / 2);
+    grid-column: span ($columns * 0.5);
   }
 }
 
 /* Desktop size and above */
 @include utils.media('>=large') {
   .half-at-desktop-up {
-    grid-column: span ($columns / 2);
+    grid-column: span ($columns * 0.5);
   }
 
   .third-at-desktop-up {
-    grid-column: span ($columns / 3);
+    grid-column: span math.div($columns, 3);
   }
 }
 

--- a/libs/designsystem/src/lib/components/avatar/avatar.component.scss
+++ b/libs/designsystem/src/lib/components/avatar/avatar.component.scss
@@ -10,10 +10,10 @@ $badge-diameter: utils.$avatar-badge-size;
 
 @function get-badge-position($avatar-diameter) {
   $cos-to-45-degrees: 0.70710678118;
-  $avatar-radius: $avatar-diameter / 2;
+  $avatar-radius: $avatar-diameter * 0.5;
   $position-from-center: math.round($cos-to-45-degrees * $avatar-radius);
   $position-from-edge: $avatar-radius - $position-from-center;
-  $badge-radius: $badge-diameter / 2;
+  $badge-radius: $badge-diameter * 0.5;
   $badge-position: $position-from-edge - $badge-radius;
   @return $badge-position;
 }

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -92,7 +92,7 @@ td {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: $dayWidth / 2;
+  border-radius: $dayWidth * 0.5;
   width: $dayWidth;
   height: $dayWidth;
   margin: utils.size('xxxs') 0;

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
@@ -8,7 +8,7 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
 $default-checkbox-radio-size: map.get(utils.$checkbox-radio-sizes, 'md');
 
 @function getVerticalPadding($target-height) {
-  @return ($target-height - $checkbox-icon-size) / 2;
+  @return ($target-height - $checkbox-icon-size) * 0.5;
 }
 
 :host {

--- a/libs/designsystem/src/lib/components/radio/radio.component.scss
+++ b/libs/designsystem/src/lib/components/radio/radio.component.scss
@@ -9,7 +9,7 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
 $default-checkbox-radio-size: map.get(utils.$checkbox-radio-sizes, 'md');
 
 @function getVerticalPadding($target-height) {
-  @return ($target-height - $radio-icon-size) / 2;
+  @return ($target-height - $radio-icon-size) * 0.5;
 }
 
 :host {

--- a/libs/designsystem/src/lib/components/range/range.component.scss
+++ b/libs/designsystem/src/lib/components/range/range.component.scss
@@ -38,7 +38,7 @@ ion-range {
   padding: 0;
 
   &.range-has-pin {
-    padding: 0 $tickWidth / 2;
+    padding: 0 $tickWidth * 0.5;
   }
 
   &::part(pin) {
@@ -68,7 +68,7 @@ ion-range {
     width: $tickWidth;
     height: $tickHeight;
     z-index: 1;
-    margin-inline-start: -$tickWidth / 2;
+    margin-inline-start: -$tickWidth * 0.5;
   }
 
   &::part(tick) {

--- a/libs/designsystem/src/lib/components/slide-button/slide-button.component.scss
+++ b/libs/designsystem/src/lib/components/slide-button/slide-button.component.scss
@@ -40,7 +40,7 @@
   @for $i from 1 through 10 {
     $iTenth: $i * 10;
     .slide-#{$iTenth}-pct {
-      opacity: 1- ($i/10);
+      opacity: 1- ($i * 0.1);
     }
   }
 

--- a/libs/designsystem/src/lib/components/slide-button/slide-button.component.shared.scss
+++ b/libs/designsystem/src/lib/components/slide-button/slide-button.component.shared.scss
@@ -8,5 +8,5 @@ $slide-button-container-bg-color: utils.get-color('primary');
 $slider-thumb-bg-color: utils.get-color('white');
 $slide-button-text-color: utils.get-color('primary-contrast');
 $total-slider-thumb-width: $slide-button-width + $slide-button-spacing * 2;
-$slide-button-container-radius: $slide-button-width/2;
+$slide-button-container-radius: $slide-button-width * 0.5;
 $slide-button-text-padding: 0 $slide-button-container-radius 0 $total-slider-thumb-width;


### PR DESCRIPTION
## Which issue does this PR close?

This PR is the last part of #1798, which removes some deprecation warnings.

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->
Now the Sass compiler won't print out deprecation warnings.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


