### PR TITLE
Fix Sass module configuration failure in relationsbanken

### DIFF
--- a/libs/designsystem/src/lib/scss/_utils.scss
+++ b/libs/designsystem/src/lib/scss/_utils.scss
@@ -1,0 +1,1 @@
+@forward '~@kirbydesign/core/scss/utils';

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -118,6 +118,14 @@ function copyScssFiles() {
   return fs.copy(`${coreLibDir}/scss`, `${distTarget}/scss`, { filter: onlyScssFiles });
 }
 
+function copyScssUtilsFile() {
+  console.log('Copying SCSS utils file...');
+  const onlyScssFiles = (input) => ['', '.scss'].includes(path.extname(input));
+  return fs.copy(`${angularLibDir}/scss/_utils.scss`, `${distTarget}/scss/_utils.scss`, {
+    filter: onlyScssFiles,
+  });
+}
+
 function copyIcons() {
   console.log('Copying Icons...');
   const onlySvgFiles = (input) => ['', '.svg'].includes(path.extname(input));
@@ -136,7 +144,7 @@ function copyPolyfills() {
 function createTarballPackage() {
   return npm(['pack', distTarget], {
     onFailMessage: 'Unable to create gzipped tar-ball package',
-  })
+  });
 }
 
 function publish() {
@@ -152,17 +160,17 @@ function publish() {
   } else {
     // Create a GZipped Tarball
     console.log('Running on non-CI, hence creating a gzipped tar-ball');
-    
+
     // Make sure any local core changes (proxies etc.) are included in the local .tgz package
     // For CI, we build and publish this package separately.
     npm(['run', 'build:core'], {
       onFailMessage: 'Unable to build core package (stencil compiler)',
-    }).then(createTarballPackage)
+    })
+      .then(createTarballPackage)
       .then(() => fs.promises.readdir('.'))
       .then(findTarball)
       .then((filename) => fs.move(filename, `${dist}/${filename}`, { overwrite: true }));
   }
-  
 }
 
 // Actual execution of script!
@@ -172,6 +180,7 @@ cleanDistribution()
   .then(enhancePackageJson)
   .then(copyReadme)
   .then(copyScssFiles)
+  .then(copyScssUtilsFile)
   .then(copyIcons)
   .then(copyPolyfills)
   .then(publish)


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #1936 

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

Forward Sass module utils instead of copying file from `core` to `designsystem`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


