### PR TITLE
Do not apply outline to clickable card on touch devices

### DIFF
--- a/libs/designsystem/src/lib/components/card/card.component.scss
+++ b/libs/designsystem/src/lib/components/card/card.component.scss
@@ -34,7 +34,9 @@
 
   &[role='button'] {
     cursor: pointer;
-    outline-offset: utils.size('xxxxs');
+    @include utils.not-touch {
+      outline-offset: utils.size('xxxxs');
+    }
   }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #1944

## What is the new behavior?
Touch-devices (iOS specifically) should no longer show focus outline on a clickable card.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


