### PR TITLE
🐛 Should not run when PR merged (no changes to libs/)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,17 @@
 name: Publish new version to npm - trigger on push to master (all changes)
 
 on:
-  push:
-    branches:
-      - experiment/1947-fix-publish-workflow-target
-    # paths:
-    #   - libs/**
+  pull_request:
+    types: closed
+    branches: experiment/1947-fix-publish-workflow-target
+    # paths: 'libs/**'
+
+# on:
+#   push:
+#     branches:
+#       - experiment/1947-fix-publish-workflow-target
+#     # paths:
+#     #   - libs/**
 
 defaults:
   run:
@@ -19,7 +25,7 @@ jobs:
     steps:
       - name: Echo something
         run: |
-          echo 'hello world'
+          echo 'replicate bug'
       # - name: Checkout repo
       #   uses: actions/checkout@v2
       #   with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Test do not run when it should not
+name: Should run when push to target branch (merge PR)
 
 on:
   push:
@@ -17,9 +17,9 @@ jobs:
     name: Bump version and publish changed packages
     runs-on: ubuntu-latest
     steps:
-      - name: Do not run this when PR is closed without merge
+      - name: Should run when PR is merged
         run: |
-          echo 'Do not run this when PR is closed without merge'
+          echo 'Should run when PR is merged'
       # - name: Checkout repo
       #   uses: actions/checkout@v2
       #   with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,11 @@
-name: Publish new version to npm
+name: Publish new version to npm - trigger on push to master (all changes)
 
 on:
-  pull_request:
-    types: closed
-    branches: master
-    paths: 'libs/**'
+  push:
+    branches:
+      - experiment/1947-fix-publish-workflow-target
+    # paths:
+    #   - libs/**
 
 defaults:
   run:
@@ -16,51 +17,54 @@ jobs:
     name: Bump version and publish changed packages
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-        with:
-          token: ${{secrets.VERSION_BUMP_GITHUB_TOKEN}}
-      - name: Kirby setup
-        uses: ./.github/actions/kirby-setup
-      - name: Configure git
+      - name: Echo something
         run: |
-          git config user.name "Kirby Bot"
-          git config user.email "<>"
-      - name: Check if core has been modified
-        id: modified-files
-        uses: dorny/paths-filter@v2.9.2
-        with:
-          filters: |
-            core:
-              - 'libs/core/**'
-      - name: Create npm config
-        if: steps.modified-files.outputs.core == 'true'
-        run: |
-          cd libs/core 
-          echo '//registry.npmjs.org/:_authToken=${{secrets.NPM_PUBLISH_TOKEN}}' > ~/.npmrc
-      - name: Version bump core and update core dependency version in designsystem
-        id: bump-core
-        if: steps.modified-files.outputs.core == 'true'
-        run: | # For explanation: https://github.com/kirbydesign/designsystem/pull/1722#issuecomment-928181479
-          cd libs/core
-          NEW_VERSION=$(npm version patch | cut -d v -f2) 
-          cd ../../ 
-          echo $(jq --arg version "$NEW_VERSION" '.dependencies["@kirbydesign/core"]=$version' libs/designsystem/package.json) > libs/designsystem/package.json
-          npx prettier --write libs/designsystem/package.json
-          git add libs/core/package.json libs/core/package-lock.json libs/designsystem/package.json 
-          GIT_MESSAGE=":bookmark:Bumping version to $NEW_VERSION (core)"
-          git commit -m "$GIT_MESSAGE"
-      - name: Publish core package to npm
-        if: steps.modified-files.outputs.core == 'true'
-        run: |
-          npm run build:core
-          cd libs/core
-          npm publish --access public
-      - name: Create npm config
-        run: echo '//registry.npmjs.org/:_authToken=${{secrets.NPM_PUBLISH_TOKEN}}' > ~/.npmrc
-      - name: Bump designsystem package
-        run: npm version patch -m ":bookmark:Bumping version to %s (designsystem)"
-      - name: Build designsystem package and publish to npm
-        run: npm run publish
-      - name: Push version bump(s) and tag to Github
-        run: git push --follow-tags
+          echo 'hello world'
+      # - name: Checkout repo
+      #   uses: actions/checkout@v2
+      #   with:
+      #     token: ${{secrets.VERSION_BUMP_GITHUB_TOKEN}}
+      # - name: Kirby setup
+      #   uses: ./.github/actions/kirby-setup
+      # - name: Configure git
+      #   run: |
+      #     git config user.name "Kirby Bot"
+      #     git config user.email "<>"
+      # - name: Check if core has been modified
+      #   id: modified-files
+      #   uses: dorny/paths-filter@v2.9.2
+      #   with:
+      #     filters: |
+      #       core:
+      #         - 'libs/core/**'
+      # - name: Create npm config
+      #   if: steps.modified-files.outputs.core == 'true'
+      #   run: |
+      #     cd libs/core 
+      #     echo '//registry.npmjs.org/:_authToken=${{secrets.NPM_PUBLISH_TOKEN}}' > ~/.npmrc
+      # - name: Version bump core and update core dependency version in designsystem
+      #   id: bump-core
+      #   if: steps.modified-files.outputs.core == 'true'
+      #   run: | # For explanation: https://github.com/kirbydesign/designsystem/pull/1722#issuecomment-928181479
+      #     cd libs/core
+      #     NEW_VERSION=$(npm version patch | cut -d v -f2) 
+      #     cd ../../ 
+      #     echo $(jq --arg version "$NEW_VERSION" '.dependencies["@kirbydesign/core"]=$version' libs/designsystem/package.json) > libs/designsystem/package.json
+      #     npx prettier --write libs/designsystem/package.json
+      #     git add libs/core/package.json libs/core/package-lock.json libs/designsystem/package.json 
+      #     GIT_MESSAGE=":bookmark:Bumping version to $NEW_VERSION (core)"
+      #     git commit -m "$GIT_MESSAGE"
+      # - name: Publish core package to npm
+      #   if: steps.modified-files.outputs.core == 'true'
+      #   run: |
+      #     npm run build:core
+      #     cd libs/core
+      #     npm publish --access public
+      # - name: Create npm config
+      #   run: echo '//registry.npmjs.org/:_authToken=${{secrets.NPM_PUBLISH_TOKEN}}' > ~/.npmrc
+      # - name: Bump designsystem package
+      #   run: npm version patch -m ":bookmark:Bumping version to %s (designsystem)"
+      # - name: Build designsystem package and publish to npm
+      #   run: npm run publish
+      # - name: Push version bump(s) and tag to Github
+      #   run: git push --follow-tags

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,11 @@
-name: Should run when push to target branch (merge PR)
+name: Should not run when PR merged (no changes to libs/)
 
 on:
   push:
     branches:
       - experiment/1947-fix-publish-workflow-target
-#     # paths:
-#     #   - libs/**
+    paths:
+      - libs/**
 
 defaults:
   run:
@@ -17,9 +17,9 @@ jobs:
     name: Bump version and publish changed packages
     runs-on: ubuntu-latest
     steps:
-      - name: Should run when PR is merged
+      - name: Should not run when PR merged (no changes to libs/)
         run: |
-          echo 'Should run when PR is merged'
+          echo 'Should not run when PR merged (no changes to libs/)'
       # - name: Checkout repo
       #   uses: actions/checkout@v2
       #   with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,9 @@
-name: Publish new version to npm - trigger on push to master (all changes)
+name: Test do not run when it should not
 
 on:
-  pull_request:
-    types: closed
-    branches: experiment/1947-fix-publish-workflow-target
-    # paths: 'libs/**'
-
-# on:
-#   push:
-#     branches:
-#       - experiment/1947-fix-publish-workflow-target
+  push:
+    branches:
+      - experiment/1947-fix-publish-workflow-target
 #     # paths:
 #     #   - libs/**
 
@@ -23,9 +17,9 @@ jobs:
     name: Bump version and publish changed packages
     runs-on: ubuntu-latest
     steps:
-      - name: Echo something
+      - name: Do not run this when PR is closed without merge
         run: |
-          echo 'replicate bug'
+          echo 'Do not run this when PR is closed without merge'
       # - name: Checkout repo
       #   uses: actions/checkout@v2
       #   with:


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes # (insert issue number here)

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


