### PR TITLE
Remove 'danger' messageType from cookbook API description

### DIFF
--- a/apps/cookbook/src/app/showcase/toast-showcase/toast-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/toast-showcase/toast-showcase.component.ts
@@ -18,9 +18,9 @@ export class ToastShowcaseComponent {
     {
       name: 'messageType',
       description:
-        'Message type defines which color the toast will have. There are three different toast types: success (green), warning (yellow), danger (red).',
+        "Message type defines which color the toast will have. There are two different toast types: 'success' (green) and 'warning' (yellow)",
       defaultValue: 'success',
-      type: ['success', 'warning', 'danger'],
+      type: ['success', 'warning'],
     },
     {
       name: 'durationInMs',


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue. 

## What is the new behavior?

The `danger` messageType for the toast has been deprecated: #1499 
But the original PR forgot to remove it from the documentation - hence this PR. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->
## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [X] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [X] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [X] Request that the changes are code-reviewed 
- [ ] ~~Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


