### PR TITLE
🐛 BUGFIX: Prevent Kirby Dropdown from submitting form

### DIFF
--- a/libs/designsystem/src/lib/components/dropdown/dropdown.component.html
+++ b/libs/designsystem/src/lib/components/dropdown/dropdown.component.html
@@ -6,6 +6,7 @@
   (click)="onToggle($event)"
   (mousedown)="onButtonMouseEvent($event)"
   [disabled]="disabled"
+  type="button"
 >
   <span class="text">{{ selectedText || placeholder }}</span>
   <kirby-icon [name]="isOpen ? 'arrow-up' : 'arrow-down'"></kirby-icon>

--- a/libs/designsystem/src/lib/components/dropdown/dropdown.component.spec.ts
+++ b/libs/designsystem/src/lib/components/dropdown/dropdown.component.spec.ts
@@ -128,6 +128,11 @@ describe('DropdownComponent', () => {
       expect(spectator.element).toBeFocused();
     });
 
+    // Fixes https://github.com/kirbydesign/designsystem/issues/1987
+    it('should have type="button" attribute', () => {
+      expect(buttonElement).toHaveAttribute('type', 'button');
+    });
+
     describe('when setting selected index', () => {
       let onChangeSpy: jasmine.Spy;
       const newSelectedIndex = 2;
@@ -1205,37 +1210,6 @@ describe('DropdownComponent', () => {
         expect(spectator.component['itemClickUnlisten']).toHaveLength(0);
         expect(unlistenCounter).toEqual(unlistenMockArrayLength);
       });
-    });
-  });
-
-  describe('when inside form', () => {
-    let spectator: SpectatorHost<DropdownComponent>;
-    let buttonElement: HTMLButtonElement;
-
-    const createHost = createHostFactory({
-      component: DropdownComponent,
-      declarations: [
-        MockComponents(
-          ButtonComponent,
-          CardComponent,
-          IconComponent,
-          ItemComponent,
-          PopoverComponent
-        ),
-      ],
-    });
-
-    beforeEach(() => {
-      spectator = createHost(`<kirby-dropdown></kirby-dropdown>`, {
-        props: {
-          items: items,
-        },
-      });
-      buttonElement = spectator.queryHost('button[kirby-button]');
-    });
-
-    it('should have type="button" attribute', () => {
-      expect(buttonElement).toHaveAttribute('type', 'button');
     });
   });
 });

--- a/libs/designsystem/src/lib/components/dropdown/dropdown.component.spec.ts
+++ b/libs/designsystem/src/lib/components/dropdown/dropdown.component.spec.ts
@@ -1207,4 +1207,35 @@ describe('DropdownComponent', () => {
       });
     });
   });
+
+  describe('when inside form', () => {
+    let spectator: SpectatorHost<DropdownComponent>;
+    let buttonElement: HTMLButtonElement;
+
+    const createHost = createHostFactory({
+      component: DropdownComponent,
+      declarations: [
+        MockComponents(
+          ButtonComponent,
+          CardComponent,
+          IconComponent,
+          ItemComponent,
+          PopoverComponent
+        ),
+      ],
+    });
+
+    beforeEach(() => {
+      spectator = createHost(`<kirby-dropdown></kirby-dropdown>`, {
+        props: {
+          items: items,
+        },
+      });
+      buttonElement = spectator.queryHost('button[kirby-button]');
+    });
+
+    it('should have type="button" attribute', () => {
+      expect(buttonElement).toHaveAttribute('type', 'button');
+    });
+  });
 });


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #1987 

## What is the new behavior?

Click on `<kirby-dropdown>` button will no longer submit form containing the dropdown.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] ~~Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


