### PR TITLE
Fixed wrong cancel-button color on action-sheet

### DIFF
--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -220,7 +220,8 @@ $button-width: (
   --kirby-button-color: #{utils.get-color('success-contrast')};
 }
 
-:host-context(kirby-dropdown) {
+:host-context(kirby-dropdown),
+:host-context(kirby-action-sheet) {
   &.attention-level2 {
     --kirby-button-background-color: #{utils.get-color('white')};
     --kirby-button-color: #{utils.get-color('white-contrast')};

--- a/libs/designsystem/src/lib/components/modal/action-sheet/action-sheet.component.spec.ts
+++ b/libs/designsystem/src/lib/components/modal/action-sheet/action-sheet.component.spec.ts
@@ -5,6 +5,7 @@ import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/t
 import * as ionic from '@ionic/angular';
 import { MockComponent } from 'ng-mocks';
 
+import { DesignTokenHelper } from '../../..';
 import { ButtonComponent } from '../../button/button.component';
 import { CardHeaderComponent } from '../../card/card-header/card-header.component';
 import { CardComponent } from '../../card/card.component';
@@ -15,6 +16,8 @@ import { GroupByPipe } from '../../list/pipes/group-by.pipe';
 import { SpinnerComponent } from '../../spinner/spinner.component';
 
 import { ActionSheetComponent } from './action-sheet.component';
+
+const getColor = DesignTokenHelper.getColor;
 
 describe('ActionSheetComponent', () => {
   let component: ActionSheetComponent;
@@ -150,6 +153,22 @@ describe('ActionSheetComponent', () => {
       const cancelButton = fixture.debugElement.query(By.css('.cancel-btn'));
       expect(component.cancelButtonText).toEqual(expected);
       expect(cancelButton.nativeElement.innerText).toEqual(expected);
+    });
+  });
+
+  describe('cancel button color', () => {
+    it('should render with correct color', () => {
+      const cancelButton = fixture.debugElement.query(By.css('.cancel-btn'));
+      const element = cancelButton.nativeElement as HTMLElement;
+      expect(element).toHaveComputedStyle({
+        'border-width': '1px',
+        'border-style': 'solid',
+        'border-color': 'transparent',
+        'background-color': getColor('white', 'contrast'),
+        /* prettier-ignore */
+        // tslint:disable-next-line: prettier
+        'color': getColor('white')
+      });
     });
   });
 });

--- a/libs/designsystem/src/lib/components/modal/action-sheet/action-sheet.component.spec.ts
+++ b/libs/designsystem/src/lib/components/modal/action-sheet/action-sheet.component.spec.ts
@@ -166,7 +166,6 @@ describe('ActionSheetComponent', () => {
         'border-color': 'transparent',
         'background-color': getColor('white', 'contrast'),
         /* prettier-ignore */
-        // tslint:disable-next-line: prettier
         'color': getColor('white')
       });
     });


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2018 

## What is the new behavior?
The cancel button color of kirby-action-sheet is now being rendered as a white button.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


