### PR TITLE
Mute "ResizeObserver loop limit exceeded" exception

### DIFF
--- a/libs/designsystem/src/lib/directives/fit-heading/fit-heading.directive.ts
+++ b/libs/designsystem/src/lib/directives/fit-heading/fit-heading.directive.ts
@@ -73,9 +73,18 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
   }
 
   private observeResize(): void {
-    this.resizeObserverService.observe(this.elementRef, () => {
-      this.scaleHeader();
-    });
+    // Supress select errors thrown from ResizeObserver as they do not have any
+    // impact on the users.
+    // @see {@link https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded}
+    try {
+      this.resizeObserverService.observe(this.elementRef, () => {
+        this.scaleHeader();
+      });
+    } catch (e) {
+      if (e !== 'ResizeObserver loop limit exceeded') {
+        throw e;
+      }
+    }
   }
 
   private scaleHeader(): void {

--- a/libs/designsystem/src/lib/directives/fit-heading/fit-heading.directive.ts
+++ b/libs/designsystem/src/lib/directives/fit-heading/fit-heading.directive.ts
@@ -73,18 +73,17 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
   }
 
   private observeResize(): void {
-    // Supress select errors thrown from ResizeObserver as they do not have any
-    // impact on the users.
-    // @see {@link https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded}
-    try {
-      this.resizeObserverService.observe(this.elementRef, () => {
+    this.resizeObserverService.observe(this.elementRef, (entry) => {
+      // We wrap it in requestAnimationFrame to avoid this error
+      // - ResizeObserver loop limit exceeded
+      // For more information @see(https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded)
+      window.requestAnimationFrame(() => {
+        if (!Array.isArray(entry) || !entry.length) {
+          return;
+        }
         this.scaleHeader();
       });
-    } catch (e) {
-      if (e !== 'ResizeObserver loop limit exceeded') {
-        throw e;
-      }
-    }
+    });
   }
 
   private scaleHeader(): void {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2031

## What is the new behavior?

No ResizeObserver exceptions thrown in Azure App Insight when navigating to select pages
```
/drb/investment/securities
/drb/investment/overview
/drb/inbox
```
Other routes should be thoroughly tested.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

It's unclear if the changes has any sideeffects. It should be tested.

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


