### PR TITLE
Revert "Mute "ResizeObserver loop limit exceeded" exception (#2032)"

### DIFF
--- a/libs/designsystem/src/lib/directives/fit-heading/fit-heading.directive.ts
+++ b/libs/designsystem/src/lib/directives/fit-heading/fit-heading.directive.ts
@@ -73,16 +73,8 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
   }
 
   private observeResize(): void {
-    this.resizeObserverService.observe(this.elementRef, (entry) => {
-      // We wrap it in requestAnimationFrame to avoid this error
-      // - ResizeObserver loop limit exceeded
-      // For more information @see(https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded)
-      window.requestAnimationFrame(() => {
-        if (!Array.isArray(entry) || !entry.length) {
-          return;
-        }
-        this.scaleHeader();
-      });
+    this.resizeObserverService.observe(this.elementRef, () => {
+      this.scaleHeader();
     });
   }
 


### PR DESCRIPTION
This reverts commit 912e97bc13dbc2df33fa75d8a2b128678babad08.

## Which issue does this PR close?

This PR closes no issue, rather i reopens #2031 

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


