### PR TITLE
Declare button in calendar tests

### DIFF
--- a/libs/designsystem/src/lib/components/calendar/calendar.component.initialization.spec.ts
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.initialization.spec.ts
@@ -3,6 +3,7 @@ import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
 import { MockComponent } from 'ng-mocks';
 
 import {
+  ButtonComponent,
   CalendarComponent,
   CardComponent,
   DropdownComponent,
@@ -24,6 +25,7 @@ describe('CalendarComponent', () => {
       RadioComponent,
       CardComponent,
       ItemComponent,
+      ButtonComponent,
     ],
     providers: [
       {

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.spec.ts
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.spec.ts
@@ -4,7 +4,7 @@ import { format, startOfDay, startOfMonth } from 'date-fns';
 import { zonedTimeToUtc } from 'date-fns-tz';
 import { MockComponent } from 'ng-mocks';
 
-import { CalendarComponent, IconComponent } from '..';
+import { ButtonComponent, CalendarComponent, IconComponent } from '..';
 import { TestHelper } from '../../testing/test-helper';
 import { WindowRef } from '../../types/window-ref';
 import { CardComponent } from '../card';
@@ -30,6 +30,7 @@ describe('CalendarComponent', () => {
       RadioComponent,
       CardComponent,
       ItemComponent,
+      ButtonComponent,
     ],
     providers: [
       {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue 🥷 

## What is the new behavior?

We got an awful lot of `ERROR: 'NG0303: Can't bind to 'noDecoration' since it isn't a known property of 'button'.'` since 2754df7eebdd0cacf5903b5bf74e6a9674cd327c introduced buttons in the calendar. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


