### PR TITLE
Add missing input properties to card & modal footer mocks

### DIFF
--- a/libs/designsystem/testing-base/src/lib/components/mock.card.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.card.component.ts
@@ -16,6 +16,7 @@ import { CardComponent } from '@kirbydesign/designsystem';
 export class MockCardComponent {
   @Input() title: string;
   @Input() subtitle: string;
+  @Input() backgroundImageUrl: string;
   @Input() hasPadding: boolean;
   @Input() sizes: { [size: string]: number };
   @Input() mode: 'flat' | 'highlighted';

--- a/libs/designsystem/testing-base/src/lib/components/mock.modal-footer.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.modal-footer.component.ts
@@ -15,6 +15,7 @@ import { ModalFooterComponent } from '@kirbydesign/designsystem';
 })
 export class MockModalFooterComponent {
   @Input() snapToKeyboard: boolean;
+  @Input() type: 'inline' | 'fixed';
 }
 
 // #endregion


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue. I've gone rogue 🥷 

## What is the new behavior?

Missing input properties has been added to mocks.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/master/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to master via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


