### PR TITLE
Experimental: Allow popover to be used for calendar year selector

### DIFF
--- a/libs/designsystem/src/lib/components/calendar/calendar.component.html
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.html
@@ -15,6 +15,7 @@
   </div>
   <kirby-dropdown
     *ngIf="_hasYearNavigator"
+    [usePopover]="usePopover"
     [selectedIndex]="navigatedYear"
     [items]="navigableYears"
     popout="left"

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.ts
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.ts
@@ -79,6 +79,11 @@ export class CalendarComponent implements OnInit, AfterViewInit, OnChanges {
   @Input() disableFutureDates = false;
   @Input() alwaysEnableToday = false;
   @Input() customLocales: { [key: string]: Locale } = {};
+  /* 
+    Experimental: Input property not documented on purpose. 
+    For context see: https://github.com/kirbydesign/designsystem/issues/2087
+  */
+  @Input() usePopover = false;
   /**
    * Configuration for the year navigator.
    *


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue.

## What is the new behavior?

An `usePopover` input property has been added to the calendar component. This allows for enabling popover functionality for the year selector in the calendar. 

The popover functionality is still experimental - hence it is not documented. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

The input property is needed as some consumers has begun experimenting with the popover functionality in order to report back bugs if any is encountered. To track progress of the popover functionality see: #2087 