### PR TITLE
Add MuteError service and handle resize observer error

### DIFF
--- a/libs/designsystem/src/lib/directives/fit-heading/fit-heading.directive.ts
+++ b/libs/designsystem/src/lib/directives/fit-heading/fit-heading.directive.ts
@@ -62,10 +62,7 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
       const firefoxResizeObserverError: string =
         'ResizeObserver loop completed with undelivered notifications.';
       const chromeResizeObserverError: string = 'ResizeObserver loop limit exceeded';
-      this.muteErrorService.registerErrorMessages([
-        firefoxResizeObserverError,
-        chromeResizeObserverError,
-      ]);
+      this.muteErrorService.register([firefoxResizeObserverError, chromeResizeObserverError]);
 
       this.lineClampHelper.setMaxLines(this.elementRef.nativeElement, this.config.maxLines);
       this.observeResize();

--- a/libs/designsystem/src/lib/directives/fit-heading/fit-heading.directive.ts
+++ b/libs/designsystem/src/lib/directives/fit-heading/fit-heading.directive.ts
@@ -58,17 +58,10 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
   ngOnInit(): void {
     if (this.config && this.config.maxLines) {
       this.lineClampHelper.setMaxLines(this.elementRef.nativeElement, this.config.maxLines);
-      window.addEventListener('error', (e) => {
-        if (
-          e.message === 'ResizeObserver loop completed with undelivered notifications.' ||
-          e.message === 'ResizeObserver loop limit exceeded'
-        ) {
-          console.log('Stopping ResizeObserver error propagation');
-          e.stopImmediatePropagation();
-          e.preventDefault();
-        }
-      });
+      console.log('registering eventlistener');
+      window.addEventListener('error', this.muteResizeObserverError);
       this.observeResize();
+
       this.isObservingHostElement = true;
     }
   }
@@ -79,6 +72,10 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
       if (this.hostElementClone) {
         this.renderer.removeChild(this.elementRef.nativeElement, this.hostElementClone);
       }
+
+      console.log('removing eventlistener');
+
+      window.removeEventListener('error', this.muteResizeObserverError);
     }
   }
 
@@ -129,5 +126,16 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
   private setSize(el: Element, size: HeadingSize): void {
     this.renderer.setStyle(el, 'font-size', size.fontSize);
     this.renderer.setStyle(el, 'line-height', size.lineHeight);
+  }
+
+  private muteResizeObserverError(e: ErrorEvent) {
+    if (
+      e.message === 'ResizeObserver loop completed with undelivered notifications.' ||
+      e.message === 'ResizeObserver loop limit exceeded'
+    ) {
+      console.log('Muting...');
+      e.stopImmediatePropagation();
+      e.preventDefault();
+    }
   }
 }

--- a/libs/designsystem/src/lib/directives/fit-heading/fit-heading.directive.ts
+++ b/libs/designsystem/src/lib/directives/fit-heading/fit-heading.directive.ts
@@ -58,6 +58,16 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
   ngOnInit(): void {
     if (this.config && this.config.maxLines) {
       this.lineClampHelper.setMaxLines(this.elementRef.nativeElement, this.config.maxLines);
+      window.addEventListener('error', (e) => {
+        if (
+          e.message === 'ResizeObserver loop completed with undelivered notifications.' ||
+          e.message === 'ResizeObserver loop limit exceeded'
+        ) {
+          console.log('Stopping ResizeObserver error propagation');
+          e.stopImmediatePropagation();
+          e.preventDefault();
+        }
+      });
       this.observeResize();
       this.isObservingHostElement = true;
     }

--- a/libs/designsystem/src/lib/directives/fit-heading/fit-heading.directive.ts
+++ b/libs/designsystem/src/lib/directives/fit-heading/fit-heading.directive.ts
@@ -59,7 +59,15 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
     if (this.config && this.config.maxLines) {
       this.lineClampHelper.setMaxLines(this.elementRef.nativeElement, this.config.maxLines);
       console.log('registering eventlistener');
-      window.addEventListener('error', this.muteResizeObserverError);
+      const e = window.onerror;
+      window.onerror = function(err) {
+        if (err === 'ResizeObserver loop limit exceeded') {
+          console.log('Ignored: ResizeObserver loop limit exceeded');
+          return true;
+        } else {
+          return e;
+        }
+      };
       this.observeResize();
 
       this.isObservingHostElement = true;

--- a/libs/designsystem/src/lib/helpers/mute-error.service.spec.ts
+++ b/libs/designsystem/src/lib/helpers/mute-error.service.spec.ts
@@ -1,0 +1,73 @@
+import { MuteErrorService } from './mute-error.service';
+
+describe('MuteErrorService', () => {
+  let muteErrorService: MuteErrorService;
+
+  beforeEach(() => {
+    muteErrorService = new MuteErrorService();
+  });
+
+  it('should create service', () => {
+    expect(muteErrorService).toBeInstanceOf(MuteErrorService);
+  });
+
+  it('should register error message supplied as string', () => {
+    const firstErrorMsg: string = 'Evil Error';
+    const secondErrorMsg: string = 'Even more Evil Error';
+
+    muteErrorService.register(firstErrorMsg);
+
+    expect(muteErrorService['mutedErrors']).toEqual([firstErrorMsg]);
+
+    muteErrorService.register(secondErrorMsg);
+
+    expect(muteErrorService['mutedErrors']).toEqual([firstErrorMsg, secondErrorMsg]);
+  });
+
+  it('should register error message supplied as array', () => {
+    const errorMsgs: string[] = ['Evil Error', 'Even more Evil Error'];
+
+    muteErrorService.register(errorMsgs);
+
+    expect(muteErrorService['mutedErrors']).toEqual(errorMsgs);
+  });
+
+  describe('handleError method', () => {
+    it('should return error if not registered in service', () => {
+      const error = { message: 'Evil Error' };
+      const result = muteErrorService['handleError'](error);
+
+      expect(result).toBe(error);
+    });
+
+    it('should mute error message if it is registered in service', () => {
+      muteErrorService.register('Evil Error');
+
+      const error = { message: 'Evil Error' };
+      const result = muteErrorService['handleError'](error);
+
+      expect(result).toBe(true);
+    });
+
+    it('should call errorHandler when passed handleError method', () => {
+      const error = { message: 'Evil Error', modified: false };
+      const errorHandler = jasmine.createSpy('errorHandler');
+      muteErrorService['handleError'](error, errorHandler);
+
+      expect(errorHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reuse supplied error handler when returning error', () => {
+      const error = { message: 'Evil Error', modified: false };
+      const errorHandler = (error) => {
+        error.modified = true;
+        return error;
+      };
+
+      const result = muteErrorService['handleError'](error, errorHandler);
+
+      expect(result.message).toBe(error.message);
+      expect(result.modified).toBe(true);
+    });
+  });
+});

--- a/libs/designsystem/src/lib/helpers/mute-error.service.ts
+++ b/libs/designsystem/src/lib/helpers/mute-error.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MuteErrorService {
+  constructor() {
+    this.extendErrorHandler();
+  }
+  private errorMessages: string[] = [];
+
+  public registerErrorMessages(messages: string[] | string) {
+    this.errorMessages = this.errorMessages.concat(messages);
+    console.log('Error messages: ', this.errorMessages);
+  }
+
+  private extendErrorHandler() {
+    const existingErrorHandler = window.onerror;
+    window.onerror = (message, url, lineno, colno, error) => {
+      const originalError = {
+        message: message as string,
+        url,
+        lineno,
+        colno,
+        error,
+      };
+
+      if (this.errorMessages.includes(originalError.message)) {
+        console.log('Muting resizeobserver error');
+        // Return true here, to prevent firing the default event handler
+        return true;
+      } else if (existingErrorHandler !== null) {
+        console.log('Old window.onerror exists, rethrow');
+        return existingErrorHandler(originalError.message);
+      } else {
+        console.log('Just throwing that old onerror as usual, nothing to see here.');
+        console.log(originalError);
+        return originalError;
+      }
+    };
+  }
+}

--- a/libs/designsystem/src/lib/helpers/mute-error.service.ts
+++ b/libs/designsystem/src/lib/helpers/mute-error.service.ts
@@ -4,14 +4,14 @@ import { Injectable } from '@angular/core';
   providedIn: 'root',
 })
 export class MuteErrorService {
+  private mutedErrors: string[] = [];
+
   constructor() {
     this.extendErrorHandler();
   }
-  private errorMessages: string[] = [];
 
-  public registerErrorMessages(messages: string[] | string) {
-    this.errorMessages = this.errorMessages.concat(messages);
-    console.log('Error messages: ', this.errorMessages);
+  public register(messages: string[] | string) {
+    this.mutedErrors = this.mutedErrors.concat(messages);
   }
 
   private extendErrorHandler() {
@@ -25,18 +25,21 @@ export class MuteErrorService {
         error,
       };
 
-      if (this.errorMessages.includes(originalError.message)) {
-        console.log('Muting resizeobserver error');
-        // Return true here, to prevent firing the default event handler
-        return true;
-      } else if (existingErrorHandler !== null) {
-        console.log('Old window.onerror exists, rethrow');
-        return existingErrorHandler(originalError.message);
-      } else {
-        console.log('Just throwing that old onerror as usual, nothing to see here.');
-        console.log(originalError);
-        return originalError;
-      }
+      this.handleError(originalError, existingErrorHandler);
     };
+  }
+
+  private handleError(error: any, errorHandler?: OnErrorEventHandlerNonNull) {
+    if (this.mutedErrors.includes(error.message)) {
+      // Return true here, which means we mute the error
+      // by preventing the firing of the default event handler
+      return true;
+    } else if (errorHandler !== null && errorHandler !== undefined) {
+      // If an error handler has previously been registered
+      // reuse it with the original error
+      return errorHandler(error);
+    } else {
+      return error;
+    }
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2031

## What is the new behavior?
This PR introduces a service that can mute specific error messages. The service is then used to mute 'ResizeObserver loop limit exceeded' errors in chrome and firefox. 
 
To make this non-breaking in contexts that might already define a handler for `window.onerror`, we reuse any existing handling for all other error messages. 

A more detailed explanation of the findings when working with this error can be found on the issue this PR closes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


