### PR TITLE
Avoid ResizeObserver loop by delaying scaling of header to next cycle

### DIFF
--- a/libs/designsystem/src/lib/directives/fit-heading/fit-heading.directive.ts
+++ b/libs/designsystem/src/lib/directives/fit-heading/fit-heading.directive.ts
@@ -74,7 +74,15 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
 
   private observeResize(): void {
     this.resizeObserverService.observe(this.elementRef, () => {
-      this.scaleHeader();
+      /**
+       * setTimeout is used here to avoid repeated size changes
+       * while the first size change is still ongoing.
+       * This would result in the ResizeObserver being called again,
+       * giving 'ResizeObserver loop limit exceeded' types of errors.
+       */
+      setTimeout(() => {
+        this.scaleHeader();
+      }, 0);
     });
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2031 

## What is the new behavior?
See this comment: https://github.com/kirbydesign/designsystem/issues/2031#issuecomment-1070549974

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


