### PR TITLE
Set fallback value for --padding-top/bottom on item

### DIFF
--- a/libs/designsystem/src/lib/components/item/item.component.scss
+++ b/libs/designsystem/src/lib/components/item/item.component.scss
@@ -7,8 +7,8 @@
   position: relative;
 
   ion-item {
-    --padding-top: var(--item-padding-top, 0);
-    --padding-bottom: var(--item-padding-bottom, 0);
+    --padding-top: var(--item-padding-top, initial);
+    --padding-bottom: var(--item-padding-bottom, initial);
     font-size: utils.font-size('s');
     --min-height: #{map.get(utils.$item-heights, 'm')};
     --padding-start: #{utils.size('s')};

--- a/libs/designsystem/src/lib/components/item/item.component.scss
+++ b/libs/designsystem/src/lib/components/item/item.component.scss
@@ -7,8 +7,8 @@
   position: relative;
 
   ion-item {
-    --padding-top: var(--item-padding-top, initial);
-    --padding-bottom: var(--item-padding-bottom, initial);
+    --padding-top: var(--item-padding-top, 0px);
+    --padding-bottom: var(--item-padding-bottom, 0px);
     font-size: utils.font-size('s');
     --min-height: #{map.get(utils.$item-heights, 'm')};
     --padding-start: #{utils.size('s')};

--- a/libs/designsystem/src/lib/components/item/item.component.scss
+++ b/libs/designsystem/src/lib/components/item/item.component.scss
@@ -7,8 +7,8 @@
   position: relative;
 
   ion-item {
-    --padding-top: var(--item-padding-top);
-    --padding-bottom: var(--item-padding-bottom);
+    --padding-top: var(--item-padding-top, 0);
+    --padding-bottom: var(--item-padding-bottom, 0);
     font-size: utils.font-size('s');
     --min-height: #{map.get(utils.$item-heights, 'm')};
     --padding-start: #{utils.size('s')};


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2117

## What is the new behavior?
Item will not inherit custom properties like `--padding-top` from 'above', as this poses a problem when an item is used within e.g. a modal, where `ion-content` defines `--padding-top` and `--padding-bottom`. 

Now, it has to be specifically set on the item. This bug was introduced in v. 5.1.1, as mentioned [here](https://github.com/kirbydesign/designsystem/pull/2029/files#diff-47a4f9a6346abfbf0d4e08bccd42083ab3cf87d2871dc195a50fcd143ecf2c0bR10-R11
)
 
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


