### PR TITLE
Interaction state hover for input

### DIFF
--- a/libs/designsystem/src/lib/components/form-field/input/input.component.scss
+++ b/libs/designsystem/src/lib/components/form-field/input/input.component.scss
@@ -1,7 +1,14 @@
 @use '../form-field-inputs.shared' as shared;
+@use "~@kirbydesign/core/src/scss/interaction-state";
 @use "~@kirbydesign/core/src/scss/utils";
 
 :host {
+  @include interaction-state.transition(background-color);
+  @include interaction-state.apply-hover($loudness: 's') {
+    background-color: interaction-state.get-state-color('white');
+    cursor: text;
+  }
+
   &[type='number'] {
     //fallback
     appearance: textfield;

--- a/libs/designsystem/src/lib/components/form-field/input/input.component.scss
+++ b/libs/designsystem/src/lib/components/form-field/input/input.component.scss
@@ -4,8 +4,8 @@
 
 :host {
   @include interaction-state.transition(background-color);
-  @include interaction-state.apply-hover($loudness: 's') {
-    background-color: interaction-state.get-state-color('white');
+  @include interaction-state.apply-hover() {
+    background-color: interaction-state.get-state-color('white', 's');
     cursor: text;
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2105

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


