### PR TITLE
Interaction state hover for accordion

### DIFF
--- a/libs/designsystem/src/lib/components/accordion/accordion-item.component.html
+++ b/libs/designsystem/src/lib/components/accordion/accordion-item.component.html
@@ -1,28 +1,26 @@
-<ng-container>
-  <span class="state-layer" aria-hidden="true"></span>
-  <div class="content-layer">
-    <div
-      (click)="isExpanded = !isExpanded"
-      class="header"
-      role="button"
-      [class.expanded]="isExpanded"
-      [attr.aria-expanded]="isExpanded"
-      [attr.aria-controls]="_contentId"
-      [id]="_titleId"
-    >
-      <div class="title">{{ title }}</div>
-      <kirby-icon name="arrow-down"></kirby-icon>
-    </div>
-    <div
-      class="content"
-      role="region"
-      [attr.aria-labelledby]="_titleId"
-      [id]="_contentId"
-      [@isExpanded]="!!isExpanded"
-    >
-      <div class="content-body">
-        <ng-content></ng-content>
-      </div>
+<span class="state-layer" aria-hidden="true"></span>
+<div class="content-layer">
+  <div
+    (click)="isExpanded = !isExpanded"
+    class="header"
+    role="button"
+    [class.expanded]="isExpanded"
+    [attr.aria-expanded]="isExpanded"
+    [attr.aria-controls]="_contentId"
+    [id]="_titleId"
+  >
+    <div class="title">{{ title }}</div>
+    <kirby-icon name="arrow-down"></kirby-icon>
+  </div>
+  <div
+    class="content"
+    role="region"
+    [attr.aria-labelledby]="_titleId"
+    [id]="_contentId"
+    [@isExpanded]="!!isExpanded"
+  >
+    <div class="content-body">
+      <ng-content></ng-content>
     </div>
   </div>
-</ng-container>
+</div>

--- a/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
+++ b/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
@@ -18,7 +18,6 @@ $padding: utils.size('s');
   height: utils.size('xxxl');
   padding-left: $padding;
   padding-right: $padding;
-  cursor: pointer;
   user-select: none;
 }
 .title {
@@ -29,6 +28,7 @@ $padding: utils.size('s');
 }
 .content {
   overflow: hidden;
+  cursor: default;
 }
 .content-body {
   padding: 0 $padding $padding $padding;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2089

## What is the new behavior?
Hover background styles are applied when hovering the whole item, also when expanded. 
The cursor is only a pointer when hovering over the header, as it is only the header that is interactive. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


