### PR TITLE
Add "collapsibleTitle" field to modal config

### DIFF
--- a/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.html
+++ b/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.html
@@ -48,15 +48,9 @@
         class="nested-modal-configuration"
       >
         <h3>Open nested:</h3>
-        <button kirby-button attentionLevel="2" (click)="showNestedModal()">
-          Modal
-        </button>
-        <button kirby-button attentionLevel="2" (click)="showNestedDrawer()">
-          Drawer
-        </button>
-        <button kirby-button attentionLevel="2" (click)="showNestedAlert()">
-          Alert
-        </button>
+        <button kirby-button attentionLevel="2" (click)="showNestedModal()">Modal</button>
+        <button kirby-button attentionLevel="2" (click)="showNestedDrawer()">Drawer</button>
+        <button kirby-button attentionLevel="2" (click)="showNestedAlert()">Alert</button>
         <button kirby-button attentionLevel="2" (click)="showNestedActionSheet()">
           Action sheet
         </button>
@@ -161,6 +155,7 @@
 
 <kirby-modal-footer
   *ngIf="!isLoading && showFooter"
+  [type]="_footerType"
   themeColor="white"
   [snapToKeyboard]="snapFooterToKeyboard"
 >

--- a/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.ts
@@ -38,11 +38,16 @@ export class EmbeddedModalExampleComponent implements OnInit {
   delayLoadDummyContent: boolean;
   loadAdditionalContent: boolean;
   disableScroll: boolean = false;
+  displayFooterAsInline: boolean = false;
   openFullHeight: boolean;
 
   isLoading = false;
   isLoadingAdditionalContent = false;
   snapFooterToKeyboard = false;
+
+  get _footerType(): 'inline' | 'fixed' {
+    return this.displayFooterAsInline ? 'inline' : 'fixed';
+  }
 
   constructor(
     @Inject(COMPONENT_PROPS) componentProps,

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.html
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.html
@@ -23,6 +23,15 @@
 ></kirby-checkbox>
 
 <kirby-checkbox
+  *ngIf="displayFooterAsInline !== undefined"
+  [checked]="displayFooterAsInline"
+  (checkedChange)="toggleDisplayFooterAsInline($event)"
+  [disabled]="disabled || !showFooter"
+  text="Display footer as inline"
+  class="indent"
+></kirby-checkbox>
+
+<kirby-checkbox
   *ngIf="disableScroll !== undefined"
   [checked]="disableScroll"
   (checkedChange)="toggleDisableScroll($event)"

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.html
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.html
@@ -64,6 +64,13 @@
   text="Open in full height"
 ></kirby-checkbox>
 
+<kirby-checkbox
+  [checked]="collapseTitle"
+  (checkedChange)="toggleCollapseTitle($event)"
+  [disabled]="disabled"
+  text="Collapse title"
+></kirby-checkbox>
+
 <ng-container *ngIf="interactWithBackground !== undefined || customCssClass !== undefined">
   <kirby-divider [hasMargin]="true"></kirby-divider>
   <p>Custom modal/drawer:</p>

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.ts
@@ -18,6 +18,9 @@ export class ModalExampleConfigurationComponent {
   @Input() showPageProgress: boolean;
   @Output() showPageProgressChange = new EventEmitter<boolean>();
 
+  @Input() collapseTitle: boolean;
+  @Output() collapseTitleChange = new EventEmitter<boolean>();
+
   @Input() showFooter: boolean;
   @Output() showFooterChange = new EventEmitter<boolean>();
 
@@ -79,6 +82,12 @@ export class ModalExampleConfigurationComponent {
     if (this.preventChangeEvent) return;
     this.showFooter = show;
     this.showFooterChange.emit(this.showFooter);
+  }
+
+  toggleCollapseTitle(value: boolean) {
+    if (this.preventChangeEvent) return;
+    this.collapseTitle = value;
+    this.collapseTitleChange.emit(this.collapseTitle);
   }
 
   toggleShowDummyContent(show: boolean) {

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.ts
@@ -24,6 +24,9 @@ export class ModalExampleConfigurationComponent {
   @Input() showFooter: boolean;
   @Output() showFooterChange = new EventEmitter<boolean>();
 
+  @Input() displayFooterAsInline: boolean = false;
+  @Output() displayFooterAsInlineChange = new EventEmitter<boolean>();
+
   @Input() showDummyContent: boolean;
   @Output() showDummyContentChange = new EventEmitter<boolean>();
 
@@ -82,6 +85,12 @@ export class ModalExampleConfigurationComponent {
     if (this.preventChangeEvent) return;
     this.showFooter = show;
     this.showFooterChange.emit(this.showFooter);
+  }
+
+  toggleDisplayFooterAsInline(value: boolean) {
+    if (this.preventChangeEvent) return;
+    this.displayFooterAsInline = value;
+    this.displayFooterAsInlineChange.emit(this.displayFooterAsInline);
   }
 
   toggleCollapseTitle(value: boolean) {

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-default.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-default.component.ts
@@ -15,6 +15,7 @@ const config = {
       <cookbook-modal-example-configuration [disabled]="preventInteraction" [(showDummyKeyboard)]="showDummyKeyboard"
       [(showPageProgress)]="showPageProgress"
       [(showFooter)]="showFooter"
+      [(displayFooterAsInline)]="displayFooterAsInline"
       [(collapseTitle)]="collapseTitle"
       [(showDummyContent)]="showDummyContent"
       [(delayLoadDummyContent)]="delayLoadDummyContent"
@@ -208,6 +209,7 @@ export class ModalExampleDefaultComponent {
   );
   showPageProgress = false;
   showFooter = false;
+  displayFooterAsInline = false;
   collapseTitle = false;
   showDummyContent = true;
   delayLoadDummyContent = true;
@@ -235,6 +237,7 @@ export class ModalExampleDefaultComponent {
       size: this.openFullHeight ? 'full-height' : null,
       componentProps: {
         title,
+        displayFooterAsInline: this.displayFooterAsInline,
         subtitle: 'Hello from the first embedded example component!',
         exampleProperties: {
           stringProperty: 'Value injected from parent component',

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-default.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-default.component.ts
@@ -15,6 +15,7 @@ const config = {
       <cookbook-modal-example-configuration [disabled]="preventInteraction" [(showDummyKeyboard)]="showDummyKeyboard"
       [(showPageProgress)]="showPageProgress"
       [(showFooter)]="showFooter"
+      [(collapseTitle)]="collapseTitle"
       [(showDummyContent)]="showDummyContent"
       [(delayLoadDummyContent)]="delayLoadDummyContent"
       [(loadAdditionalContent)]="loadAdditionalContent"
@@ -207,6 +208,7 @@ export class ModalExampleDefaultComponent {
   );
   showPageProgress = false;
   showFooter = false;
+  collapseTitle = false;
   showDummyContent = true;
   delayLoadDummyContent = true;
   loadAdditionalContent = false;
@@ -226,6 +228,7 @@ export class ModalExampleDefaultComponent {
     this.preventInteraction = this.interactWithBackground;
     const config: ModalConfig = {
       flavor,
+      collapseTitle: this.collapseTitle,
       component: EmbeddedModalExampleComponent,
       interactWithBackground: this.interactWithBackground,
       cssClass: this.customCssClass ? ['my-custom-modal-class'] : [],

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
@@ -45,6 +45,13 @@ export class ModalShowcaseComponent implements AfterViewInit {
       type: ['undefined', 'modal', 'drawer', 'compact'],
     },
     {
+      name: 'collapseTitle',
+      description: `(Optional) If \`true\` will cause the title to initially be rendered as part of the content; once scrolled out of view it collapses and appears in the header area. 
+      \n Useful for long titles that would otherwise truncate. `,
+      defaultValue: 'false',
+      type: ['boolean'],
+    },
+    {
       name: 'size',
       description: `(Optional) The initial size of the modal before content is loaded.
         The \`full-height\` option will take up as much vertical space as possible and not resize with content or native keyboard.`,

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/config/modal-config.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/config/modal-config.ts
@@ -11,6 +11,7 @@ export interface ModalConfig {
    * @deprecated Will be removed in next major version. Embed a `<kirby-page-title>` element inside the component instead.
    */
   title?: string;
+  collapseTitle?: boolean;
   component: any;
   size?: ModalSize;
   modalRoute?: ActivatedRoute;

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.html
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.html
@@ -1,6 +1,8 @@
 <ion-header (touchstart)="onHeaderTouchStart($event)">
   <ion-toolbar>
-    <ion-title></ion-title>
+    <span class="kirby-text-medium">
+      <ion-title></ion-title>
+    </span>
     <ion-buttons slot="start" *ngIf="config.flavor === 'drawer'">
       <ng-container *ngTemplateOutlet="closeButton; context: { icon: 'arrow-down' }"></ng-container>
     </ion-buttons>
@@ -16,9 +18,9 @@
 </ion-header>
 
 <ion-content [scrollEvents]="true">
-  <ion-header *ngIf="config.collapseTitle" collapse="condense">
+  <ion-header *ngIf="_hasCollapsibleTitle" collapse="condense">
     <ion-toolbar>
-      <h1 class="kirby-text-large" #contentTitle></h1>
+      <span class="kirby-text-large" #contentTitle></span>
     </ion-toolbar>
   </ion-header>
   <ng-container

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.html
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.html
@@ -1,6 +1,6 @@
 <ion-header (touchstart)="onHeaderTouchStart($event)">
   <ion-toolbar>
-    <ion-title>{{ config.title }}</ion-title>
+    <ion-title></ion-title>
     <ion-buttons slot="start" *ngIf="config.flavor === 'drawer'">
       <ng-container *ngTemplateOutlet="closeButton; context: { icon: 'arrow-down' }"></ng-container>
     </ion-buttons>
@@ -16,6 +16,14 @@
 </ion-header>
 
 <ion-content [scrollEvents]="true">
+  <ion-header *ngIf="doTheThing" collapse="condense">
+    <ion-toolbar>
+      <h1 class="kirby-text-large" #condensedTitle>
+        Hustlers er langt fra noget ensartet folkefærd. Der findes den beregnende type som Jazzy,
+        der aldrig mister overblikket og altid tænker stort.
+      </h1>
+    </ion-toolbar>
+  </ion-header>
   <ng-container
     *ngComponentOutlet="config.component; injector: componentPropsInjector"
   ></ng-container>

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.html
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.html
@@ -18,10 +18,7 @@
 <ion-content [scrollEvents]="true">
   <ion-header *ngIf="doTheThing" collapse="condense">
     <ion-toolbar>
-      <h1 class="kirby-text-large" #condensedTitle>
-        Hustlers er langt fra noget ensartet folkefærd. Der findes den beregnende type som Jazzy,
-        der aldrig mister overblikket og altid tænker stort.
-      </h1>
+      <h1 class="kirby-text-large" #contentTitle></h1>
     </ion-toolbar>
   </ion-header>
   <ng-container

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.html
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.html
@@ -16,7 +16,7 @@
 </ion-header>
 
 <ion-content [scrollEvents]="true">
-  <ion-header *ngIf="doTheThing" collapse="condense">
+  <ion-header *ngIf="config.collapseTitle" collapse="condense">
     <ion-toolbar>
       <h1 class="kirby-text-large" #contentTitle></h1>
     </ion-toolbar>

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.html
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.html
@@ -1,8 +1,6 @@
 <ion-header (touchstart)="onHeaderTouchStart($event)">
   <ion-toolbar>
-    <span class="kirby-text-medium">
-      <ion-title></ion-title>
-    </span>
+    <ion-title></ion-title>
     <ion-buttons slot="start" *ngIf="config.flavor === 'drawer'">
       <ng-container *ngTemplateOutlet="closeButton; context: { icon: 'arrow-down' }"></ng-container>
     </ion-buttons>

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.scss
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.scss
@@ -134,4 +134,23 @@ ion-content {
     --padding-end: #{utils.size('xxxl')};
   }
 }
+
+:host(.collapsible-title) {
+  ion-content {
+    --padding-top: 0;
+
+    ion-header ion-toolbar:first-of-type {
+      padding-top: 0;
+      --padding-top: 0;
+      --padding-bottom: 0;
+      --padding-start: 0;
+      --padding-end: 0;
+    }
+  }
+  ion-title {
+    font-size: utils.font-size('m');
+    font-weight: utils.font-weight('bold');
+  }
+}
+
 /* clean-css ignore:end */

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.spec.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.spec.ts
@@ -1,21 +1,65 @@
 import { fakeAsync, tick } from '@angular/core/testing';
-import { IonContent } from '@ionic/angular';
-import { Spectator } from '@ngneat/spectator';
+import { RouterTestingModule } from '@angular/router/testing';
+import { IonButtons, IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
+import { createComponentFactory, Spectator } from '@ngneat/spectator';
+import { MockComponents } from 'ng-mocks';
 
 import { KirbyAnimation } from '../../../animation/kirby-animation';
 import { TestHelper } from '../../../testing/test-helper';
+import { WindowRef } from '../../../types';
+import { ButtonComponent } from '../../button/button.component';
 import { IconComponent } from '../../icon/icon.component';
+import { PageProgressComponent } from '../../page';
+import { ModalFooterComponent } from '../footer/modal-footer.component';
 
 import { ModalWrapperComponent } from './modal-wrapper.component';
 import {
   DynamicFooterEmbeddedComponent,
   DynamicPageProgressEmbeddedComponent,
+  InputEmbeddedComponent,
   ModalWrapperTestBuilder,
+  StaticFooterEmbeddedComponent,
+  StaticPageProgressEmbeddedComponent,
 } from './modal-wrapper.testbuilder';
 
 describe('ModalWrapperComponent', () => {
-  const modalWrapperTestBuilder = new ModalWrapperTestBuilder();
+  const createComponent = createComponentFactory({
+    component: ModalWrapperComponent,
+    imports: [RouterTestingModule],
+    entryComponents: [
+      StaticFooterEmbeddedComponent,
+      DynamicFooterEmbeddedComponent,
+      InputEmbeddedComponent,
+      StaticPageProgressEmbeddedComponent,
+      DynamicPageProgressEmbeddedComponent,
+    ],
+    providers: [
+      {
+        provide: WindowRef,
+        useValue: <WindowRef>{ nativeWindow: window },
+      },
+    ],
+    declarations: [
+      MockComponents(
+        IconComponent,
+        ButtonComponent,
+        PageProgressComponent,
+        ModalFooterComponent,
+        IonHeader,
+        IonToolbar,
+        IonTitle,
+        IonButtons,
+        IonContent
+      ),
+    ],
+  });
+
+  let modalWrapperTestBuilder = new ModalWrapperTestBuilder(createComponent);
   let spectator: Spectator<ModalWrapperComponent>;
+
+  beforeEach(() => {
+    modalWrapperTestBuilder = new ModalWrapperTestBuilder(createComponent);
+  });
 
   it('should create', () => {
     spectator = modalWrapperTestBuilder.build();
@@ -27,10 +71,7 @@ describe('ModalWrapperComponent', () => {
 
   describe('title', () => {
     beforeEach(() => {
-      spectator = modalWrapperTestBuilder
-        .title('Test title')
-        .flavor('modal')
-        .build();
+      spectator = modalWrapperTestBuilder.title('Test title').flavor('modal').build();
     });
 
     afterEach(() => {
@@ -60,10 +101,7 @@ describe('ModalWrapperComponent', () => {
 
   describe('sizing', () => {
     beforeEach(() => {
-      spectator = modalWrapperTestBuilder
-        .flavor('modal')
-        .withEmbeddedInputComponent()
-        .build();
+      spectator = modalWrapperTestBuilder.flavor('modal').withEmbeddedInputComponent().build();
     });
     afterEach(() => {
       spectator.fixture.destroy();
@@ -124,10 +162,7 @@ describe('ModalWrapperComponent', () => {
 
     describe('when flavor is modal', () => {
       beforeEach(() => {
-        spectator = modalWrapperTestBuilder
-          .flavor('modal')
-          .interactWithBackground()
-          .build();
+        spectator = modalWrapperTestBuilder.flavor('modal').interactWithBackground().build();
         spectator.element.style.height = `${elementHeight}px`;
         spectator.element.style.width = `${elementWidth}px`;
         spectator.element.style.overflow = 'hidden';
@@ -167,10 +202,7 @@ describe('ModalWrapperComponent', () => {
 
     describe('when flavor is drawer', () => {
       beforeEach(() => {
-        spectator = modalWrapperTestBuilder
-          .flavor('drawer')
-          .interactWithBackground()
-          .build();
+        spectator = modalWrapperTestBuilder.flavor('drawer').interactWithBackground().build();
         spectator.element.style.height = `${elementHeight}px`;
         spectator.element.style.width = `${elementWidth}px`;
         spectator.element.style.overflow = 'hidden';
@@ -367,10 +399,7 @@ describe('ModalWrapperComponent', () => {
   describe('with embedded page progress component', () => {
     describe('with static page progress', () => {
       beforeEach(() => {
-        spectator = modalWrapperTestBuilder
-          .flavor('modal')
-          .withStaticPageProgress()
-          .build();
+        spectator = modalWrapperTestBuilder.flavor('modal').withStaticPageProgress().build();
         spectator.detectComponentChanges();
       });
 
@@ -384,9 +413,8 @@ describe('ModalWrapperComponent', () => {
         const ionToolbarElement = spectator.query('ion-toolbar');
         const embeddedComponentElement = ionContentElement.firstElementChild;
         const embeddedPageProgress = embeddedComponentElement.querySelector('kirby-page-progress');
-        const pageProgressAsIonToolbarChild = ionToolbarElement.querySelector(
-          'kirby-page-progress'
-        );
+        const pageProgressAsIonToolbarChild =
+          ionToolbarElement.querySelector('kirby-page-progress');
 
         expect(embeddedPageProgress).toBeNull();
         expect(pageProgressAsIonToolbarChild).not.toBeNull();
@@ -395,10 +423,7 @@ describe('ModalWrapperComponent', () => {
 
     describe('with dynamic page progress', () => {
       beforeEach(() => {
-        spectator = modalWrapperTestBuilder
-          .flavor('modal')
-          .withDynamicPageProgress()
-          .build();
+        spectator = modalWrapperTestBuilder.flavor('modal').withDynamicPageProgress().build();
         spectator.detectComponentChanges();
       });
 
@@ -420,9 +445,8 @@ describe('ModalWrapperComponent', () => {
         const ionToolbarElement = spectator.query('ion-toolbar');
         const embeddedComponentElement = ionContentElement.firstElementChild;
         const embeddedPageProgress = embeddedComponentElement.querySelector('kirby-page-progress');
-        const pageProgressAsIonToolbarChild = ionToolbarElement.querySelector(
-          'kirby-page-progress'
-        );
+        const pageProgressAsIonToolbarChild =
+          ionToolbarElement.querySelector('kirby-page-progress');
         expect(embeddedPageProgress).toBeNull();
         expect(pageProgressAsIonToolbarChild).not.toBeNull();
       });
@@ -517,10 +541,7 @@ describe('ModalWrapperComponent', () => {
 
   describe('with embedded component with dynamic footer', () => {
     beforeEach(() => {
-      spectator = modalWrapperTestBuilder
-        .flavor('modal')
-        .withDynamicFooter()
-        .build();
+      spectator = modalWrapperTestBuilder.flavor('modal').withDynamicFooter().build();
       spectator.detectComponentChanges();
     });
 
@@ -696,10 +717,7 @@ describe('ModalWrapperComponent', () => {
     let input: HTMLInputElement;
 
     beforeEach(async () => {
-      spectator = modalWrapperTestBuilder
-        .flavor('drawer')
-        .withEmbeddedInputComponent()
-        .build();
+      spectator = modalWrapperTestBuilder.flavor('drawer').withEmbeddedInputComponent().build();
 
       // Ensure ion-content gets height
       // or embedded component won't be visible:

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.spec.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.spec.ts
@@ -71,7 +71,10 @@ describe('ModalWrapperComponent', () => {
 
   describe('title', () => {
     beforeEach(() => {
-      spectator = modalWrapperTestBuilder.title('Test title').flavor('modal').build();
+      spectator = modalWrapperTestBuilder
+        .title('Test title')
+        .flavor('modal')
+        .build();
     });
 
     afterEach(() => {
@@ -101,7 +104,10 @@ describe('ModalWrapperComponent', () => {
 
   describe('sizing', () => {
     beforeEach(() => {
-      spectator = modalWrapperTestBuilder.flavor('modal').withEmbeddedInputComponent().build();
+      spectator = modalWrapperTestBuilder
+        .flavor('modal')
+        .withEmbeddedInputComponent()
+        .build();
     });
     afterEach(() => {
       spectator.fixture.destroy();
@@ -162,7 +168,10 @@ describe('ModalWrapperComponent', () => {
 
     describe('when flavor is modal', () => {
       beforeEach(() => {
-        spectator = modalWrapperTestBuilder.flavor('modal').interactWithBackground().build();
+        spectator = modalWrapperTestBuilder
+          .flavor('modal')
+          .interactWithBackground()
+          .build();
         spectator.element.style.height = `${elementHeight}px`;
         spectator.element.style.width = `${elementWidth}px`;
         spectator.element.style.overflow = 'hidden';
@@ -202,7 +211,10 @@ describe('ModalWrapperComponent', () => {
 
     describe('when flavor is drawer', () => {
       beforeEach(() => {
-        spectator = modalWrapperTestBuilder.flavor('drawer').interactWithBackground().build();
+        spectator = modalWrapperTestBuilder
+          .flavor('drawer')
+          .interactWithBackground()
+          .build();
         spectator.element.style.height = `${elementHeight}px`;
         spectator.element.style.width = `${elementWidth}px`;
         spectator.element.style.overflow = 'hidden';
@@ -399,7 +411,10 @@ describe('ModalWrapperComponent', () => {
   describe('with embedded page progress component', () => {
     describe('with static page progress', () => {
       beforeEach(() => {
-        spectator = modalWrapperTestBuilder.flavor('modal').withStaticPageProgress().build();
+        spectator = modalWrapperTestBuilder
+          .flavor('modal')
+          .withStaticPageProgress()
+          .build();
         spectator.detectComponentChanges();
       });
 
@@ -413,8 +428,9 @@ describe('ModalWrapperComponent', () => {
         const ionToolbarElement = spectator.query('ion-toolbar');
         const embeddedComponentElement = ionContentElement.firstElementChild;
         const embeddedPageProgress = embeddedComponentElement.querySelector('kirby-page-progress');
-        const pageProgressAsIonToolbarChild =
-          ionToolbarElement.querySelector('kirby-page-progress');
+        const pageProgressAsIonToolbarChild = ionToolbarElement.querySelector(
+          'kirby-page-progress'
+        );
 
         expect(embeddedPageProgress).toBeNull();
         expect(pageProgressAsIonToolbarChild).not.toBeNull();
@@ -423,7 +439,10 @@ describe('ModalWrapperComponent', () => {
 
     describe('with dynamic page progress', () => {
       beforeEach(() => {
-        spectator = modalWrapperTestBuilder.flavor('modal').withDynamicPageProgress().build();
+        spectator = modalWrapperTestBuilder
+          .flavor('modal')
+          .withDynamicPageProgress()
+          .build();
         spectator.detectComponentChanges();
       });
 
@@ -445,8 +464,9 @@ describe('ModalWrapperComponent', () => {
         const ionToolbarElement = spectator.query('ion-toolbar');
         const embeddedComponentElement = ionContentElement.firstElementChild;
         const embeddedPageProgress = embeddedComponentElement.querySelector('kirby-page-progress');
-        const pageProgressAsIonToolbarChild =
-          ionToolbarElement.querySelector('kirby-page-progress');
+        const pageProgressAsIonToolbarChild = ionToolbarElement.querySelector(
+          'kirby-page-progress'
+        );
         expect(embeddedPageProgress).toBeNull();
         expect(pageProgressAsIonToolbarChild).not.toBeNull();
       });
@@ -541,7 +561,10 @@ describe('ModalWrapperComponent', () => {
 
   describe('with embedded component with dynamic footer', () => {
     beforeEach(() => {
-      spectator = modalWrapperTestBuilder.flavor('modal').withDynamicFooter().build();
+      spectator = modalWrapperTestBuilder
+        .flavor('modal')
+        .withDynamicFooter()
+        .build();
       spectator.detectComponentChanges();
     });
 
@@ -717,7 +740,10 @@ describe('ModalWrapperComponent', () => {
     let input: HTMLInputElement;
 
     beforeEach(async () => {
-      spectator = modalWrapperTestBuilder.flavor('drawer').withEmbeddedInputComponent().build();
+      spectator = modalWrapperTestBuilder
+        .flavor('drawer')
+        .withEmbeddedInputComponent()
+        .build();
 
       // Ensure ion-content gets height
       // or embedded component won't be visible:

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
@@ -41,8 +41,10 @@ import { COMPONENT_PROPS } from './config/modal-config.helper';
   providers: [{ provide: Modal, useExisting: ModalWrapperComponent }],
 })
 export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDestroy {
-  //TODO: Do something with doTheThing :-)
-  doTheThing = true;
+  @HostBinding('class.collapsible-title')
+  get _hasCollapsibleTitle() {
+    return !!this.config?.collapseTitle;
+  }
 
   static readonly KEYBOARD_HIDE_DELAY_IN_MS = 100;
 

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
@@ -447,10 +447,12 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
     });
   }
 
+  /* TODO: Rewrite to make this function independent of element order. 
+     See: https://github.com/kirbydesign/designsystem/issues/2096
+  */
   private getEmbeddedComponentElement() {
-    return !!this.config.modalRoute
-      ? this.ionContentElement.nativeElement.lastElementChild
-      : this.ionContentElement.nativeElement.firstElementChild;
+    const { lastElementChild } = this.ionContentElement.nativeElement;
+    return !!this.config.modalRoute ? lastElementChild : lastElementChild.previousElementSibling;
   }
 
   private getEmbeddedFooterElement() {

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
@@ -458,11 +458,22 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
   /* TODO: Rewrite to make this function independent of element order. 
      See: https://github.com/kirbydesign/designsystem/issues/2096
   */
-  private getEmbeddedComponentElement() {
+  private getEmbeddedComponentElement(): null | Element {
     const contentElementChildren = Array.from(
       this.ionContentElement.nativeElement.children
     ).reverse(); // Reverse makes it easier to retrieve the last children in the list
-    return !!this.config.modalRoute ? contentElementChildren[0] : contentElementChildren[1];
+
+    const embeddedComponentElement = !!this.config.modalRoute
+      ? contentElementChildren[0]
+      : contentElementChildren[1];
+
+    /* 
+      As ModalConfig.component has type 'any' all values are valid for component; 
+      explicitly handle the case where no embedded component element is found due to 
+      this.
+    */
+    if (!embeddedComponentElement) return null;
+    return embeddedComponentElement;
   }
 
   private getEmbeddedFooterElement() {
@@ -498,6 +509,8 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
 
   private observeEmbeddedElements() {
     const parentElement = this.getEmbeddedComponentElement();
+    if (parentElement === null) return; // Mute observe warning when parentElement is null
+
     this.mutationObserver.observe(parentElement, {
       childList: true, // Listen for addition or removal of child nodes
     });

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
@@ -41,6 +41,9 @@ import { COMPONENT_PROPS } from './config/modal-config.helper';
   providers: [{ provide: Modal, useExisting: ModalWrapperComponent }],
 })
 export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDestroy {
+  //TODO: Do something with doTheThing :-)
+  doTheThing = true;
+
   static readonly KEYBOARD_HIDE_DELAY_IN_MS = 100;
 
   scrollY: number = Math.abs(this.windowRef.nativeWindow.scrollY);
@@ -57,18 +60,14 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
     ElementRef<HTMLButtonElement>
   >;
   @ViewChild(IonContent, { static: true }) private ionContent: IonContent;
-  @ViewChild(IonContent, { static: true, read: ElementRef }) private ionContentElement: ElementRef<
-    HTMLIonContentElement
-  >;
-  @ViewChild(IonHeader, { static: true, read: ElementRef }) private ionHeaderElement: ElementRef<
-    HTMLIonHeaderElement
-  >;
-  @ViewChild(IonToolbar, { static: true, read: ElementRef }) private ionToolbarElement: ElementRef<
-    HTMLIonToolbarElement
-  >;
-  @ViewChild(IonTitle, { static: true, read: ElementRef }) private ionTitleElement: ElementRef<
-    HTMLIonTitleElement
-  >;
+  @ViewChild(IonContent, { static: true, read: ElementRef })
+  private ionContentElement: ElementRef<HTMLIonContentElement>;
+  @ViewChild(IonHeader, { static: true, read: ElementRef })
+  private ionHeaderElement: ElementRef<HTMLIonHeaderElement>;
+  @ViewChild(IonToolbar, { static: true, read: ElementRef })
+  private ionToolbarElement: ElementRef<HTMLIonToolbarElement>;
+  @ViewChild(IonTitle, { static: true, read: ElementRef })
+  private ionTitleElement: ElementRef<HTMLIonTitleElement>;
   @ViewChild(RouterOutlet, { static: true }) private routerOutlet: RouterOutlet;
 
   private keyboardVisible = false;

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.ts
@@ -459,8 +459,10 @@ export class ModalWrapperComponent implements Modal, AfterViewInit, OnInit, OnDe
      See: https://github.com/kirbydesign/designsystem/issues/2096
   */
   private getEmbeddedComponentElement() {
-    const { lastElementChild } = this.ionContentElement.nativeElement;
-    return !!this.config.modalRoute ? lastElementChild : lastElementChild.previousElementSibling;
+    const contentElementChildren = Array.from(
+      this.ionContentElement.nativeElement.children
+    ).reverse(); // Reverse makes it easier to retrieve the last children in the list
+    return !!this.config.modalRoute ? contentElementChildren[0] : contentElementChildren[1];
   }
 
   private getEmbeddedFooterElement() {

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.testbuilder.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.testbuilder.ts
@@ -1,14 +1,5 @@
 import { Component } from '@angular/core';
-import { RouterTestingModule } from '@angular/router/testing';
-import { IonButtons, IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular';
-import { createComponentFactory, Spectator } from '@ngneat/spectator';
-import { MockComponents } from 'ng-mocks';
-
-import { WindowRef } from '../../../types';
-import { ButtonComponent } from '../../button/button.component';
-import { IconComponent } from '../../icon';
-import { PageProgressComponent } from '../../page/page.component';
-import { ModalFooterComponent } from '../footer/modal-footer.component';
+import { Spectator, SpectatorFactory } from '@ngneat/spectator';
 
 import { ModalConfig } from './config/modal-config';
 import { ModalWrapperComponent } from './modal-wrapper.component';
@@ -16,39 +7,11 @@ import { ModalWrapperComponent } from './modal-wrapper.component';
 export class ModalWrapperTestBuilder {
   private config: ModalConfig = {
     title: null,
-    component: null,
+    component: DefaultTestComponent,
     flavor: null,
   };
-  private readonly createComponent = createComponentFactory({
-    component: ModalWrapperComponent,
-    imports: [RouterTestingModule],
-    entryComponents: [
-      StaticFooterEmbeddedComponent,
-      DynamicFooterEmbeddedComponent,
-      InputEmbeddedComponent,
-      StaticPageProgressEmbeddedComponent,
-      DynamicPageProgressEmbeddedComponent,
-    ],
-    providers: [
-      {
-        provide: WindowRef,
-        useValue: <WindowRef>{ nativeWindow: window },
-      },
-    ],
-    declarations: [
-      MockComponents(
-        IconComponent,
-        ButtonComponent,
-        PageProgressComponent,
-        ModalFooterComponent,
-        IonHeader,
-        IonToolbar,
-        IonTitle,
-        IonButtons,
-        IonContent
-      ),
-    ],
-  });
+
+  constructor(private readonly createComponent: SpectatorFactory<ModalWrapperComponent>) {}
 
   title(title: string) {
     this.config.title = title;
@@ -127,6 +90,11 @@ export class ModalWrapperTestBuilder {
 }
 
 @Component({
+  template: ``,
+})
+export class DefaultTestComponent {}
+
+@Component({
   template: `
     <div>Some test content</div>
     <kirby-modal-footer>
@@ -160,15 +128,11 @@ export class DynamicFooterEmbeddedComponent {
 export class InputEmbeddedComponent {}
 
 @Component({
-  template: `
-    <kirby-page-progress> </kirby-page-progress>
-  `,
+  template: ` <kirby-page-progress> </kirby-page-progress> `,
 })
 export class StaticPageProgressEmbeddedComponent {}
 @Component({
-  template: `
-    <kirby-page-progress *ngIf="showPageProgress"> </kirby-page-progress>
-  `,
+  template: ` <kirby-page-progress *ngIf="showPageProgress"> </kirby-page-progress> `,
 })
 export class DynamicPageProgressEmbeddedComponent {
   showPageProgress = false;

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.testbuilder.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.testbuilder.ts
@@ -7,7 +7,7 @@ import { ModalWrapperComponent } from './modal-wrapper.component';
 export class ModalWrapperTestBuilder {
   private config: ModalConfig = {
     title: null,
-    component: DefaultTestComponent,
+    component: null,
     flavor: null,
   };
 
@@ -88,11 +88,6 @@ export class ModalWrapperTestBuilder {
     return spectator;
   }
 }
-
-@Component({
-  template: ``,
-})
-export class DefaultTestComponent {}
 
 @Component({
   template: `

--- a/package-lock.json
+++ b/package-lock.json
@@ -25007,9 +25007,9 @@
           "dev": true
         },
         "ssri": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+          "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8089,6 +8089,12 @@
       "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.1.4.tgz",
       "integrity": "sha512-lQ+FF7xUxxRuRqIY7H/lagnT3PhhSnnvtGHzjE5WZKwRyLU7glJfLys05SZ7zHlEr6RXWiqkmgWq4nCkcElR+g=="
     },
+    "date-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
+      "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==",
+      "dev": true
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -9790,9 +9796,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -21791,6 +21797,25 @@
       "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
       "dev": true
     },
+    "streamroller": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
+      "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
+      "dev": true,
+      "requires": {
+        "date-format": "^2.1.0",
+        "debug": "^4.1.1",
+        "fs-extra": "^8.1.0"
+      },
+      "dependencies": {
+        "date-format": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
+          "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
+          "dev": true
+        }
+      }
+    },
     "string-argv": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
@@ -24982,9 +25007,9 @@
           "dev": true
         },
         "ssri": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
-          "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #843

## What is the new behavior?

The field `collapseTitle` has been added to the `ModalConfig` type. 
When that is `true` the title will initially be part of the content. When scrolled out of view it will appear in the toolbar.

While i was in there i took the liberty documenting the inline footer from #958. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


