### PR TITLE
Flag: New danger color and heavier font weight

### DIFF
--- a/libs/core/src/scss/base/_typography.scss
+++ b/libs/core/src/scss/base/_typography.scss
@@ -2,6 +2,7 @@
 
 @import '~@fontsource/roboto/300.css';
 @import '~@fontsource/roboto/400.css';
+@import '~@fontsource/roboto/500.css';
 @import '~@fontsource/roboto/700.css';
 @import '~@fontsource/roboto/900.css';
 

--- a/libs/core/src/scss/base/_variables.scss
+++ b/libs/core/src/scss/base/_variables.scss
@@ -51,6 +51,7 @@ $line-height: (
 $font-weight: (
   light: 300,
   normal: 400,
+  medium: 500,
   bold: 700,
   // black will be treated as a named css color if not quoted
   'black': 900,

--- a/libs/core/src/scss/themes/_colors.scss
+++ b/libs/core/src/scss/themes/_colors.scss
@@ -28,6 +28,8 @@ $text-colors: (
   'danger': #ee0d0d,
 );
 $focus-ring-color: rgb(77 144 254);
+$red-30: #ff878a;
+$danger-background-weak: $red-30;
 
 @function get-all-colors() {
   @return map.merge(map.merge($brand-colors, $notification-colors), $system-colors);

--- a/libs/designsystem/src/lib/components/flag/flag.component.scss
+++ b/libs/designsystem/src/lib/components/flag/flag.component.scss
@@ -9,6 +9,7 @@
   border-radius: utils.size('xxxs');
   font-size: utils.font-size('n');
   padding: utils.size('xxxxs') utils.size('xxs');
+  font-weight: utils.font-weight('medium');
 
   &.sm {
     font-size: utils.font-size('s');

--- a/libs/designsystem/src/lib/components/flag/flag.component.scss
+++ b/libs/designsystem/src/lib/components/flag/flag.component.scss
@@ -27,12 +27,13 @@
       utils.$notification-colors,
       (
         'semi-light': utils.get-color('semi-light'),
+        'danger': utils.$danger-background-weak,
       )
     )
 {
   :host(.#{$color-name}) {
-    --kirby-flag-background-color: #{utils.get-color($color-name)};
+    --kirby-flag-background-color: #{$color-value};
     --kirby-flag-color: #{utils.get-color($color-name + '-contrast')};
-    --kirby-flag-border-color: #{utils.get-color($color-name)};
+    --kirby-flag-border-color: #{$color-value};
   }
 }

--- a/libs/designsystem/src/lib/components/flag/flag.component.spec.ts
+++ b/libs/designsystem/src/lib/components/flag/flag.component.spec.ts
@@ -7,6 +7,7 @@ import { FlagComponent } from './flag.component';
 const getColor = DesignTokenHelper.getColor;
 const size = DesignTokenHelper.size;
 const fontSize = DesignTokenHelper.fontSize;
+const fontWeight = DesignTokenHelper.fontWeight;
 
 describe('FlagComponent', () => {
   let spectator: SpectatorHost<FlagComponent>;
@@ -55,6 +56,10 @@ describe('FlagComponent', () => {
 
   it('should render with correct font-size', () => {
     expect(element).toHaveComputedStyle({ 'font-size': fontSize('n') });
+  });
+
+  it('should render with correct font-weight', () => {
+    expect(element).toHaveComputedStyle({ 'font-weight': fontWeight('medium') });
   });
 
   it('should render with correct padding', () => {

--- a/libs/designsystem/src/lib/components/flag/flag.component.spec.ts
+++ b/libs/designsystem/src/lib/components/flag/flag.component.spec.ts
@@ -114,7 +114,7 @@ describe('FlagComponent', () => {
   });
 
   describe(`when configured with themeColor`, () => {
-    const allowedThemeColors = ['success', 'warning', 'danger', 'semi-light'] as const;
+    const allowedThemeColors = ['success', 'warning', 'semi-light'] as const;
     type FlagThemeColor = typeof allowedThemeColors[number];
     const themeColors = allowedThemeColors.map((color) => getColor(color));
     themeColors.forEach((color) => {
@@ -127,6 +127,13 @@ describe('FlagComponent', () => {
           color: getColor(color.name as ThemeColorExtended, 'contrast'),
         });
       });
+    });
+
+    it(`should render with correct colors when themeColor = 'danger'`, async () => {
+      spectator.component.themeColor = 'danger';
+      spectator.detectChanges();
+
+      expect(element).toHaveComputedStyle({ 'background-color': '#ff878a' });
     });
 
     it(`should render with correct colors when themeColor = 'transparent'`, async () => {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2041 

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

We introduce a new color design token and use it for `danger` theme on Flag components. Other components' danger color is not affected.

We also introduce a new font weight `medium` with a CSS font-weight value of 500. This new font weight is used for text in Flag components.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


