### PR TITLE
Fix Card with background example

### DIFF
--- a/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.ts
@@ -11,7 +11,7 @@ import {
 })
 export class CardShowcaseComponent {
   exampleHtml: string =
-    require('!raw-loader!../../examples/card-example/card-example.component.html').default;
+    require('!raw-loader!../../examples/card-example/examples/card-example.component.html').default;
   properties: ApiDescriptionProperty[] = [
     {
       name: 'title',


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes NO ISSUE

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

Wrong template file path was used with `raw-loader`. This should be correct now.

https://github.com/kirbydesign/designsystem/pull/2163 was closed a bit too soon. This should have been part of that PR.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


