### PR TITLE
Remove option to inject IconSettings via IconRegistryService constructor

### DIFF
--- a/apps/cookbook/src/app/examples/examples.common.ts
+++ b/apps/cookbook/src/app/examples/examples.common.ts
@@ -1,8 +1,6 @@
 import { DropdownExampleComponent } from '~/app/examples/dropdown-example/dropdown-example.component';
 import { PagePullToRefreshExampleComponent } from '~/app/examples/page-example/pull-to-refresh/page-pull-to-refresh-example.component';
 
-import { IconSettings, ICON_SETTINGS } from '@kirbydesign/designsystem';
-
 import { AccordionExampleComponent } from './accordion-example/accordion-example.component';
 import { ActionSheetExampleComponent } from './action-sheet-example/action-sheet-example.component';
 import { AlertExampleComponent } from './alert-example/alert-example.component';
@@ -52,20 +50,6 @@ import { TabExampleComponent } from './tabs-example/tab/tab-example.component';
 import { TabsExampleComponent } from './tabs-example/tabs-example.component';
 import { ToastExampleComponent } from './toast-example/toast-example.component';
 import { ToggleExampleComponent } from './toggle-example/toggle-example.component';
-
-// Example of "custom" icons
-export const iconSettings: IconSettings = {
-  icons: [
-    {
-      name: 'football',
-      svg: 'assets/icons/football.svg',
-    },
-    {
-      name: 'umbrella',
-      svg: 'assets/icons/umbrella.svg',
-    },
-  ],
-};
 
 export const COMPONENT_DECLARATIONS: any[] = [
   ExamplesComponent,
@@ -121,6 +105,3 @@ export const COMPONENT_DECLARATIONS: any[] = [
   SectionHeaderExampleComponent,
   ListExperimentalExampleComponent,
 ];
-
-// Configure custom icons (used by example to show the usage of custom icons)
-export const PROVIDER_DECLARATIONS: any[] = [{ provide: ICON_SETTINGS, useValue: iconSettings }];

--- a/libs/designsystem/src/lib/components/icon/icon-registry.service.spec.ts
+++ b/libs/designsystem/src/lib/components/icon/icon-registry.service.spec.ts
@@ -1,5 +1,4 @@
 import { IconRegistryService } from './icon-registry.service';
-import { IconSettings } from './icon-settings';
 
 describe('KirbyIconRegistryService', () => {
   let service: IconRegistryService;
@@ -10,21 +9,6 @@ describe('KirbyIconRegistryService', () => {
 
   it('should create service', () => {
     expect(service).toBeTruthy();
-  });
-
-  it('should register icons if injected', () => {
-    const consoleWarnSpy = spyOn(console, 'warn');
-    const iconSettings: IconSettings = {
-      icons: [
-        { name: 'name1', svg: 'svg1' },
-        { name: 'name2', svg: 'svg2' },
-      ],
-    };
-    service = new IconRegistryService(iconSettings);
-    expect(service.getIcons()).toEqual(iconSettings.icons);
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      'Use of IconSettings is deprecated, use IconRegistryService instead'
-    );
   });
 
   describe('getIcon', () => {

--- a/libs/designsystem/src/lib/components/icon/icon-registry.service.ts
+++ b/libs/designsystem/src/lib/components/icon/icon-registry.service.ts
@@ -1,19 +1,12 @@
-import { Inject, Injectable, Optional } from '@angular/core';
+import { Injectable } from '@angular/core';
 
-import { Icon, IconSettings, ICON_SETTINGS } from './icon-settings';
+import { Icon } from './icon-settings';
 
 @Injectable({
   providedIn: 'root',
 })
 export class IconRegistryService {
   private iconRegistry = new Map<string, string>();
-
-  constructor(@Optional() @Inject(ICON_SETTINGS) iconSettings?: IconSettings) {
-    if (iconSettings) {
-      this.addIcons(iconSettings.icons);
-      console.warn(`Use of IconSettings is deprecated, use IconRegistryService instead`);
-    }
-  }
 
   public addIcon(iconName: string, svgPath: string): void {
     if (!this.iconRegistry.has(iconName)) {

--- a/libs/designsystem/src/lib/components/icon/icon-settings.ts
+++ b/libs/designsystem/src/lib/components/icon/icon-settings.ts
@@ -1,5 +1,3 @@
-import { InjectionToken } from '@angular/core';
-
 export interface Icon {
   name: string;
   svg?: string;
@@ -8,5 +6,3 @@ export interface Icon {
 export interface IconSettings {
   icons: Icon[];
 }
-
-export const ICON_SETTINGS = new InjectionToken<IconSettings>('IconSettings');

--- a/libs/designsystem/src/lib/components/icon/index.ts
+++ b/libs/designsystem/src/lib/components/icon/index.ts
@@ -1,5 +1,5 @@
 export { IconComponent, IconSize } from './icon.component';
 export { IconModule } from './icon.module';
-export { IconSettings, ICON_SETTINGS, Icon } from './icon-settings';
+export { IconSettings, Icon } from './icon-settings';
 export { defaultIcons } from './kirby-icon-settings';
 export { IconRegistryService } from './icon-registry.service';


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2062

## What is the new behavior?
The constructor for the IconRegistryService no longer accounts for any injected IconSettings. 

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Icons can no longer be injected in a module like this: 
```
providers: [
 { 
    provide: ICON_SETTINGS, 
    useValue: iconSettings 
 }
]
```
Instead, the IconRegistryService should be used, as [per the documentation](https://cookbook.kirby.design/#/home/showcase/icon): 
```
export class @NGModule {
  constructor(iconRegistryService: IconRegistryService) {
    iconRegistryService.addIcons(this.icons);
  }
}
```