### PR TITLE
Remove deprecated okBtnText and cancelBtnText from AlertConfig

### DIFF
--- a/apps/cookbook/src/app/examples/chart-deprecated-example/examples/chart-deprecated-example-bar.component.ts
+++ b/apps/cookbook/src/app/examples/chart-deprecated-example/examples/chart-deprecated-example-bar.component.ts
@@ -38,7 +38,7 @@ const config = {
   this.modalController.showAlert({
     title: 'Clicked chart',
     message: 'You clicked on year: ' + ev.point.category,
-    okBtnText: 'Ok',
+    okBtn: 'Ok',
   });
 
   this.selectedYear = ev.point.category;
@@ -109,7 +109,7 @@ export class ChartDeprecatedExampleBarComponent {
     this.modalController.showAlert({
       title: 'Clicked chart',
       message: 'You clicked on year: ' + ev.point.category,
-      okBtnText: 'Ok',
+      okBtn: 'Ok',
     });
 
     this.selectedYear = ev.point.category;

--- a/apps/cookbook/src/app/examples/chart-deprecated-example/examples/chart-deprecated-example-column.component.ts
+++ b/apps/cookbook/src/app/examples/chart-deprecated-example/examples/chart-deprecated-example-column.component.ts
@@ -39,7 +39,7 @@ const config = {
       this.modalController.showAlert({
     title: 'Clicked chart',
     message: 'You clicked on column: ' + ev.point.category,
-    okBtnText: 'Ok',
+    okBtn: 'Ok',
   });
 
   this.selectedIdx = this.categories.indexOf(ev.point.category);
@@ -94,7 +94,7 @@ export class ChartDeprecatedExampleColumnComponent {
     this.modalController.showAlert({
       title: 'Clicked chart',
       message: 'You clicked on column: ' + ev.point.category,
-      okBtnText: 'Ok',
+      okBtn: 'Ok',
     });
 
     this.selectedIdx = this.categories.indexOf(ev.point.category);

--- a/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.ts
+++ b/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.ts
@@ -13,8 +13,8 @@ export class SlideButtonExampleComponent {
     const config: AlertConfig = {
       title: 'Your alert',
       message: 'Your alert message',
-      okBtnText: 'Ok',
-      cancelBtnText: 'Cancel',
+      okBtn: 'Ok',
+      cancelBtn: 'Cancel',
     };
     this.modalController.showAlert(config, this.onAlertClosed);
   }

--- a/libs/designsystem/src/lib/components/modal/alert/alert.component.html
+++ b/libs/designsystem/src/lib/components/modal/alert/alert.component.html
@@ -8,22 +8,22 @@
   <div class="buttongroup">
     <button
       kirby-button
-      *ngIf="cancelBtnText"
+      *ngIf="cancelBtn"
       attentionLevel="3"
       class="cancel-btn"
       (click)="onCancel()"
     >
-      {{ cancelBtnText }}
+      {{ cancelBtn }}
     </button>
     <button
       kirby-button
-      [size]="cancelBtnText ? null : 'lg'"
+      [size]="cancelBtn ? null : 'lg'"
       attentionLevel="1"
       class="ok-btn"
       [isDestructive]="okBtnIsDestructive"
       (click)="onOk()"
     >
-      {{ okBtnText }}
+      {{ okBtn }}
     </button>
   </div>
 </article>

--- a/libs/designsystem/src/lib/components/modal/alert/alert.component.spec.ts
+++ b/libs/designsystem/src/lib/components/modal/alert/alert.component.spec.ts
@@ -32,7 +32,7 @@ describe('AlertComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(AlertComponent);
     component = fixture.componentInstance;
-    component.okBtnText = 'Test OK Button Text';
+    component.okBtn = 'Test OK Button Text';
     fixture.detectChanges();
   });
 
@@ -45,7 +45,7 @@ describe('AlertComponent', () => {
       const expected = 'Test OK Button Text';
       const okButton = fixture.debugElement.query(By.css('.ok-btn'));
 
-      expect(component.okBtnText).toEqual(expected);
+      expect(component.okBtn).toEqual(expected);
       expect(okButton.nativeElement.innerText).toEqual(expected);
     });
 
@@ -67,7 +67,7 @@ describe('AlertComponent', () => {
 
     it('should have default size', () => {
       const okButton = fixture.debugElement.query(By.css('.ok-btn'));
-      component.cancelBtnText = 'Test Cancel Button Text';
+      component.cancelBtn = 'Test Cancel Button Text';
       fixture.detectChanges();
 
       expect(okButton.attributes['ng-reflect-size']).toBeUndefined();
@@ -75,7 +75,7 @@ describe('AlertComponent', () => {
 
     it('should have large ok button when no cancel button', () => {
       const okButton = fixture.debugElement.query(By.css('.ok-btn'));
-      component.cancelBtnText = null;
+      component.cancelBtn = null;
       fixture.detectChanges();
 
       expect(okButton.attributes['ng-reflect-size']).toBe('lg');
@@ -85,7 +85,7 @@ describe('AlertComponent', () => {
   describe('cancel button', () => {
     it('should render', () => {
       const expected = 'Test Cancel Button Text';
-      component.cancelBtnText = 'Test Cancel Button Text';
+      component.cancelBtn = 'Test Cancel Button Text';
       fixture.detectChanges();
       const cancelButton = fixture.debugElement.query(By.css('.cancel-btn'));
 
@@ -93,7 +93,7 @@ describe('AlertComponent', () => {
     });
 
     it('should not render when cancelBtn not set', () => {
-      component.cancelBtnText = null;
+      component.cancelBtn = null;
       fixture.detectChanges();
       const cancelButton = fixture.debugElement.query(By.css('.cancel-btn'));
 
@@ -129,7 +129,7 @@ describe('AlertComponent with okBtn', () => {
 
   beforeEach(() => {
     spectator = createHost(`
-    <kirby-alert okBtnText="OK Button Text">
+    <kirby-alert okBtn="OK Button Text">
     </kirby-alert>
     `);
     element = spectator.element;

--- a/libs/designsystem/src/lib/components/modal/alert/alert.component.ts
+++ b/libs/designsystem/src/lib/components/modal/alert/alert.component.ts
@@ -29,9 +29,9 @@ export class AlertComponent implements AfterViewInit {
 
   @Input() iconName: string;
   @Input() iconThemeColor: string;
-  @Input() okBtnText: string;
+  @Input() okBtn: string;
   @Input() okBtnIsDestructive: boolean;
-  @Input() cancelBtnText: string;
+  @Input() cancelBtn: string;
 
   constructor(private elementRef: ElementRef<HTMLElement>, private windowRef: WindowRef) {}
 

--- a/libs/designsystem/src/lib/components/modal/alert/config/alert-config.ts
+++ b/libs/designsystem/src/lib/components/modal/alert/config/alert-config.ts
@@ -3,17 +3,6 @@ import { Observable } from 'rxjs';
 export interface AlertConfig {
   title: string | Observable<string>;
   message?: string | Observable<string>;
-
-  /**
-   * @deprecated Will be deprecated in next major version. Use `okBtn` instead.
-   */
-  okBtnText?: string;
-
-  /**
-   * @deprecated Will be deprecated in next major version. Use `cancelBtn` instead.
-   */
-  cancelBtnText?: string;
-
   cancelBtn?: string;
 
   icon?: {

--- a/libs/designsystem/src/lib/components/modal/services/alert.helper.ts
+++ b/libs/designsystem/src/lib/components/modal/services/alert.helper.ts
@@ -30,7 +30,7 @@ export class AlertHelper {
   private getComponentProps(config: AlertConfig) {
     return {
       ...config,
-      okBtn: this.getOkBtnText(config),
+      okBtn: this.getOkBtn(config),
       cancelBtn: config.cancelBtn,
       okBtnIsDestructive: this.getOkBtnIsDestructive(config),
       iconName: config.icon && config.icon.name,
@@ -38,7 +38,7 @@ export class AlertHelper {
     };
   }
 
-  private getOkBtnText(config: AlertConfig) {
+  private getOkBtn(config: AlertConfig) {
     let text: string;
 
     if (config.okBtn) {

--- a/libs/designsystem/src/lib/components/modal/services/alert.helper.ts
+++ b/libs/designsystem/src/lib/components/modal/services/alert.helper.ts
@@ -31,7 +31,7 @@ export class AlertHelper {
     return {
       ...config,
       okBtn: this.getOkBtnText(config),
-      cancelBtn: this.getCancelBtnText(config),
+      cancelBtn: config.cancelBtn,
       okBtnIsDestructive: this.getOkBtnIsDestructive(config),
       iconName: config.icon && config.icon.name,
       iconThemeColor: config.icon && config.icon.themeColor,
@@ -53,9 +53,5 @@ export class AlertHelper {
 
   getOkBtnIsDestructive(config) {
     return typeof config.okBtn === 'object' ? config.okBtn.isDestructive : undefined;
-  }
-
-  private getCancelBtnText(config: AlertConfig) {
-    return config.cancelBtn;
   }
 }

--- a/libs/designsystem/src/lib/components/modal/services/alert.helper.ts
+++ b/libs/designsystem/src/lib/components/modal/services/alert.helper.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
 import { ModalController } from '@ionic/angular';
 
-import { AlertConfig } from '../alert/config/alert-config';
 import { AlertComponent } from '../alert/alert.component';
+import { AlertConfig } from '../alert/config/alert-config';
+
 import { Overlay } from './modal.interfaces';
 
 @Injectable()
@@ -29,8 +30,8 @@ export class AlertHelper {
   private getComponentProps(config: AlertConfig) {
     return {
       ...config,
-      okBtnText: this.getOkBtnText(config),
-      cancelBtnText: this.getCancelBtnText(config),
+      okBtn: this.getOkBtnText(config),
+      cancelBtn: this.getCancelBtnText(config),
       okBtnIsDestructive: this.getOkBtnIsDestructive(config),
       iconName: config.icon && config.icon.name,
       iconThemeColor: config.icon && config.icon.themeColor,

--- a/libs/designsystem/src/lib/components/modal/services/alert.helper.ts
+++ b/libs/designsystem/src/lib/components/modal/services/alert.helper.ts
@@ -40,12 +40,7 @@ export class AlertHelper {
 
   private getOkBtnText(config: AlertConfig) {
     let text: string;
-    if (config.okBtnText) {
-      console.warn(
-        '`okBtnText` will be deprecated on next major version. Please use `okBtn` instead.'
-      );
-      text = config.okBtnText;
-    }
+
     if (config.okBtn) {
       if (typeof config.okBtn === 'string') {
         text = config.okBtn;
@@ -61,11 +56,6 @@ export class AlertHelper {
   }
 
   private getCancelBtnText(config: AlertConfig) {
-    if (config.cancelBtnText) {
-      console.warn(
-        '`cancelBtnText` will be deprecated on next major version. Please use `cancelBtn` instead.'
-      );
-    }
-    return config.cancelBtn || config.cancelBtnText;
+    return config.cancelBtn;
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?
This PR closes #2063 

## What is the new behavior?
`okBtnText` and `cancelBtnText` properties of the AlertConfig interface has been removed. The AlertConfig interface is used by consumers to configure the `ModalController` with the alert flavor. 

Additionally, the input-props of the AlertComponent has been changed to reflect this. This makes it a breaking change to the alert component too, but this should have low to no impact on consumers, as the alert component should not be used on its own, but rather through the ModalController/AlertHelper configuration. 

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

`okBtnText` and `cancelBtnText` of `AlertConfig` are removed, and the existing `okBtn` and `cancelBtn` should be used instead, as a direct replacement for these. 

If for some reason the AlertComponent is used directly in markup as `kirby-alert` instead of passing the config to the modalController, the input bindings of `kirby-alert` should be changed accordingly, to `okBtn` and `cancelBtn`. 

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] ~~Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


