### PR TITLE
Remove deprecated dim property on ModalConfig

### DIFF
--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/config/modal-config.ts
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/config/modal-config.ts
@@ -16,10 +16,6 @@ export interface ModalConfig {
   modalRoute?: ActivatedRoute;
   siblingModalRouteActivated$?: Observable<ActivatedRoute>;
   flavor?: ModalFlavor;
-  /**
-   * @deprecated Will be removed in next major version.
-   */
-  dim?: number;
   componentProps?: { [key: string]: any };
   // the supplementary action is only available in the drawer
   drawerSupplementaryAction?: DrawerSupplementaryAction;

--- a/libs/designsystem/src/lib/components/modal/services/modal.controller.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal.controller.ts
@@ -74,9 +74,6 @@ export class ModalController implements OnDestroy {
   }
 
   public async showModal(config: ModalConfig, onClose?: (data?: any) => void): Promise<void> {
-    if (config.hasOwnProperty('dim')) {
-      console.warn('ModalConfig.dim is deprecated - please remove from your configuration.');
-    }
     await this.showAndRegisterOverlay(() => this.modalHelper.showModalWindow(config), onClose);
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2064

## What is the new behavior?
Dim is removed 🥳 

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Dim is no longer a configurable option, so it should be removed from ModalConfig. 


