### PR TITLE
Remove deprecated 'dataLabels' property

### DIFF
--- a/libs/designsystem/src/lib/components/chart/chart.component.spec.ts
+++ b/libs/designsystem/src/lib/components/chart/chart.component.spec.ts
@@ -34,7 +34,7 @@ describe('ChartComponent', () => {
 
     beforeEach(() => {
       updateFnSpy = spyOn<any>(component, 'updateLabels');
-      spectator.setInput('dataLabels', ['1', '2']);
+      spectator.setInput('labels', ['1', '2']);
     });
 
     it('should not call the corresponding update function', () => {

--- a/libs/designsystem/src/lib/components/chart/chart.component.ts
+++ b/libs/designsystem/src/lib/components/chart/chart.component.ts
@@ -21,9 +21,6 @@ import {
   ChartType,
 } from './chart.types';
 
-const DATA_LABELS_DEPRECATION_WARNING =
-  'Deprecation warning: The "kirby-chart" input property "dataLabels" will be removed in a future release of Kirby designsystem. Use "labels" instead. For more information see the following announcement: https://github.com/kirbydesign/designsystem/discussions/1980';
-
 @Component({
   selector: 'kirby-chart',
   templateUrl: './chart.component.html',
@@ -34,18 +31,7 @@ export class ChartComponent implements AfterViewInit, OnChanges {
   @Input() type: ChartType = 'column';
   @Input() data: ChartDataset[] | number[];
 
-  private _labels: string[] | string[][];
-
-  get labels(): string[] | string[][] {
-    return this._labels;
-  }
-  @Input() set labels(value: string[] | string[][]) {
-    this._labels = value;
-  }
-  @Input() set dataLabels(value: string[] | string[][]) {
-    console.warn(DATA_LABELS_DEPRECATION_WARNING);
-    this._labels = value;
-  }
+  @Input() labels: string[] | string[][];
 
   @Input() customOptions?: ChartOptions;
   @Input() dataLabelOptions?: ChartDataLabelOptions;
@@ -98,10 +84,8 @@ export class ChartComponent implements AfterViewInit, OnChanges {
     if (this.chartHasBeenRendered) {
       let shouldRedrawChart = false;
 
-      // TODO: Remove 'dataLabels' key when the input property is removed
       const keyUpdateFnPairs = {
         data: () => this.updateData(),
-        dataLabels: () => this.updateLabels(),
         labels: () => this.updateLabels(),
         type: () => this.updateType(),
         customOptions: () => this.updateCustomOptions(),

--- a/libs/designsystem/testing-base/src/lib/components/mock.chart.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.chart.component.ts
@@ -25,7 +25,6 @@ export class MockChartComponent {
   @Input() type: ChartType;
   @Input() data: ChartDataset[] | number[];
   @Input() labels: string[] | string[][];
-  @Input() dataLabels: string[] | string[][];
   @Input() customOptions: ChartOptions;
   @Input() dataLabelOptions: ChartDataLabelOptions;
   @Input() annotations: AnnotationOptions[];


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2068

## What is the new behavior?

The dataLabels property has been fully removed. 

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

