### PR TITLE
Remove deprecated toast danger MessageType

### DIFF
--- a/apps/cookbook/src/app/examples/alert-example/alert-example.component.ts
+++ b/apps/cookbook/src/app/examples/alert-example/alert-example.component.ts
@@ -140,7 +140,7 @@ this.modalController.showAlert(config);`;
   private onAlertDestructiveClosed(result?: boolean) {
     const config: ToastConfig = {
       message: result ? 'Message deleted' : 'Nothing happened',
-      messageType: result ? 'danger' : 'success',
+      messageType: result ? 'warning' : 'success',
       durationInMs: 1500,
     };
     this.toastController.showToast(config);

--- a/apps/cookbook/src/app/examples/list-swipe-example/list-swipe-example.component.ts
+++ b/apps/cookbook/src/app/examples/list-swipe-example/list-swipe-example.component.ts
@@ -136,7 +136,7 @@ export class ListSwipeExampleComponent {
     item.deleted = !item.deleted;
     const config: ToastConfig = {
       message: `Item '${item.title}' has been deleted.`,
-      messageType: 'danger',
+      messageType: 'warning',
       durationInMs: 1500,
     };
     this.toastController.showToast(config);

--- a/libs/designsystem/src/lib/components/toast/config/toast-config.ts
+++ b/libs/designsystem/src/lib/components/toast/config/toast-config.ts
@@ -5,7 +5,4 @@ export interface ToastConfig {
   animated?: boolean;
 }
 
-/**
- * 'danger' is deprecated. Use Kirby Alert for critical events
- */
-export type MessageType = 'success' | 'warning' | 'danger';
+export type MessageType = 'success' | 'warning';

--- a/libs/designsystem/src/lib/components/toast/services/toast.helper.spec.ts
+++ b/libs/designsystem/src/lib/components/toast/services/toast.helper.spec.ts
@@ -61,13 +61,12 @@ describe('ToastHelper', () => {
     });
 
     describe('when configured with messageType', () => {
-      type MessageType = 'success' | 'warning' | 'danger';
-      type NotificationColor = 'success' | 'warning' | 'danger';
+      type MessageType = 'success' | 'warning';
+      type NotificationColor = 'success' | 'warning';
 
       const messageTypeColorMap = new Map<MessageType, NotificationColor>([
         ['success', 'success'],
         ['warning', 'warning'],
-        ['danger', 'danger'],
       ]);
 
       messageTypeColorMap.forEach((notificationColor, messageType) => {
@@ -79,25 +78,11 @@ describe('ToastHelper', () => {
           const ionToast = window.document.getElementsByTagName('ion-toast')[0];
           await TestHelper.whenReady(ionToast);
           const toastWrapper = ionToast.shadowRoot.querySelector('.toast-wrapper');
-          const expectedColor =
-            messageType === 'danger' ? getColor('warning') : getColor(notificationColor);
+
           expect(toastWrapper).toHaveComputedStyle({
-            'background-color': expectedColor,
+            'background-color': getColor(notificationColor),
           });
         });
-      });
-
-      it(`should display warning in console when using 'danger' MessageType`, async () => {
-        spyOn(console, 'warn');
-
-        overlay = await spectator.service.showToast({
-          message: 'Test message',
-          messageType: 'danger',
-        });
-
-        expect(console.warn).toHaveBeenCalledWith(
-          `[DEPRECATED] 'danger' message type is deprecated. Use Kirby Alerts for critical warnings. Toast will be shown as 'warning'`
-        );
       });
     });
   });

--- a/libs/designsystem/src/lib/components/toast/services/toast.helper.ts
+++ b/libs/designsystem/src/lib/components/toast/services/toast.helper.ts
@@ -30,14 +30,6 @@ export class ToastHelper {
   private getCssClass(messageType: MessageType): string {
     let cssClass = ToastHelper.CSS_CLASS;
 
-    if (messageType === 'danger') {
-      console.warn(
-        `[DEPRECATED] 'danger' message type is deprecated. Use Kirby Alerts for critical warnings. Toast will be shown as 'warning'`
-      );
-
-      messageType = 'warning';
-    }
-
     if (messageType) {
       cssClass += ' ' + messageType;
     }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #1979

## What is the new behavior?
So long danger toast 

![image](https://user-images.githubusercontent.com/42470636/164618318-4e8da641-cb13-4b04-8b4b-1b9a1d12b629.png)

More details in #1085 and #1979

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [ ] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] ~~Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


