### PR TITLE
Add back CSS Custom Property px unit

### DIFF
--- a/libs/designsystem/src/lib/components/card/card-header/card-header.component.scss
+++ b/libs/designsystem/src/lib/components/card/card-header/card-header.component.scss
@@ -58,6 +58,6 @@ $notification-levels-class-selectors: utils.keys-to-classes($notification-levels
 
   h2 {
     --kirby-internal-card-header-line-height: #{utils.line-height('n')};
-    --kirby-internal-card-header-margin-bottom: 0;
+    --kirby-internal-card-header-margin-bottom: 0px;
   }
 }

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.scss
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.scss
@@ -62,8 +62,8 @@ ion-header ion-toolbar {
 
 :host {
   --vh100: var(--vh, 1vh) * 100; /// Fixes an issue with vh units on iOS Safari
-  --header-height: 0;
-  --footer-height: 0;
+  --header-height: 0px;
+  --footer-height: 0px;
 
   &.drawer {
     // Prevent iOS safe-area padding-top on drawer flavor

--- a/libs/designsystem/src/lib/components/radio/radio.component.scss
+++ b/libs/designsystem/src/lib/components/radio/radio.component.scss
@@ -110,7 +110,7 @@ ion-radio {
   }
 
   &.radio-checked {
-    --border-width: 0;
+    --border-width: 0px;
 
     &:not(:focus):not(.radio-disabled) {
       &::part(container) {

--- a/libs/designsystem/src/lib/components/tabs/tabs.component.scss
+++ b/libs/designsystem/src/lib/components/tabs/tabs.component.scss
@@ -1,7 +1,7 @@
 @use '~@kirbydesign/core/src/scss/utils';
 
 :host(:not(.tab-bar-bottom-hidden)) {
-  --kirby-page-footer-safe-area-bottom: 0;
+  --kirby-page-footer-safe-area-bottom: 0px;
 }
 
 ion-tabs {

--- a/libs/designsystem/src/lib/components/tabs/tabs.component.spec.ts
+++ b/libs/designsystem/src/lib/components/tabs/tabs.component.spec.ts
@@ -59,10 +59,10 @@ describe('TabsComponent', () => {
           expect(ionTabBarElm).not.toHaveComputedStyle({ display: 'none' });
         });
 
-        it('should set footer safe area to 0', () => {
+        it('should set footer safe area to 0px', () => {
           const ionTabBarElm = spectator.query('ion-tab-bar');
           expect(ionTabBarElm).toHaveComputedStyle({
-            '--kirby-page-footer-safe-area-bottom': '0',
+            '--kirby-page-footer-safe-area-bottom': '0px',
           });
         });
       });


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue. 

## What is the new behavior?

The issue described in #2158 is also present for other CSS custom properties, so I have added px back everywhere #2146 removed it for CSS Custom Properties. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


