### PR TITLE
Remove deprecated list directives

### DIFF
--- a/libs/designsystem/src/lib/components/list/index.ts
+++ b/libs/designsystem/src/lib/components/list/index.ts
@@ -11,9 +11,7 @@ export { ListSwipeAction, ListSwipeActionType, ListSwipeEnd } from './list-swipe
 
 export { InfiniteScrollDirective } from './directives/infinite-scroll.directive';
 export { ListItemColorDirective } from './directives/list-item-color.directive';
-export { ListFlexItemDirective } from './list.directive';
 export { ListHeaderDirective } from './list.directive';
-export { ListItemDirective } from './list.directive';
 export { ListItemTemplateDirective } from './list.directive';
 export { ListSectionHeaderDirective } from './list.directive';
 export { ListFooterDirective } from './list.directive';

--- a/libs/designsystem/src/lib/components/list/list.directive.ts
+++ b/libs/designsystem/src/lib/components/list/list.directive.ts
@@ -1,28 +1,6 @@
 import { Directive } from '@angular/core';
 
 @Directive({
-  selector: '[kirbyListItem]',
-})
-export class ListItemDirective {
-  constructor() {
-    console.warn(
-      '*kirbyListItem directive is deprecated - please use *kirbyListItemTemplate directive instead.'
-    );
-  }
-}
-
-@Directive({
-  selector: '[kirbyListFlexItem]',
-})
-export class ListFlexItemDirective {
-  constructor() {
-    console.warn(
-      '*kirbyListFlexItem directive is deprecated - please use *kirbyListItemTemplate directive instead.'
-    );
-  }
-}
-
-@Directive({
   selector: '[kirbyListItemTemplate]',
 })
 export class ListItemTemplateDirective {}

--- a/libs/designsystem/src/lib/components/list/list.module.ts
+++ b/libs/designsystem/src/lib/components/list/list.module.ts
@@ -13,10 +13,8 @@ import { ListItemComponent } from './list-item/list-item.component';
 import { ListSectionHeaderComponent } from './list-section-header/list-section-header.component';
 import { ListComponent } from './list.component';
 import {
-  ListFlexItemDirective,
   ListFooterDirective,
   ListHeaderDirective,
-  ListItemDirective,
   ListItemTemplateDirective,
   ListSectionHeaderDirective,
 } from './list.directive';
@@ -24,8 +22,6 @@ import {
 const exportedDeclarations = [
   ListComponent,
   ListItemComponent,
-  ListItemDirective,
-  ListFlexItemDirective,
   ListItemTemplateDirective,
   ListSectionHeaderComponent,
   ListSectionHeaderDirective,

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,7 @@ In each `.scss` file where you need to access the Sass utility functions from Ki
 ```
 
 #### Generic Print Styles (Optional)
+
 Kirby also provides a generic print stylesheet. It includes the basics. You most likely have to add local print styles specific to your app as well.
 
 Import it into your app, e.g., in `src/styles.scss` or in your local print stylesheet if you have one:
@@ -170,22 +171,6 @@ Remove any previously installed dev-dependencies for `sass-extract` , `sass-extr
 This can be done by the following command:
 
 `npm uninstall --save-dev sass-extract sass-extract-loader ng-mocks`
-
-#### Deprecation
-
-The following legacy components have been removed:
-
-- `ListItemComponent` (`<kirby-list-item>`)
-- `ListFlexItemComponent` (`<kirby-list-flex-item>`)
-- `ListCellComponent` (`<kirby-list-cell>`)
-- `ListCellLineComponent` (`<kirby-list-cell-line>`)
-
-The following directives have been deprecated and will be removed in future versions:
-
-- `ListItemDirective` (`[kirbyListItem]`)
-- `ListFlexItemDirective` (`[kirbyListFlexItem]`)
-
-_Please see the [list documentation][kirby.cookbook.list] on how to use the list component(s) and directives._
 
 ### Icons
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2066 

## What is the new behavior?
There are now no more deprecated list directives.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


