### PR TITLE
Move shared functionality to utilities partial

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -26,6 +26,12 @@
       {
         "ignore": ["custom-properties"]
       }
+    ],
+    "declaration-block-no-redundant-longhand-properties": [
+      true,
+      {
+        "ignoreShorthands": ["transition"]
+      }
     ]
   }
 }

--- a/libs/core/src/scss/interaction-state/_focus.scss
+++ b/libs/core/src/scss/interaction-state/_focus.scss
@@ -1,4 +1,5 @@
 @use '../utils';
+@use 'utilities';
 
 // ---------------------------------------------------------------------------
 // The apply-focus-visible mixin is used by most interactive elements to apply
@@ -60,7 +61,8 @@
 
 @mixin _focus-ring($shadow, $gap) {
   $stroke-width: utils.size('xxxxs');
+
   box-shadow: #{$shadow}, 0 0 0 $gap #{utils.get-color('background-color')},
     0 0 0 $gap + $stroke-width utils.$focus-ring-color;
-  transition: box-shadow utils.get-transition-duration('quick');
+  transition: box-shadow utilities.$default-transition-duration;
 }

--- a/libs/core/src/scss/interaction-state/_hover.scss
+++ b/libs/core/src/scss/interaction-state/_hover.scss
@@ -1,9 +1,11 @@
 @use 'layer';
+@use 'utilities';
 @use '../utils';
 
-@mixin apply-hover($loudness: layer.$default-loudness, $flip: false) {
+@mixin apply-hover($loudness: utilities.$default-loudness, $flip: false) {
   @include utils.hover {
     @include layer.apply-state($loudness, $flip);
+
     cursor: pointer;
     @content;
   }

--- a/libs/core/src/scss/interaction-state/_layer.scss
+++ b/libs/core/src/scss/interaction-state/_layer.scss
@@ -1,26 +1,22 @@
 @use 'sass:list';
 @use 'sass:math';
 @use 'sass:meta';
+@use 'utilities';
 @use '../utils';
 
 // Put state layer above content layer as default.
 // You can change move the content layer on top by declaring e.g.:
-//
 //    --content-layer-z-index: calc(#{layer.$state-layer-z-index} + 1);
-//
 // in a component that uses interaction state layer.
 $_content-layer-z-index: utils.z('default');
 $state-layer-z-index: $_content-layer-z-index + 1;
-
 $_dark: utils.get-color('black');
 $_light: utils.get-color('black-contrast');
-
-$default-loudness: 'm';
 
 /// Prepare state layer and content layer for interaction state changes.
 /// Should be initialized before applying hover.
 /// @param {*} $border-width [0px] - Necessary for making the state layer cover border (if any) on parent element
-@mixin initialize-layer($border-width: 0px) {
+@mixin initialize-layer($border-width: 0) {
   --state-layer-opacity: 0;
   --state-layer-background-color: $_dark;
 
@@ -33,6 +29,7 @@ $default-loudness: 'm';
 
   .state-layer {
     position: absolute;
+
     // When we use negated value of border-width on parent for inset
     // then the hover effect (state layer) will also cover the border.
     // Otherwise the border will not be affected on hover.
@@ -41,7 +38,6 @@ $default-loudness: 'm';
     overflow: hidden;
     pointer-events: none;
     border-radius: inherit;
-
     z-index: $state-layer-z-index;
 
     &::before {
@@ -51,14 +47,13 @@ $default-loudness: 'm';
       position: absolute;
       pointer-events: none;
       inset: -50%;
-
       opacity: var(--state-layer-opacity, 0);
       background-color: var(--state-layer-background-color, $_dark);
     }
   }
 }
 
-@mixin apply-state($loudness: $default-loudness, $flip: false) {
+@mixin apply-state($loudness: utilities.$default-loudness, $flip: false) {
   $loudness-percent: utils.get-loudness($loudness);
 
   @if not(meta.type-of($loudness-percent) == number and math.unit($loudness-percent) == '%') {
@@ -86,6 +81,7 @@ $default-loudness: 'm';
   @if list.length($property-list) == 0 {
     $property-list: all;
   }
+
   transition-property: $property-list;
   transition-duration: utils.get-transition-duration('quick');
   transition-timing-function: utils.get-transition-easing('static');

--- a/libs/core/src/scss/interaction-state/_layer.scss
+++ b/libs/core/src/scss/interaction-state/_layer.scss
@@ -41,7 +41,7 @@ $_light: utils.get-color('black-contrast');
     z-index: $state-layer-z-index;
 
     &::before {
-      @include transition;
+      @include utilities.transition;
 
       content: '';
       position: absolute;
@@ -73,17 +73,4 @@ $_light: utils.get-color('black-contrast');
   .content-layer {
     @content;
   }
-}
-
-/// Apply streamlined transition to interaction state changes
-/// @param {*} $property-list [all]
-@mixin transition($property-list...) {
-  @if list.length($property-list) == 0 {
-    $property-list: all;
-  }
-
-  transition-property: $property-list;
-  transition-duration: utils.get-transition-duration('quick');
-  transition-timing-function: utils.get-transition-easing('static');
-  transition-delay: 0ms;
 }

--- a/libs/core/src/scss/interaction-state/_utilities.scss
+++ b/libs/core/src/scss/interaction-state/_utilities.scss
@@ -1,10 +1,13 @@
 @use 'sass:color';
-@use 'layer';
 @use '../utils';
 
-@function get-state-color($variant, $loudness: layer.$default-loudness, $flip: false) {
-  $_background: utils.get-color($variant, $getValueOnly: true);
+// ---------------------------------------------------------------------------
+// Shared interaction state variables
+// ---------------------------------------------------------------------------
+$default-loudness: 'm';
 
+@function get-state-color($variant, $loudness: $default-loudness, $flip: false) {
+  $_background: utils.get-color($variant, $getValueOnly: true);
   $_lightness: 0% !default;
 
   @if $flip {

--- a/libs/core/src/scss/interaction-state/_utilities.scss
+++ b/libs/core/src/scss/interaction-state/_utilities.scss
@@ -3,6 +3,7 @@
 @use '../utils';
 
 $default-loudness: 'm';
+$default-transition-duration: utils.get-transition-duration('quick');
 
 @function get-state-color($variant, $loudness: $default-loudness, $flip: false) {
   $_background: utils.get-color($variant, $getValueOnly: true);
@@ -28,7 +29,7 @@ $default-loudness: 'm';
   }
 
   transition-property: $property-list;
-  transition-duration: utils.get-transition-duration('quick');
+  transition-duration: $default-transition-duration;
   transition-timing-function: utils.get-transition-easing('static');
   transition-delay: 0ms;
 }

--- a/libs/core/src/scss/interaction-state/_utilities.scss
+++ b/libs/core/src/scss/interaction-state/_utilities.scss
@@ -1,9 +1,7 @@
 @use 'sass:color';
+@use 'sass:list';
 @use '../utils';
 
-// ---------------------------------------------------------------------------
-// Shared interaction state variables
-// ---------------------------------------------------------------------------
 $default-loudness: 'm';
 
 @function get-state-color($variant, $loudness: $default-loudness, $flip: false) {
@@ -20,4 +18,17 @@ $default-loudness: 'm';
   $hover-color: #{color.scale($_background, $lightness: $_lightness)};
 
   @return $hover-color;
+}
+
+/// Apply streamlined transition to interaction state changes
+/// @param {*} $property-list [all]
+@mixin transition($property-list...) {
+  @if list.length($property-list) == 0 {
+    $property-list: all;
+  }
+
+  transition-property: $property-list;
+  transition-duration: utils.get-transition-duration('quick');
+  transition-timing-function: utils.get-transition-easing('static');
+  transition-delay: 0ms;
 }

--- a/libs/core/src/scss/interaction-state/ionic/_hover.scss
+++ b/libs/core/src/scss/interaction-state/ionic/_hover.scss
@@ -1,9 +1,11 @@
 @use '../layer';
+@use '../utilities';
 @use '../../utils';
 
-@mixin apply-hover($loudness: layer.$default-loudness, $flip: false) {
+@mixin apply-hover($loudness: utilities.$default-loudness, $flip: false) {
   @include utils.hover {
     @include layer.apply-state($loudness, $flip);
+
     --background-hover: var(--state-layer-background-color);
     --background-hover-opacity: var(--state-layer-opacity);
     @content;

--- a/libs/core/src/scss/interaction-state/ionic/_index.scss
+++ b/libs/core/src/scss/interaction-state/ionic/_index.scss
@@ -1,2 +1,2 @@
-@forward '../layer' show transition;
 @forward 'hover';
+@forward '../utilities' show transition;

--- a/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
+++ b/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
@@ -27,7 +27,7 @@ $padding: utils.size('s');
 }
 
 .kirby-icon {
-  transition: transform utils.get-transition-duration('quick');
+  transition: transform interaction-state.$default-transition-duration;
 }
 
 .content {

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
@@ -70,7 +70,7 @@ $default-checkbox-radio-size: map.get(utils.$checkbox-radio-sizes, 'md');
       --background: #{interaction-state.get-state-color('white', 's')};
     }
 
-    --transition: #{utils.get-transition-duration('quick')};
+    --transition: #{interaction-state.$default-transition-duration};
     --size: #{$checkbox-icon-size};
     --checkmark-width: #{utils.size('xxxs')};
     --background: #{utils.get-color('white')};

--- a/libs/designsystem/src/lib/components/toggle/toggle.component.scss
+++ b/libs/designsystem/src/lib/components/toggle/toggle.component.scss
@@ -30,6 +30,6 @@ ion-toggle {
   // Checked
   --background-checked: #{utils.get-color($background-checked)};
   --handle-background-checked: #{utils.get-color($handle-background)};
-  --handle-transition: #{utils.get-transition-duration('quick')};
+  --handle-transition: #{interaction-state.$default-transition-duration};
   --handle-box-shadow: #{utils.get-elevation(2)};
 }


### PR DESCRIPTION
## Which issue does this PR close?
This PR closes #2135 

## What is the new behavior?
The functionality that is shared between interaction-states has been moved to the utilities partial. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [ ] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] ~~Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


