### PR TITLE
Remove deprecated 'checked' property on SegmentItem interface

### DIFF
--- a/libs/designsystem/src/lib/components/segmented-control/segment-item.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segment-item.ts
@@ -10,10 +10,6 @@ type SegmentItemBadge = {
 export interface SegmentItem {
   id: string;
   text: string;
-  /**
-   * @deprecated Will be removed in next major version. Use `selectedIndex` or `value` on `<kirby-segmented-control>` instead.
-   */
-  checked?: boolean;
   badge?: Omit<SegmentItemBadge, 'isCustomIcon'>; // we do not expose the isCustomIcon for the external type
 }
 

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
@@ -53,14 +53,6 @@ export class SegmentedControlComponent {
         item.badge.icon !== undefined &&
         this.iconRegistryService.getIcon(item.badge.icon) !== undefined;
     });
-
-    const checkedItemIndex = this.items.findIndex((item) => item.checked);
-    if (checkedItemIndex > -1) {
-      console.warn(
-        'SegmentItem.checked is deprecated - please remove from your `items` configuration. Use `selectedIndex` or `value` on `<kirby-segmented-control>` instead '
-      );
-      this._selectedIndex = checkedItemIndex;
-    }
     this._value = this.items[this.selectedIndex];
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2065

## What is the new behavior?
It is no longer an option to mark a `SegmentItem` in the `items` input of `SegmentedControl` as checked.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Use `selectedIndex` or `value` on `<kirby-segmented-control>` instead of setting `checked` on any of the `SegmentItem`s.

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


