### PR TITLE
Fix popovers hide() being called twice

### DIFF
--- a/libs/designsystem/src/lib/components/popover/popover.component.ts
+++ b/libs/designsystem/src/lib/components/popover/popover.component.ts
@@ -56,12 +56,6 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
     }
   }
 
-  @HostListener('click')
-  _backdropClick() {
-    this.willHide.emit();
-    this.hide();
-  }
-
   @HostListener('window:resize')
   _onWindowResize() {
     if (this.isShowing) {

--- a/libs/designsystem/src/lib/components/popover/popover.component.ts
+++ b/libs/designsystem/src/lib/components/popover/popover.component.ts
@@ -58,9 +58,7 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
 
   @HostListener('window:resize')
   _onWindowResize() {
-    if (this.isShowing) {
-      this.hide();
-    }
+    this.hide();
   }
 
   constructor(private elementRef: ElementRef<HTMLElement>, private renderer: Renderer2) {

--- a/libs/designsystem/src/lib/components/popover/popover.component.ts
+++ b/libs/designsystem/src/lib/components/popover/popover.component.ts
@@ -65,7 +65,6 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
   @HostListener('window:resize')
   _onWindowResize() {
     if (this.isShowing) {
-      this.willHide.emit();
       this.hide();
     }
   }
@@ -141,12 +140,13 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
   }
 
   hide() {
-    if (this.isShowing) {
-      this.renderer.removeChild(
-        this.elementRef.nativeElement.parentElement,
-        this.elementRef.nativeElement
-      );
-    }
+    if (!this.isShowing) return;
+
+    this.willHide.emit();
+    this.renderer.removeChild(
+      this.elementRef.nativeElement.parentElement,
+      this.elementRef.nativeElement
+    );
     this.releaseScroll();
 
     this.renderer.removeStyle(this.targetElement, 'z-index');

--- a/libs/designsystem/src/lib/components/popover/popover.component.ts
+++ b/libs/designsystem/src/lib/components/popover/popover.component.ts
@@ -141,7 +141,12 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
   }
 
   hide() {
-    this.renderer.removeChild(this.document.body, this.elementRef.nativeElement);
+    if (this.isShowing) {
+      this.renderer.removeChild(
+        this.elementRef.nativeElement.parentElement,
+        this.elementRef.nativeElement
+      );
+    }
     this.releaseScroll();
 
     this.renderer.removeStyle(this.targetElement, 'z-index');


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2180 

## What is the new behavior?
The hide functionality has been refactored a bit to ensure that the element is in fact showing, before doing hide logic.

Furthermore, the backdropClick listener was removed, because it was not functional, as described in the commit message: 

> The event listener was not called because dropdowns onBlur event was
> always fired first, closing the dropdown including the popover
> component. In fact it was only called when clicking inside the dropdown
> because onBlur is not fired then - and thus it is useless at this point.
> 
> Components using popover (dropdown only right now) should take care of
> calling hide() at the appropriate time themselves, e.g. in onBlur.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


