### PR TITLE
Apply apply-active mixin to various components

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -120,7 +120,7 @@
                 {
                   "type": "anyComponentStyle",
                   "maximumWarning": "6kb",
-                  "maximumError": "11kb"
+                  "maximumError": "12kb"
                 }
               ]
             }

--- a/libs/core/src/scss/interaction-state/_active.scss
+++ b/libs/core/src/scss/interaction-state/_active.scss
@@ -1,0 +1,10 @@
+@use 'layer';
+
+$default-loudness-active: 'l';
+
+@mixin apply-active($loudness: $default-loudness-active, $make-lighter: false) {
+  &:active {
+    @include layer.apply-state($loudness, $make-lighter);
+    @content;
+  }
+}

--- a/libs/core/src/scss/interaction-state/_active.scss
+++ b/libs/core/src/scss/interaction-state/_active.scss
@@ -1,8 +1,7 @@
+@use 'interaction-state.utilities';
 @use 'layer';
 
-$default-loudness-active: 'l';
-
-@mixin apply-active($loudness: $default-loudness-active, $make-lighter: false) {
+@mixin apply-active($loudness: interaction-state.$default-loudness-active, $make-lighter: false) {
   &:active {
     @include layer.apply-state($loudness, $make-lighter);
     @content;

--- a/libs/core/src/scss/interaction-state/_index.scss
+++ b/libs/core/src/scss/interaction-state/_index.scss
@@ -1,3 +1,4 @@
+@forward 'active';
 @forward 'focus';
 @forward 'hover';
 @forward 'layer' hide apply-state;

--- a/libs/core/src/scss/interaction-state/_interaction-state.utilities.scss
+++ b/libs/core/src/scss/interaction-state/_interaction-state.utilities.scss
@@ -3,6 +3,7 @@
 @use '../utils';
 
 $default-loudness: 'm';
+$default-loudness-active: 'l';
 $default-transition-duration: utils.get-transition-duration('quick');
 
 @function get-state-color($variant, $loudness: $default-loudness, $make-lighter: false) {

--- a/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
+++ b/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
@@ -7,6 +7,7 @@ $padding: utils.size('s');
 :host {
   @include interaction-state.initialize-layer;
   @include interaction-state.apply-hover('s');
+  @include interaction-state.apply-active('m');
 
   display: block;
   border-top: 1px solid $divider-color;

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -54,6 +54,7 @@ $button-width: (
   --kirby-button-border-color: transparent;
 
   @include interaction-state.apply-hover('s');
+  @include interaction-state.apply-active('m');
 
   &.destructive {
     --kirby-button-color: #{utils.get-color('danger')};
@@ -75,6 +76,7 @@ $button-width: (
   --kirby-button-color: #{utils.get-color('black-contrast')};
 
   @include interaction-state.apply-hover('xxl', $make-lighter: true);
+  @include interaction-state.apply-active('xxxl', $make-lighter: true);
 
   &.destructive {
     --kirby-button-background-color: #{utils.get-color('light')};
@@ -89,6 +91,7 @@ $button-width: (
   --kirby-button-border-color: #{utils.get-color('medium')};
 
   @include interaction-state.apply-hover('s');
+  @include interaction-state.apply-active('m');
 
   &.destructive {
     --kirby-button-color: #{utils.get-color('danger')};
@@ -210,6 +213,7 @@ $button-width: (
       --kirby-button-color: #{utils.get-color('white-contrast')};
 
       @include interaction-state.apply-hover;
+      @include interaction-state.apply-active;
     }
 
     &.attention-level3 {
@@ -217,6 +221,7 @@ $button-width: (
       --kirby-button-color: #{utils.get-color('white')};
 
       @include interaction-state.apply-hover('l', $make-lighter: true);
+      @include interaction-state.apply-active('xl', $make-lighter: true);
     }
   }
 
@@ -250,6 +255,7 @@ $button-width: (
     --kirby-button-color: #{utils.get-color('white-contrast')};
 
     @include interaction-state.apply-hover('s');
+    @include interaction-state.apply-active('m');
   }
 }
 
@@ -259,6 +265,7 @@ $button-width: (
     --kirby-button-color: #{utils.get-color('white-contrast')};
 
     @include interaction-state.apply-hover;
+    @include interaction-state.apply-active;
   }
 }
 
@@ -314,6 +321,7 @@ $button-width: (
       --kirby-button-color: #{utils.get-color($color-name + '-contrast')};
 
       @include interaction-state.apply-hover;
+      @include interaction-state.apply-active;
     }
   }
 }

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -102,6 +102,7 @@ $button-width: (
   @include interaction-state.apply-focus-visible;
   @include interaction-state.initialize-layer($border-width);
   @include interaction-state.apply-hover;
+  @include interaction-state.apply-active;
   @include interaction-state.extend-content {
     display: inherit;
     flex-direction: inherit;
@@ -190,10 +191,6 @@ $button-width: (
 
   &[expand='block'] {
     width: 100%;
-  }
-
-  &:active {
-    opacity: 0.8;
   }
 
   &:disabled {

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -100,6 +100,7 @@ td {
 
 .day.today {
   @include interaction-state.apply-hover;
+  @include interaction-state.apply-active;
 
   color: utils.get-color('medium-contrast');
   background-color: utils.get-color('medium');
@@ -107,6 +108,7 @@ td {
 
 .day.selected {
   @include interaction-state.apply-hover('xl', $make-lighter: true);
+  @include interaction-state.apply-active('xxl', $make-lighter: true);
 
   color: utils.get-color('black-contrast');
   background-color: utils.get-color('black');
@@ -120,4 +122,5 @@ td {
 .contain-state-layer {
   @include interaction-state.initialize-layer;
   @include interaction-state.apply-hover('s');
+  @include interaction-state.apply-active('m');
 }

--- a/libs/designsystem/src/lib/components/card/card.component.scss
+++ b/libs/designsystem/src/lib/components/card/card.component.scss
@@ -46,6 +46,7 @@
   &[role='button'] {
     @include interaction-state.initialize-layer;
     @include interaction-state.apply-hover('s');
+    @include interaction-state.apply-active('m');
     @include interaction-state.apply-focus-visible($shadow: utils.get-elevation(2));
 
     &.highlighted {

--- a/libs/designsystem/src/lib/components/chip/chip.component.scss
+++ b/libs/designsystem/src/lib/components/chip/chip.component.scss
@@ -4,6 +4,7 @@
 :host {
   @include interaction-state.initialize-layer;
   @include interaction-state.apply-hover;
+  @include interaction-state.apply-active;
 
   @include utils.accessible-target-size;
 
@@ -12,6 +13,7 @@
 
   &.is-selected {
     @include interaction-state.apply-hover('xxl', $make-lighter: true);
+    @include interaction-state.apply-active('xxxl', $make-lighter: true);
 
     background-color: utils.get-color('black');
     color: utils.get-color('black-contrast');
@@ -37,12 +39,14 @@
 
   :host-context(.kirby-color-brightness-dark) {
     @include interaction-state.apply-hover($make-lighter: true);
+    @include interaction-state.apply-active($make-lighter: true);
 
     background-color: transparent;
     color: utils.get-text-color('white');
 
     &.is-selected {
       @include interaction-state.apply-hover('l');
+      @include interaction-state.apply-active('xl');
 
       background-color: utils.get-color('white');
       color: utils.get-color('white-contrast');
@@ -55,6 +59,7 @@
 
     &.is-selected {
       @include interaction-state.apply-hover('xxl', $make-lighter: true);
+      @include interaction-state.apply-active('xxxl', $make-lighter: true);
 
       background-color: utils.get-color('black');
       color: utils.get-color('black-contrast');
@@ -67,6 +72,7 @@
 
     &.is-selected {
       @include interaction-state.apply-hover('xl', $make-lighter: true);
+      @include interaction-state.apply-active('xxl', $make-lighter: true);
 
       background-color: utils.get-color('black');
       color: utils.get-color('black-contrast');


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2149 

## What is the new behavior?

Everywhere we use the hover interaction state layer we now also use active/pressed interaction state layer.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [x] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


