### PR TITLE
Only prevent touchevent outside popover

### DIFF
--- a/libs/designsystem/src/lib/components/popover/popover.component.ts
+++ b/libs/designsystem/src/lib/components/popover/popover.component.ts
@@ -97,7 +97,7 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
   }
 
   // document.removeEventListener needs the exact same event handler & options reference:
-  private preventEventOutsidePopover(event: TouchEvent) {
+  private static preventEventOutsidePopover(event: TouchEvent) {
     if (event.target instanceof HTMLElement) {
       const targetIsInPopover = !!event.target.closest('kirby-popover');
       if (!targetIsInPopover) {
@@ -115,7 +115,7 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
     // preventDefault does not work with Renderer2.listen method; add event listener directly to document instead
     this.document.addEventListener(
       'touchmove',
-      this.preventEventOutsidePopover,
+      PopoverComponent.preventEventOutsidePopover,
       this.preventScrollEventListenerOptions
     );
   }
@@ -127,7 +127,7 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
 
     this.document.removeEventListener(
       'touchmove',
-      this.preventEventOutsidePopover,
+      PopoverComponent.preventEventOutsidePopover,
       this.preventScrollEventListenerOptions
     );
   }

--- a/libs/designsystem/src/lib/components/popover/popover.component.ts
+++ b/libs/designsystem/src/lib/components/popover/popover.component.ts
@@ -97,7 +97,7 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
   }
 
   // document.removeEventListener needs the exact same event handler & options reference:
-  private preventEvent(event: TouchEvent) {
+  private preventEventOutsidePopover(event: TouchEvent) {
     if (event.target instanceof HTMLElement) {
       const targetIsInPopover = !!event.target.closest('kirby-popover');
       if (!targetIsInPopover) {
@@ -115,7 +115,7 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
     // preventDefault does not work with Renderer2.listen method; add event listener directly to document instead
     this.document.addEventListener(
       'touchmove',
-      this.preventEvent,
+      this.preventEventOutsidePopover,
       this.preventScrollEventListenerOptions
     );
   }
@@ -127,7 +127,7 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
 
     this.document.removeEventListener(
       'touchmove',
-      this.preventEvent,
+      this.preventEventOutsidePopover,
       this.preventScrollEventListenerOptions
     );
   }

--- a/libs/designsystem/src/lib/components/popover/popover.component.ts
+++ b/libs/designsystem/src/lib/components/popover/popover.component.ts
@@ -98,7 +98,12 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
 
   // document.removeEventListener needs the exact same event handler & options reference:
   private preventEvent(event: TouchEvent) {
-    event.preventDefault();
+    if (event.target instanceof HTMLElement) {
+      const targetIsInPopover = !!event.target.closest('kirby-popover');
+      if (!targetIsInPopover) {
+        event.preventDefault();
+      }
+    }
   }
 
   private preventScroll() {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2204 

## What is the new behavior?
We make sure to check that we are not actually scrolling inside the popover, before we prevent the touchmove event. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


