### PR TITLE
Active state for ionic components and special cases

### DIFF
--- a/apps/cookbook/src/app/showcase/item-showcase/item-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/item-showcase/item-showcase.component.ts
@@ -21,10 +21,6 @@ export class ItemShowcaseComponent {
       description: 'Background of the item',
     },
     {
-      name: '--kirby-item-background-activated',
-      description: 'Background of the item when pressed',
-    },
-    {
       name: '--kirby-item-background-focused',
       description: 'Background of the item when focused with the tab key',
     },

--- a/libs/core/src/scss/interaction-state/ionic/_active.scss
+++ b/libs/core/src/scss/interaction-state/ionic/_active.scss
@@ -1,0 +1,12 @@
+@use '../interaction-state.utilities';
+@use '../layer';
+
+@mixin apply-active($loudness: interaction-state.$default-loudness-active, $make-lighter: false) {
+  &:active {
+    @include layer.apply-state($loudness, $make-lighter);
+
+    --background-activated: var(--state-layer-background-color);
+    --background-activated-opacity: var(--state-layer-opacity);
+    @content;
+  }
+}

--- a/libs/core/src/scss/interaction-state/ionic/_index.scss
+++ b/libs/core/src/scss/interaction-state/ionic/_index.scss
@@ -1,2 +1,3 @@
+@forward 'active';
 @forward 'hover';
 @forward '../interaction-state.utilities' show transition;

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
@@ -23,10 +23,9 @@ $default-checkbox-radio-size: map.get(utils.$checkbox-radio-sizes, 'md');
     @include interaction-state.apply-hover {
       --background-checked: #{interaction-state.get-state-color('success')};
     }
-
-    &:active {
-      --background-checked: #{utils.get-color('success-shade')};
-      --border-color-checked: #{utils.get-color('success-shade')};
+    @include interaction-state.apply-active {
+      --background-checked: #{interaction-state.get-state-color('success', 'xl')};
+      --border-color-checked: #{interaction-state.get-state-color('success', 'xl')};
     }
   }
 
@@ -38,11 +37,18 @@ $default-checkbox-radio-size: map.get(utils.$checkbox-radio-sizes, 'md');
     @include interaction-state.apply-hover {
       --background-checked: #{interaction-state.get-state-color('black', 'xxl', $make-lighter: true)};
     }
-
-    &:active {
-      --checkmark-color: #{utils.get-color('white-shade')};
-      --background-checked: #{utils.get-color('black-tint')};
-      --border-color-checked: #{utils.get-color('black-tint')};
+    @include interaction-state.apply-active {
+      --checkmark-color: #{interaction-state.get-state-color('white')};
+      --background-checked: #{interaction-state.get-state-color(
+          'black',
+          'xxxl',
+          $make-lighter: true
+        )};
+      --border-color-checked: #{interaction-state.get-state-color(
+          'black',
+          'xxxl',
+          $make-lighter: true
+        )};
     }
   }
 
@@ -69,6 +75,9 @@ $default-checkbox-radio-size: map.get(utils.$checkbox-radio-sizes, 'md');
     @include interaction-state.apply-hover {
       --background: #{interaction-state.get-state-color('white', 's')};
     }
+    @include interaction-state.apply-active {
+      --background: #{interaction-state.get-state-color('white', 'm')};
+    }
 
     --transition: #{utils.get-transition-duration('quick')};
     --size: #{$checkbox-icon-size};
@@ -83,10 +92,6 @@ $default-checkbox-radio-size: map.get(utils.$checkbox-radio-sizes, 'md');
 
     &::part(container) {
       padding: utils.size('xxxs'); // Spacing between checkmark and container box
-    }
-
-    &:active {
-      --background: #{utils.get-color('white-shade')};
     }
   }
 

--- a/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.scss
+++ b/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.scss
@@ -12,6 +12,7 @@ $fab-sheet-margin: utils.size('s');
 // https://ionicframework.com/docs/api/fab-button
 ion-fab-button {
   @include ionic.apply-hover;
+  @include ionic.apply-active;
 
   // NOTE: This is a custom implementation of the hover interaction state;
   // identical to PageComponent's ion-back-button & SegmentedControlComponent's

--- a/libs/designsystem/src/lib/components/form-field/input/input.component.scss
+++ b/libs/designsystem/src/lib/components/form-field/input/input.component.scss
@@ -8,6 +8,9 @@
     background-color: interaction-state.get-state-color('white', 's');
     cursor: text;
   }
+  @include interaction-state.apply-active {
+    background-color: interaction-state.get-state-color('white', 'm');
+  }
 
   &[type='number'] {
     // fallback

--- a/libs/designsystem/src/lib/components/item/item.component.scss
+++ b/libs/designsystem/src/lib/components/item/item.component.scss
@@ -19,10 +19,6 @@
     --inner-padding-bottom: #{utils.size('xxs')};
     --inner-padding-end: #{utils.size('s')};
     --background: var(--kirby-item-background, #{utils.get-color('white')});
-    --background-activated: var(
-      --kirby-item-background-activated,
-      #{utils.get-color('white-shade')}
-    );
 
     // WORKAROUND: Needed to fix ignored click on scrollend
     // https://github.com/ionic-team/ionic-framework/issues/21871

--- a/libs/designsystem/src/lib/components/item/item.component.scss
+++ b/libs/designsystem/src/lib/components/item/item.component.scss
@@ -9,6 +9,7 @@
 
   ion-item {
     @include ionic.apply-hover('s');
+    @include ionic.apply-active('m');
 
     --padding-top: var(--item-padding-top, 0px);
     --padding-bottom: var(--item-padding-bottom, 0px);

--- a/libs/designsystem/src/lib/components/page/page.component.scss
+++ b/libs/designsystem/src/lib/components/page/page.component.scss
@@ -68,6 +68,7 @@ ion-title {
 
 ion-back-button {
   @include ionic.apply-hover('s');
+  @include ionic.apply-active('m');
 
   --color: #{utils.get-color('black')};
   --icon-font-size: 24px;

--- a/libs/designsystem/src/lib/components/radio/radio.component.scss
+++ b/libs/designsystem/src/lib/components/radio/radio.component.scss
@@ -89,18 +89,18 @@ ion-radio {
       background-color: interaction-state.get-state-color('white', 's');
     }
   }
+  @include interaction-state.apply-active {
+    --color: transparent;
+    --color-checked: #{interaction-state.get-state-color('success')};
+
+    &::part(container) {
+      background-color: interaction-state.get-state-color('white');
+    }
+  }
 
   &::part(mark) {
     width: $radio-icon-mark-size;
     height: $radio-icon-mark-size;
-  }
-
-  &:active {
-    --color: transparent;
-
-    &::part(container) {
-      background-color: utils.get-color('white-shade');
-    }
   }
 
   :host-context(kirby-radio-group.error),

--- a/libs/designsystem/src/lib/components/range/range.component.scss
+++ b/libs/designsystem/src/lib/components/range/range.component.scss
@@ -16,6 +16,9 @@ ion-range {
   @include interaction-state.apply-hover {
     --knob-background: #{interaction-state.get-state-color('white', 's')};
   }
+  @include interaction-state.apply-active {
+    --knob-background: #{interaction-state.get-state-color('white', 'm')};
+  }
 
   --knob-background: #{utils.get-color('white')};
   --knob-box-shadow: #{$knob-shadow};

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -55,6 +55,7 @@ ion-segment {
 ion-segment-button {
   @include interaction-state.apply-focus-part($part: 'native');
   @include ionic.apply-hover;
+  @include ionic.apply-active;
   @include utils.accessible-target-size;
 
   --border-radius: #{utils.$border-radius-round};

--- a/libs/designsystem/src/lib/components/slide-button/slide-button.component.scss
+++ b/libs/designsystem/src/lib/components/slide-button/slide-button.component.scss
@@ -17,10 +17,10 @@ $slide-button-text-padding: 0 $slide-button-container-radius 0 $total-slider-thu
 @mixin _slider-thumb() {
   @include interaction-state.transition;
   @include interaction-state.apply-hover {
-    background-color: color.scale(
-      utils.get-color('white', $getValueOnly: true),
-      $lightness: -1 * utils.get-loudness('m')
-    );
+    background-color: interaction-state.get-state-color('white');
+  }
+  @include interaction-state.apply-active {
+    background-color: interaction-state.get-state-color('white', 'l');
   }
 
   appearance: none;

--- a/libs/designsystem/src/lib/components/slide-button/slide-button.component.scss
+++ b/libs/designsystem/src/lib/components/slide-button/slide-button.component.scss
@@ -1,5 +1,3 @@
-@use 'sass:color';
-
 @use '~@kirbydesign/core/src/scss/interaction-state';
 @use '~@kirbydesign/core/src/scss/utils';
 

--- a/libs/designsystem/src/lib/components/toggle/toggle.component.scss
+++ b/libs/designsystem/src/lib/components/toggle/toggle.component.scss
@@ -23,6 +23,16 @@ ion-toggle {
     --handle-background-checked: #{interaction-state.get-state-color($handle-background, 's')};
   }
 
+  @include interaction-state.apply-active {
+    // Not checked
+    --background: #{interaction-state.get-state-color($background, 'm')};
+    --handle-background: #{interaction-state.get-state-color($handle-background, 'm')};
+
+    // Checked
+    --background-checked: #{interaction-state.get-state-color($background-checked, 'm')};
+    --handle-background-checked: #{interaction-state.get-state-color($handle-background, 'm')};
+  }
+
   // Not checked
   --background: #{utils.get-color($background)};
   --handle-background: #{utils.get-color($handle-background)};


### PR DESCRIPTION
## Which issue does this PR close?
This PR closes #2197 fixes #2198

## What is the new behavior?
An ionic-specific mixin has been created for those of ionics components that use the  `--background-activated` and `--background-activated-opacity` approach. 

Unfortunately that is not the case for all Ionics components so custom approaches has been implemented for those and some of our non-ionic based components.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Active state should not be overwritten for selectable items, it should follow the same conventions as any other component. If item has `selectable="true"` we want to make sure it has the appropriate active state. 

For most, migration should be fairly simple - just remove `--kirby-item-background-activated`-related CSS.

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


