### PR TITLE
Fix slow hot reloading

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -95,6 +95,15 @@
             "scripts": []
           },
           "configurations": {
+            "development": {
+              "optimization": false,
+              "aot": false,
+              "buildOptimizer": false,
+              "sourceMap": true,
+              "extractLicenses": false,
+              "namedChunks": true,
+              "vendorChunk": true
+            },
             "production": {
               "fileReplacements": [
                 {
@@ -127,12 +136,16 @@
         },
         "serve": {
           "builder": "@angular-builders/custom-webpack:dev-server",
+          "defaultConfiguration": "development",
           "options": {
             "browserTarget": "cookbook:build"
           },
           "configurations": {
             "production": {
               "browserTarget": "cookbook:build:production"
+            },
+            "development": {
+              "browserTarget": "cookbook:build:development"
             }
           }
         },

--- a/angular.json
+++ b/angular.json
@@ -111,14 +111,7 @@
                   "with": "apps/cookbook/src/environments/environment.prod.ts"
                 }
               ],
-              "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
-              "namedChunks": false,
-              "aot": true,
-              "extractLicenses": true,
-              "vendorChunk": false,
-              "buildOptimizer": true,
               "budgets": [
                 {
                   "type": "initial",

--- a/angular.json
+++ b/angular.json
@@ -129,17 +129,8 @@
         },
         "serve": {
           "builder": "@angular-builders/custom-webpack:dev-server",
-          "defaultConfiguration": "development",
           "options": {
-            "browserTarget": "cookbook:build"
-          },
-          "configurations": {
-            "production": {
-              "browserTarget": "cookbook:build:production"
-            },
-            "development": {
-              "browserTarget": "cookbook:build:development"
-            }
+            "browserTarget": "cookbook:build:development"
           }
         },
         "extract-i18n": {

--- a/angular.json
+++ b/angular.json
@@ -131,6 +131,11 @@
           "builder": "@angular-builders/custom-webpack:dev-server",
           "options": {
             "browserTarget": "cookbook:build:development"
+          },
+          "configurations": {
+            "production": {
+              "browserTarget": "cookbook:build:production"
+            }
           }
         },
         "extract-i18n": {
@@ -172,11 +177,6 @@
             "cypressConfig": "apps/cookbook-e2e/cypress.json",
             "tsConfig": "apps/cookbook-e2e/tsconfig.e2e.json",
             "devServerTarget": "cookbook:serve"
-          },
-          "configurations": {
-            "production": {
-              "devServerTarget": "cookbook:serve:production"
-            }
           }
         },
         "lint": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "prettier:fix": "prettier --write \"./{libs,apps}/**/*.{ts,json,md,scss,html}\"",
     "e2e": "ng e2e",
     "dist": "npm run dist:cookbook",
-    "dist:cookbook": "ng build cookbook --prod --aot --progress false",
+    "dist:cookbook": "ng build cookbook --configuration production",
     "predist:designsystem": "npm run extract-scss-variables",
     "dist:designsystem": "ng build designsystem",
     "postinstall": "npm run ngcc && npm run build-polyfills && npm run transpile:tools && npm run extract-scss-variables && npm run build:core && npm run transpile:generate-mocks && node ./decorate-angular-cli.js",


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2203

Also i got a bit carried away and submitted #2209 which removes the e2e app. There's no reason for having it. 

## What is the new behavior?

A "production builds by default" initiative (see: https://github.com/angular/angular-cli/commit/656f8d75a3368a5affd1c55145841123dafdb007) has resulted in our development configurations being the production settings. 

I've added a 'development' configuration which can be used when developing locally; it uses the old defaults which are better for development.

Also i've tried to tidying it up a little. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->