### PR TITLE
Refactor loudness scale

### DIFF
--- a/libs/core/src/scss/base/_variables.scss
+++ b/libs/core/src/scss/base/_variables.scss
@@ -192,10 +192,14 @@ $loading-overlay-backdrop-opacity: 0.8;
 /* Interaction states loudness
 ****************************************************************************/
 $loudness-scale: (
-  's': 4%,
-  'm': 8%,
-  'l': 12%,
-  'xl': 16%,
-  'xxl': 24%,
-  'xxxl': 32%,
+  'xxxs': 4%,
+  'xxs': 8%,
+  'xs': 12%,
+  's': 16%,
+  'm': 20%,
+  'l': 24%,
+  'xl': 28%,
+  'xxl': 32%,
+  'xxxl': 36%,
+  'xxxxl': 40%,
 );

--- a/libs/core/src/scss/interaction-state/_interaction-state.utilities.scss
+++ b/libs/core/src/scss/interaction-state/_interaction-state.utilities.scss
@@ -2,8 +2,8 @@
 @use 'sass:list';
 @use '../utils';
 
-$default-loudness: 'm';
-$default-loudness-active: 'l';
+$default-loudness: 'xxs';
+$default-loudness-active: 'xs';
 $default-transition-duration: utils.get-transition-duration('quick');
 
 @function get-state-color($variant, $loudness: $default-loudness, $make-lighter: false) {

--- a/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
+++ b/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
@@ -6,7 +6,7 @@ $padding: utils.size('s');
 
 :host {
   @include interaction-state.initialize-layer;
-  @include interaction-state.apply-hover('s');
+  @include interaction-state.apply-hover('xxxs');
   @include interaction-state.apply-active('m');
 
   display: block;

--- a/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
+++ b/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
@@ -7,7 +7,7 @@ $padding: utils.size('s');
 :host {
   @include interaction-state.initialize-layer;
   @include interaction-state.apply-hover('xxxs');
-  @include interaction-state.apply-active('m');
+  @include interaction-state.apply-active('xxs');
 
   display: block;
   border-top: 1px solid $divider-color;

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -221,7 +221,7 @@ $button-width: (
       --kirby-button-color: #{utils.get-color('white')};
 
       @include interaction-state.apply-hover('xs', $make-lighter: true);
-      @include interaction-state.apply-active('xl', $make-lighter: true);
+      @include interaction-state.apply-active('s', $make-lighter: true);
     }
   }
 

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -76,7 +76,7 @@ $button-width: (
   --kirby-button-color: #{utils.get-color('black-contrast')};
 
   @include interaction-state.apply-hover('l', $make-lighter: true);
-  @include interaction-state.apply-active('xxxl', $make-lighter: true);
+  @include interaction-state.apply-active('xxl', $make-lighter: true);
 
   &.destructive {
     --kirby-button-background-color: #{utils.get-color('light')};

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -53,7 +53,7 @@ $button-width: (
   --kirby-button-color: #{utils.get-color('black')};
   --kirby-button-border-color: transparent;
 
-  @include interaction-state.apply-hover('s');
+  @include interaction-state.apply-hover('xxxs');
   @include interaction-state.apply-active('m');
 
   &.destructive {
@@ -90,7 +90,7 @@ $button-width: (
   --kirby-button-color: #{utils.get-color('black')};
   --kirby-button-border-color: #{utils.get-color('medium')};
 
-  @include interaction-state.apply-hover('s');
+  @include interaction-state.apply-hover('xxxs');
   @include interaction-state.apply-active('m');
 
   &.destructive {
@@ -254,7 +254,7 @@ $button-width: (
     --kirby-button-background-color: #{utils.get-color('white')};
     --kirby-button-color: #{utils.get-color('white-contrast')};
 
-    @include interaction-state.apply-hover('s');
+    @include interaction-state.apply-hover('xxxs');
     @include interaction-state.apply-active('m');
   }
 }

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -54,7 +54,7 @@ $button-width: (
   --kirby-button-border-color: transparent;
 
   @include interaction-state.apply-hover('xxxs');
-  @include interaction-state.apply-active('m');
+  @include interaction-state.apply-active('xxs');
 
   &.destructive {
     --kirby-button-color: #{utils.get-color('danger')};
@@ -91,7 +91,7 @@ $button-width: (
   --kirby-button-border-color: #{utils.get-color('medium')};
 
   @include interaction-state.apply-hover('xxxs');
-  @include interaction-state.apply-active('m');
+  @include interaction-state.apply-active('xxs');
 
   &.destructive {
     --kirby-button-color: #{utils.get-color('danger')};
@@ -255,7 +255,7 @@ $button-width: (
     --kirby-button-color: #{utils.get-color('white-contrast')};
 
     @include interaction-state.apply-hover('xxxs');
-    @include interaction-state.apply-active('m');
+    @include interaction-state.apply-active('xxs');
   }
 }
 

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -75,7 +75,7 @@ $button-width: (
   --kirby-button-background-color: #{utils.get-color('black')};
   --kirby-button-color: #{utils.get-color('black-contrast')};
 
-  @include interaction-state.apply-hover('xxl', $make-lighter: true);
+  @include interaction-state.apply-hover('l', $make-lighter: true);
   @include interaction-state.apply-active('xxxl', $make-lighter: true);
 
   &.destructive {

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -220,7 +220,7 @@ $button-width: (
       --kirby-button-border-color: #{utils.get-color('white')};
       --kirby-button-color: #{utils.get-color('white')};
 
-      @include interaction-state.apply-hover('l', $make-lighter: true);
+      @include interaction-state.apply-hover('xs', $make-lighter: true);
       @include interaction-state.apply-active('xl', $make-lighter: true);
     }
   }

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -121,6 +121,6 @@ td {
 
 .contain-state-layer {
   @include interaction-state.initialize-layer;
-  @include interaction-state.apply-hover('s');
+  @include interaction-state.apply-hover('xxxs');
   @include interaction-state.apply-active('m');
 }

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -122,5 +122,5 @@ td {
 .contain-state-layer {
   @include interaction-state.initialize-layer;
   @include interaction-state.apply-hover('xxxs');
-  @include interaction-state.apply-active('m');
+  @include interaction-state.apply-active('xxs');
 }

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -107,7 +107,7 @@ td {
 }
 
 .day.selected {
-  @include interaction-state.apply-hover('xl', $make-lighter: true);
+  @include interaction-state.apply-hover('s', $make-lighter: true);
   @include interaction-state.apply-active('xxl', $make-lighter: true);
 
   color: utils.get-color('black-contrast');

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -108,7 +108,7 @@ td {
 
 .day.selected {
   @include interaction-state.apply-hover('s', $make-lighter: true);
-  @include interaction-state.apply-active('xxl', $make-lighter: true);
+  @include interaction-state.apply-active('l', $make-lighter: true);
 
   color: utils.get-color('black-contrast');
   background-color: utils.get-color('black');

--- a/libs/designsystem/src/lib/components/card/card.component.scss
+++ b/libs/designsystem/src/lib/components/card/card.component.scss
@@ -46,7 +46,7 @@
   &[role='button'] {
     @include interaction-state.initialize-layer;
     @include interaction-state.apply-hover('xxxs');
-    @include interaction-state.apply-active('m');
+    @include interaction-state.apply-active('xxs');
     @include interaction-state.apply-focus-visible($shadow: utils.get-elevation(2));
 
     &.highlighted {

--- a/libs/designsystem/src/lib/components/card/card.component.scss
+++ b/libs/designsystem/src/lib/components/card/card.component.scss
@@ -45,7 +45,7 @@
 
   &[role='button'] {
     @include interaction-state.initialize-layer;
-    @include interaction-state.apply-hover('s');
+    @include interaction-state.apply-hover('xxxs');
     @include interaction-state.apply-active('m');
     @include interaction-state.apply-focus-visible($shadow: utils.get-elevation(2));
 

--- a/libs/designsystem/src/lib/components/chip/chip.component.scss
+++ b/libs/designsystem/src/lib/components/chip/chip.component.scss
@@ -46,7 +46,7 @@
 
     &.is-selected {
       @include interaction-state.apply-hover('xs');
-      @include interaction-state.apply-active('xl');
+      @include interaction-state.apply-active('s');
 
       background-color: utils.get-color('white');
       color: utils.get-color('white-contrast');
@@ -71,7 +71,7 @@
     color: utils.get-text-color('black');
 
     &.is-selected {
-      @include interaction-state.apply-hover('xl', $make-lighter: true);
+      @include interaction-state.apply-hover('s', $make-lighter: true);
       @include interaction-state.apply-active('xxl', $make-lighter: true);
 
       background-color: utils.get-color('black');

--- a/libs/designsystem/src/lib/components/chip/chip.component.scss
+++ b/libs/designsystem/src/lib/components/chip/chip.component.scss
@@ -45,7 +45,7 @@
     color: utils.get-text-color('white');
 
     &.is-selected {
-      @include interaction-state.apply-hover('l');
+      @include interaction-state.apply-hover('xs');
       @include interaction-state.apply-active('xl');
 
       background-color: utils.get-color('white');

--- a/libs/designsystem/src/lib/components/chip/chip.component.scss
+++ b/libs/designsystem/src/lib/components/chip/chip.component.scss
@@ -12,7 +12,7 @@
   color: utils.get-color('white-contrast');
 
   &.is-selected {
-    @include interaction-state.apply-hover('xxl', $make-lighter: true);
+    @include interaction-state.apply-hover('l', $make-lighter: true);
     @include interaction-state.apply-active('xxxl', $make-lighter: true);
 
     background-color: utils.get-color('black');
@@ -58,7 +58,7 @@
     color: utils.get-text-color('black');
 
     &.is-selected {
-      @include interaction-state.apply-hover('xxl', $make-lighter: true);
+      @include interaction-state.apply-hover('l', $make-lighter: true);
       @include interaction-state.apply-active('xxxl', $make-lighter: true);
 
       background-color: utils.get-color('black');
@@ -72,7 +72,7 @@
 
     &.is-selected {
       @include interaction-state.apply-hover('s', $make-lighter: true);
-      @include interaction-state.apply-active('xxl', $make-lighter: true);
+      @include interaction-state.apply-active('l', $make-lighter: true);
 
       background-color: utils.get-color('black');
       color: utils.get-color('black-contrast');

--- a/libs/designsystem/src/lib/components/chip/chip.component.scss
+++ b/libs/designsystem/src/lib/components/chip/chip.component.scss
@@ -13,7 +13,7 @@
 
   &.is-selected {
     @include interaction-state.apply-hover('l', $make-lighter: true);
-    @include interaction-state.apply-active('xxxl', $make-lighter: true);
+    @include interaction-state.apply-active('xxl', $make-lighter: true);
 
     background-color: utils.get-color('black');
     color: utils.get-color('black-contrast');
@@ -59,7 +59,7 @@
 
     &.is-selected {
       @include interaction-state.apply-hover('l', $make-lighter: true);
-      @include interaction-state.apply-active('xxxl', $make-lighter: true);
+      @include interaction-state.apply-active('xxl', $make-lighter: true);
 
       background-color: utils.get-color('black');
       color: utils.get-color('black-contrast');

--- a/libs/designsystem/src/lib/components/item/item.component.scss
+++ b/libs/designsystem/src/lib/components/item/item.component.scss
@@ -8,7 +8,7 @@
   position: relative;
 
   ion-item {
-    @include ionic.apply-hover('s');
+    @include ionic.apply-hover('xxxs');
     @include ionic.apply-active('m');
 
     --padding-top: var(--item-padding-top, 0px);

--- a/libs/designsystem/src/lib/components/item/item.component.scss
+++ b/libs/designsystem/src/lib/components/item/item.component.scss
@@ -9,7 +9,7 @@
 
   ion-item {
     @include ionic.apply-hover('xxxs');
-    @include ionic.apply-active('m');
+    @include ionic.apply-active('xxs');
 
     --padding-top: var(--item-padding-top, 0px);
     --padding-bottom: var(--item-padding-bottom, 0px);

--- a/libs/designsystem/src/lib/components/page/page.component.scss
+++ b/libs/designsystem/src/lib/components/page/page.component.scss
@@ -68,7 +68,7 @@ ion-title {
 
 ion-back-button {
   @include ionic.apply-hover('xxxs');
-  @include ionic.apply-active('m');
+  @include ionic.apply-active('xxs');
 
   --color: #{utils.get-color('black')};
   --icon-font-size: 24px;

--- a/libs/designsystem/src/lib/components/page/page.component.scss
+++ b/libs/designsystem/src/lib/components/page/page.component.scss
@@ -67,7 +67,7 @@ ion-title {
 }
 
 ion-back-button {
-  @include ionic.apply-hover('s');
+  @include ionic.apply-hover('xxxs');
   @include ionic.apply-active('m');
 
   --color: #{utils.get-color('black')};


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2211 

## What is the new behavior?

Before the loudness scale was non-linear: Mostly in 4% increments but with some arbitrary variations (8% increments).

During UX review we realised that we need more levels in the scale.

This PR adds more levels and shifts the scale so it goes from (small to large) `xxxs` to `xxxxl` instead of `s` to `xxxxxxxl` 😎

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


