### PR TITLE
Apply transition to all properties on focus

### DIFF
--- a/libs/core/src/scss/interaction-state/_focus.scss
+++ b/libs/core/src/scss/interaction-state/_focus.scss
@@ -60,9 +60,10 @@
 }
 
 @mixin _focus-ring($shadow, $gap) {
+  @include interaction-state.transition;
+
   $stroke-width: utils.size('xxxxs');
 
   box-shadow: #{$shadow}, 0 0 0 $gap #{utils.get-color('background-color')},
     0 0 0 $gap + $stroke-width utils.$focus-ring-color;
-  transition: box-shadow interaction-state.$default-transition-duration;
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2134 

## What is the new behavior?

Not really new behavior. When transition is applied to more than one interaction state it should still work as intended.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


