### PR TITLE
Adjust hover and active area on Accordion

### DIFF
--- a/libs/designsystem/src/lib/components/accordion/accordion-item.component.html
+++ b/libs/designsystem/src/lib/components/accordion/accordion-item.component.html
@@ -1,4 +1,3 @@
-<span class="state-layer" aria-hidden="true"></span>
 <div class="content-layer">
   <div
     (click)="isExpanded = !isExpanded"
@@ -9,6 +8,7 @@
     [attr.aria-controls]="_contentId"
     [id]="_titleId"
   >
+    <span class="state-layer" aria-hidden="true"></span>
     <div class="title">{{ title }}</div>
     <kirby-icon name="arrow-down"></kirby-icon>
   </div>

--- a/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
+++ b/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
@@ -6,8 +6,6 @@ $padding: utils.size('s');
 
 :host {
   @include interaction-state.initialize-layer;
-  @include interaction-state.apply-hover('xxxs');
-  @include interaction-state.apply-active('xxs');
 
   display: block;
   border-top: 1px solid $divider-color;
@@ -15,6 +13,9 @@ $padding: utils.size('s');
 }
 
 .header {
+  @include interaction-state.apply-hover('xxxs');
+  @include interaction-state.apply-active('xxs');
+
   display: flex;
   align-items: center;
   height: utils.size('xxxl');


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2226 

## What is the new behavior?

Hover and active will only be effective when you interact with the header of each Accordion item.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<table>
  <tr>
    <th>Current (prod)</th>
    <th>Interaction states before this PR</th>
    <th>Interaction states after this PR</th>
  </tr>
  <tr>
    <td>

https://user-images.githubusercontent.com/150451/167113707-ceca8880-1b5a-41b6-857e-a4f9b738deaa.mov

</td>
    <td>

https://user-images.githubusercontent.com/150451/167113555-68b173af-c82e-4690-9ad0-7c2d43394411.mov

</td>
    <td>

https://user-images.githubusercontent.com/150451/167113612-b478a3fe-8eff-4629-ab83-945fe964e401.mov

</td>
  </tr>
</table>



## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


