### PR TITLE
segmented-control - disable change on swipe attribute

### DIFF
--- a/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.ts
@@ -52,5 +52,12 @@ export class SegmentedControlShowcaseComponent {
       defaultValue: 'undefined',
       type: ['number'],
     },
+    {
+      name: 'disableChangeOnSwipe',
+      description:
+        'Sets the `scrollable` attribute on ion-segment. Note that this will not make the segmented-control scrollable but it will prevent segmentChange from emitting on swipe, when set to true',
+      defaultValue: 'false',
+      type: ['boolean'],
+    },
   ];
 }

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
@@ -1,6 +1,7 @@
 <ion-segment
   *ngIf="mode === 'default'"
   [value]="value?.id"
+  [scrollable]="disableChangeOnSwipe"
   (ionChange)="onSegmentSelect($event.detail.value)"
   (click)="preventWrapperClick($event)"
 >

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
@@ -92,6 +92,15 @@ export class SegmentedControlComponent {
     this.isSmallSize = size === 'sm';
   }
 
+  private _disableChangeOnSwipe: boolean = false;
+  get disableChangeOnSwipe(): boolean {
+    return this._disableChangeOnSwipe
+  }
+
+  @Input() set disableChangeOnSwipe(value: boolean) {
+    this._disableChangeOnSwipe = value;
+  }
+
   @Output() segmentSelect: EventEmitter<SegmentItem> = new EventEmitter();
 
   onSegmentSelect(selectedId: string) {

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
@@ -94,7 +94,7 @@ export class SegmentedControlComponent {
 
   private _disableChangeOnSwipe: boolean = false;
   get disableChangeOnSwipe(): boolean {
-    return this._disableChangeOnSwipe
+    return this._disableChangeOnSwipe;
   }
 
   @Input() set disableChangeOnSwipe(value: boolean) {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2235 

## What is the new behavior?
Introduced a new input attribute to the segmented-control component (disableChangeOnSwipe), which sets the scrollable attribute on the ion-segment

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


