### PR TITLE
Wrong padding in small button

### DIFF
--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -20,8 +20,8 @@ $button-width: (
   min-width: button-width('sm');
 
   &:not(.icon-only) {
-    padding-left: utils.size('s');
-    padding-right: utils.size('s');
+    --kirby-button-padding-left: #{utils.size('s')};
+    --kirby-button-padding-right: #{utils.size('s')};
   }
 
   &.icon-only {
@@ -101,6 +101,9 @@ $button-width: (
 :host {
   $border-width: 1px;
 
+  --kirby-button-padding-left: #{utils.size('m')};
+  --kirby-button-padding-right: #{utils.size('m')};
+
   @include utils.accessible-target-size;
   @include interaction-state.apply-focus-visible;
   @include interaction-state.initialize-layer($border-width);
@@ -132,7 +135,7 @@ $button-width: (
   font-size: utils.font-size('s');
   height: utils.size('xl');
   min-width: button-width('md');
-  padding: 0 utils.size('m');
+  padding: 0;
   margin: utils.size('xxxs');
   line-height: utils.line-height('s');
 


### PR DESCRIPTION
## Which issue does this PR close?
This PR closes #2252

## What is the new behavior?
After introducing the content layer, some of the old styling added padding within the small button, while the content layer itself also defined some padding.

We now use the custom properties defined on the content layer to control padding throughout. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


