### PR TITLE
Add elevation to dropdown with attention level 2

### DIFF
--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -257,6 +257,8 @@ $button-width: (
 
     @include interaction-state.apply-hover('xxxs');
     @include interaction-state.apply-active('xxs');
+
+    box-shadow: utils.get-elevation(2);
   }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2083 

## What is the new behavior?
Shadow added when dropdown is white!

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


