### PR TITLE
Run manual CD when changing items in list

### DIFF
--- a/libs/designsystem/src/lib/components/item/item.component.html
+++ b/libs/designsystem/src/lib/components/item/item.component.html
@@ -1,8 +1,8 @@
 <ion-item
   lines="none"
   [attr.disabled]="disabled"
-  [attr.button]="selectable ? true : null"
-  [attr.tabindex]="selectable ? null : 0"
+  [attr.button]="_selectable ? true : null"
+  [attr.tabindex]="_selectable ? null : 0"
   detail="false"
   (mousedown)="onMouseDown($event)"
 >

--- a/libs/designsystem/src/lib/components/item/item.component.ts
+++ b/libs/designsystem/src/lib/components/item/item.component.ts
@@ -1,4 +1,10 @@
-import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  HostBinding,
+  Input,
+} from '@angular/core';
 
 export enum ItemSize {
   XS = 'xs',
@@ -13,12 +19,16 @@ export enum ItemSize {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ItemComponent {
+  _selectable: boolean;
+
   @Input() disabled: boolean;
   @HostBinding('class.selected')
   @Input()
   selected: boolean;
-  @Input()
-  selectable: boolean;
+  @Input() set selectable(selectable: boolean) {
+    this._selectable = selectable;
+    this.cdr.markForCheck();
+  }
   @Input()
   reorderable: boolean;
   @HostBinding('class')
@@ -34,4 +44,6 @@ export class ItemComponent {
       event.preventDefault();
     }
   }
+
+  constructor(private cdr: ChangeDetectorRef) {}
 }

--- a/libs/designsystem/src/lib/components/item/item.component.ts
+++ b/libs/designsystem/src/lib/components/item/item.component.ts
@@ -26,6 +26,7 @@ export class ItemComponent {
   @Input()
   selected: boolean;
   @Input() set selectable(selectable: boolean) {
+    if (this._selectable === selectable) return;
     this._selectable = selectable;
     this.cdr.markForCheck();
   }

--- a/libs/designsystem/src/lib/components/list/list.component.ts
+++ b/libs/designsystem/src/lib/components/list/list.component.ts
@@ -1,5 +1,6 @@
 import {
   AfterViewInit,
+  ChangeDetectorRef,
   Component,
   ContentChild,
   ContentChildren,
@@ -150,7 +151,11 @@ export class ListComponent implements OnInit, AfterViewInit, OnChanges {
   _groupedItems: any[];
   _selectedItem: any;
 
-  constructor(private listHelper: ListHelper, private groupBy: GroupByPipe) {}
+  constructor(
+    private listHelper: ListHelper,
+    private groupBy: GroupByPipe,
+    private cdr: ChangeDetectorRef
+  ) {}
 
   ngOnInit() {
     this._isSelectable = this.itemSelect.observers.length > 0;
@@ -166,6 +171,11 @@ export class ListComponent implements OnInit, AfterViewInit, OnChanges {
         this.kirbyItems.forEach((item) => {
           item.selectable = true;
         });
+
+        // We are mutating the items directly, after they have been rendered in the template.
+        // Therefore, we make sure to detectChanges.
+        // kirby-item handles marking itself for check when selectable is set.
+        this.cdr.detectChanges();
       });
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2241

## What is the new behavior?

Because kirby-item is projected into the list we currently query all the items in the list and manually set their selectable state, because we can't bind to the input of item in the list template.

This means that we need to manually trigger change detection when we have changed the state of the item component, for it to sync with the view correctly, and become clickable.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


