### PR TITLE
Add dynamic toolbar height and refine layout

### DIFF
--- a/libs/core/src/scss/base/_functions.scss
+++ b/libs/core/src/scss/base/_functions.scss
@@ -1,6 +1,7 @@
 @use 'sass:list';
 @use 'sass:map';
 @use 'sass:math';
+@use 'sass:meta';
 @use 'sass:string';
 @use '../themes/colors';
 @use 'variables';

--- a/libs/core/src/scss/base/_variables.scss
+++ b/libs/core/src/scss/base/_variables.scss
@@ -170,7 +170,6 @@ $checkbox-radio-spacing: (
 $soft-keyboard-transition-enter: 250ms ease-out 1ms; // Adding a 1ms delay seems to improve the smoothness on iPhone
 $soft-keyboard-transition-leave: 150ms ease-out;
 $transition-durations: (
-  very-quick: 100ms,
   quick: 200ms,
   short: 300ms,
   long: 500ms,

--- a/libs/core/src/scss/base/_variables.scss
+++ b/libs/core/src/scss/base/_variables.scss
@@ -5,6 +5,7 @@
   SPACINGS
 ****************************************************************************/
 $sizes: (
+  xxxxl: 64px,
   xxxl: 56px,
   xxl: 48px,
   xl: 40px,
@@ -169,6 +170,7 @@ $checkbox-radio-spacing: (
 $soft-keyboard-transition-enter: 250ms ease-out 1ms; // Adding a 1ms delay seems to improve the smoothness on iPhone
 $soft-keyboard-transition-leave: 150ms ease-out;
 $transition-durations: (
+  very-quick: 100ms,
   quick: 200ms,
   short: 300ms,
   long: 500ms,

--- a/libs/designsystem/src/lib/components/button/button.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/button/button.component.integration.spec.ts
@@ -98,9 +98,12 @@ describe('ButtonComponent in Kirby Page', () => {
       expect(actionButtonInHeader).toBeTruthy();
     });
 
-    it('should render without background-color', async () => {
+    it('should render with the correct background-color', async () => {
       await TestHelper.whenReady(ionToolbar);
-      expect(actionButtonInHeader).toHaveComputedStyle({ 'background-color': getColor('white') });
+      expect(actionButtonInHeader).toHaveComputedStyle({ 'background-color': getColor('primary') });
+      expect(actionButtonInHeaderIconOnly).toHaveComputedStyle({
+        'background-color': getColor('white'),
+      });
     });
 
     it('should render with correct color', async () => {

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -230,40 +230,41 @@ $button-width: (
 // Temp fix for https://github.com/angular/angular-cli/issues/13854#issuecomment-470831308
 
 /* clean-css ignore:start */
-
-:host-context(ion-toolbar kirby-page-actions) {
+:host-context(kirby-page ion-toolbar ion-buttons) {
   font-size: utils.font-size('s');
   margin: 0 utils.size('xxxs');
   height: utils.size('xl');
 
   &.icon-only {
     width: utils.size('xl');
+
+    &.attention-level1,
+    &.attention-level2,
+    &.attention-level3,
+    &.attention-level4 {
+      @include button-attentionlevel2;
+    }
   }
 
-  transition-property: color, background-color;
+  transition-property: color, background-color, margin;
   transition-duration: utils.get-transition-duration('short');
   transition-timing-function: utils.get-transition-easing('enter-exit');
-
-  &.attention-level1,
-  &.attention-level2,
-  &.attention-level3,
-  &.attention-level4 {
-    @include button-attentionlevel2;
-  }
 }
 
-:host-context(ion-toolbar ion-buttons:last-child kirby-page-actions) {
+:host-context(kirby-page ion-toolbar ion-buttons:last-child) {
   margin-right: 0;
 }
 
-:host-context(ion-toolbar.content-scrolled kirby-page-actions) {
+:host-context(kirby-page ion-toolbar.content-scrolled ion-buttons) {
   margin: 0;
 
-  &.attention-level1,
-  &.attention-level2,
-  &.attention-level3,
-  &.attention-level4 {
-    @include button-attentionlevel4;
+  &.icon-only {
+    &.attention-level1,
+    &.attention-level2,
+    &.attention-level3,
+    &.attention-level4 {
+      @include button-attentionlevel4;
+    }
   }
 }
 

--- a/libs/designsystem/src/lib/components/page/page.component.html
+++ b/libs/designsystem/src/lib/components/page/page.component.html
@@ -8,8 +8,8 @@
         [style.visibility]="hideBackButton ? 'hidden' : null"
       ></ion-back-button>
     </ion-buttons>
-    <ion-title>
-      <div class="toolbar-title hide" [class.fade-in]="toolbarTitleVisible">
+    <ion-title [class.slide-and-fade-in]="toolbarTitleVisible">
+      <div class="toolbar-title">
         <ng-container *ngTemplateOutlet="toolbarTitleTemplate"></ng-container>
       </div>
     </ion-title>

--- a/libs/designsystem/src/lib/components/page/page.component.scss
+++ b/libs/designsystem/src/lib/components/page/page.component.scss
@@ -23,6 +23,24 @@ ion-toolbar {
   --padding-top: 0;
   --padding-bottom: 0;
 
+  $toolbar-height-notch: utils.size('xxl');
+  $toolbar-height-default: utils.size('xxxl');
+  $notch-safe-area-top-trigger: 32px;
+
+  --notch-present: min(
+    max(calc(var(--kirby-safe-area-top, 0px) - #{$notch-safe-area-top-trigger} + 1px), 0px),
+    1px
+  );
+  --min-height: calc(
+    var(--notch-present) * #{utils.strip-unit($toolbar-height-notch)} + (
+        1px - var(--notch-present)
+      ) * #{utils.strip-unit($toolbar-height-default)}
+  );
+
+  @include utils.media('>=medium') {
+    --min-height: 64px; // TODO: #{utils.size('xxxxl')};
+  }
+
   box-sizing: border-box;
 
   $button-padding: utils.size('xs');
@@ -38,6 +56,7 @@ ion-toolbar {
 
     padding-left: $button-padding;
     padding-right: $button-padding;
+    border-bottom: 1px solid #{utils.get-color('semi-light')};
   }
 
   /*
@@ -49,6 +68,17 @@ ion-toolbar {
   }
 
   ion-title {
+    opacity: 0;
+    transform: translateY(10px);
+    transition-property: opacity, transform;
+    transition-duration: utils.get-transition-duration('quick');
+    transition-timing-function: utils.get-transition-easing('static');
+
+    &.slide-and-fade-in {
+      opacity: 1;
+      transform: translateY(0);
+    }
+
     .toolbar-title {
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -166,6 +196,7 @@ ion-toolbar.content-scrolled ion-back-button {
  * Page Content
  */
 ion-content {
+  --padding-top: #{utils.size('xs')};
   --padding-start: var(--page-content-padding-start, #{utils.size('s')});
   --padding-end: var(--page-content-padding-end, #{utils.size('s')});
   --background: #{utils.get-color('background-color')};

--- a/libs/designsystem/src/lib/components/page/page.component.scss
+++ b/libs/designsystem/src/lib/components/page/page.component.scss
@@ -1,5 +1,9 @@
 @use '~@kirbydesign/core/src/scss/utils';
 
+:host {
+  display: contents;
+}
+
 /*
  * Page Header
  */
@@ -38,7 +42,7 @@ ion-toolbar {
   );
 
   @include utils.media('>=medium') {
-    --min-height: 64px; // TODO: #{utils.size('xxxxl')};
+    --min-height: #{utils.size('xxxxl')};
   }
 
   box-sizing: border-box;
@@ -71,8 +75,8 @@ ion-toolbar {
     opacity: 0;
     transform: translateY(10px);
     transition-property: opacity, transform;
-    transition-duration: utils.get-transition-duration('quick');
-    transition-timing-function: utils.get-transition-easing('static');
+    transition-duration: 150ms;
+    transition-timing-function: utils.get-transition-easing('enter-exit');
 
     &.slide-and-fade-in {
       opacity: 1;

--- a/libs/designsystem/src/lib/components/page/page.component.scss
+++ b/libs/designsystem/src/lib/components/page/page.component.scss
@@ -27,18 +27,35 @@ ion-toolbar {
   --padding-top: 0;
   --padding-bottom: 0;
 
+  // The toolbar height for iPhone's with a notched display.
   $toolbar-height-notch: utils.size('xxl');
+
+  // The toolbar height for other displays.
   $toolbar-height-default: utils.size('xxxl');
+
+  // An iPhone with a ios-safe-area-top exceeding 32px is considered to have notched display.
   $notch-safe-area-top-trigger: 32px;
 
-  --notch-present: min(
-    max(calc(var(--kirby-safe-area-top, 0px) - #{$notch-safe-area-top-trigger} + 1px), 0px),
+  // Notch indicator:
+  // 0px represents FALSE
+  // 1px represents TRUE
+  // IF `--kirby-safe-area-top` is defined _and_ has a value strictly larger than `$notch-safe-area-top-trigger`
+  // THEN `--notch-present` = 1px (a notch _is_ present)
+  // ELSE `--notch-present` = 0px (no notch)
+  --notch-present: clamp(
+    0px,
+    var(--kirby-safe-area-top, 0px) - #{$notch-safe-area-top-trigger},
     1px
   );
-  --min-height: calc(
-    var(--notch-present) * #{utils.strip-unit($toolbar-height-notch)} + (
-        1px - var(--notch-present)
-      ) * #{utils.strip-unit($toolbar-height-default)}
+
+  // Equivalent to:
+  // IF --notch-present == 1px (i.e. the display _does_ have a notch)
+  // THEN --min-height = $toolbar-height-notch
+  // ELSE --min-height = $toolbar-height-default
+  --min-height: clamp(
+    #{$toolbar-height-notch},
+    (1px - var(--notch-present)) * #{utils.strip-unit($toolbar-height-default)},
+    #{$toolbar-height-default}
   );
 
   @include utils.media('>=medium') {
@@ -72,6 +89,7 @@ ion-toolbar {
   }
 
   ion-title {
+    // Animation on opacity and a vertical translation with 10px gives visually pleasing experience
     opacity: 0;
     transform: translateY(10px);
     transition-property: opacity, transform;

--- a/libs/designsystem/src/lib/components/page/page.component.spec.ts
+++ b/libs/designsystem/src/lib/components/page/page.component.spec.ts
@@ -1,6 +1,5 @@
 import { Component, NgZone } from '@angular/core';
 import { fakeAsync, flush, tick } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
 import { Router, Routes } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { IonRefresher } from '@ionic/angular';
@@ -12,7 +11,6 @@ import { FitHeadingDirective } from '../../directives/fit-heading/fit-heading.di
 import { TestHelper } from '../../testing/test-helper';
 import { WindowRef } from '../../types/window-ref';
 import { ButtonComponent } from '../button/button.component';
-import { backgroundColor } from '../chart/configs/shared.utils';
 import { ModalNavigationService } from '../modal/services/modal-navigation.service';
 import { TabsComponent } from '../tabs';
 
@@ -111,34 +109,30 @@ describe('PageComponent', () => {
     await TestHelper.whenReady(ionContent);
   });
 
-  describe('should show the toolbar with the correct height', () => {
-    it('when on ios-phone without top safe-area', async () => {
+  describe('toolbar with dynamic height', () => {
+    it('should be correct height on ios-phone without top-safe-area', async () => {
       ionToolbar.style.setProperty('--kirby-safe-area-top', '0px');
       await TestHelper.resizeTestWindow(TestHelper.screensize.phone);
 
       expect(ionToolbar).toHaveComputedStyle({ height: size('xxxl') });
     });
-
-    it('when on ios-phone with top safe-area', async () => {
-      ionToolbar.style.setProperty('--kirby-safe-area-top', '32px');
+    it('should be correct height on ios-phone with top-safe-area', async () => {
+      ionToolbar.style.setProperty('--kirby-safe-area-top', '33px');
       await TestHelper.resizeTestWindow(TestHelper.screensize.phone);
 
       expect(ionToolbar).toHaveComputedStyle({ height: size('xxl') });
     });
-
-    it('when on non-ios-phone', async () => {
+    it('should be correct height on non-ios-phone', async () => {
       await TestHelper.resizeTestWindow(TestHelper.screensize.phone);
 
       expect(ionToolbar).toHaveComputedStyle({ height: size('xxxl') });
     });
-
-    it('when on tablet', async () => {
+    it('should be correct height on tablet', async () => {
       await TestHelper.resizeTestWindow(TestHelper.screensize.tablet);
 
       expect(ionToolbar).toHaveComputedStyle({ height: size('xxxxl') });
     });
-
-    it('when on desktop', async () => {
+    it('should be correct height on desktop', async () => {
       await TestHelper.resizeTestWindow(TestHelper.screensize.desktop);
 
       expect(ionToolbar).toHaveComputedStyle({ height: size('xxxxl') });

--- a/libs/designsystem/src/lib/components/page/page.component.spec.ts
+++ b/libs/designsystem/src/lib/components/page/page.component.spec.ts
@@ -111,6 +111,40 @@ describe('PageComponent', () => {
     await TestHelper.whenReady(ionContent);
   });
 
+  describe('should show the toolbar with the correct height', () => {
+    it('when on ios-phone without top safe-area', async () => {
+      ionToolbar.style.setProperty('--kirby-safe-area-top', '0px');
+      await TestHelper.resizeTestWindow(TestHelper.screensize.phone);
+
+      expect(ionToolbar).toHaveComputedStyle({ height: size('xxxl') });
+    });
+
+    it('when on ios-phone with top safe-area', async () => {
+      ionToolbar.style.setProperty('--kirby-safe-area-top', '32px');
+      await TestHelper.resizeTestWindow(TestHelper.screensize.phone);
+
+      expect(ionToolbar).toHaveComputedStyle({ height: size('xxl') });
+    });
+
+    it('when on non-ios-phone', async () => {
+      await TestHelper.resizeTestWindow(TestHelper.screensize.phone);
+
+      expect(ionToolbar).toHaveComputedStyle({ height: size('xxxl') });
+    });
+
+    it('when on tablet', async () => {
+      await TestHelper.resizeTestWindow(TestHelper.screensize.tablet);
+
+      expect(ionToolbar).toHaveComputedStyle({ height: size('xxxxl') });
+    });
+
+    it('when on desktop', async () => {
+      await TestHelper.resizeTestWindow(TestHelper.screensize.desktop);
+
+      expect(ionToolbar).toHaveComputedStyle({ height: size('xxxxl') });
+    });
+  });
+
   describe('having static page action', () => {
     it('should show the action in the toolbar when content not scrolled', () => {
       const staticPageActionButton = ionToolbar.querySelector(

--- a/libs/designsystem/src/lib/components/page/page.component.ts
+++ b/libs/designsystem/src/lib/components/page/page.component.ts
@@ -1,4 +1,3 @@
-import { compileNgModule } from '@angular/compiler';
 import {
   AfterContentChecked,
   AfterViewInit,

--- a/libs/designsystem/src/lib/components/page/page.component.ts
+++ b/libs/designsystem/src/lib/components/page/page.component.ts
@@ -19,7 +19,6 @@ import {
   Optional,
   Output,
   QueryList,
-  Renderer2,
   SimpleChanges,
   SkipSelf,
   TemplateRef,
@@ -148,9 +147,7 @@ export class PageActionsComponent {}
   styleUrls: ['./page.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class PageComponent
-  implements OnInit, OnDestroy, AfterViewInit, AfterContentChecked, OnChanges
-{
+export class PageComponent implements OnDestroy, AfterViewInit, AfterContentChecked, OnChanges {
   @Input() title: string;
   @Input() subtitle: string;
   @Input() toolbarTitle: string;
@@ -234,18 +231,12 @@ export class PageComponent
   );
 
   constructor(
-    private elementRef: ElementRef,
-    private renderer: Renderer2,
     private router: Router,
     private changeDetectorRef: ChangeDetectorRef,
     private windowRef: WindowRef,
     private modalNavigationService: ModalNavigationService,
     @Optional() @SkipSelf() private tabsComponent: TabsComponent
   ) {}
-
-  ngOnInit(): void {
-    this.removeWrapper();
-  }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.titleMaxLines) {
@@ -386,14 +377,6 @@ export class PageComponent
         this.customContentTemplate = content.template;
       }
     });
-  }
-
-  private removeWrapper() {
-    const parent = this.elementRef.nativeElement.parentNode;
-    this.renderer.removeChild(parent, this.elementRef.nativeElement);
-    this.renderer.appendChild(parent, this.ionHeaderElement.nativeElement);
-    this.renderer.appendChild(parent, this.ionContentElement.nativeElement);
-    this.renderer.appendChild(parent, this.ionFooterElement.nativeElement);
   }
 
   private pageTitleIntersectionObserver() {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2219

## What is the new behavior?

- The toolbar height is set depending on the size of the screen set as follows*:
  - \>= medium: 'xxxxl'/64px
  - < medium: 'xxxl'/56px (default)
  - 'xxl'/48px (if the phone is an iPhone with a notch)
The presence of a notch on the iPhone is not easily detectable but it has been agreed that a defined ios-safe-area-top above 32px will be interpreted as an iPhone with a notch

- A 1px 'semi-light' bottom border is added to the toolbar when content is scrolled - implements #2040.
- The distance between the toolbar and the page content has been Increased.
- The toolbar button styling applies to icon-only buttons on kirby-page avoiding kirby-modal.
- The toolbar styling now works with all kinds of kirby-action templates - not necessarily using the kirby-page-action element.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/stable/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be automatically merged to `stable` via [automerge](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/automatically-merging-a-pull-request).


