### PR TITLE
Setup nx to support designsystem as default project

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
     "build": "ng build",
     "build-polyfills": "webpack --config webpack.polyfills.config.js",
     "test": "ng test",
-    "test:cookbook": "ng test cookbook",
-    "test:designsystem": "ng test designsystem",
     "test:headless-browser": "npm run test -- --browsers=ChromeCustom",
     "test:headless-browser:single": "npm run test:headless-browser -- --watch=false",
     "test:libs": "npm run test:core:single && npm run test:headless-browser:single",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "ng": "nx",
     "nx": "nx",
-    "start": "npm-run-all --parallel \"ng serve\" \"build:core:watch\"",
+    "start": "npm-run-all --parallel \"ng serve cookbook\" \"build:core:watch\"",
     "build": "ng build",
     "build-polyfills": "webpack --config webpack.polyfills.config.js",
     "test": "ng test",


### PR DESCRIPTION
## Which issue does this PR close?

This PR is a followup to #2284 

## What is the new behavior?
`npm start` (ng serve) in the end, should run the cookbook, but with the newest changes in `nx` it ran the designsystem projects serve command which does not exist because it is a library.

I also removed some unused scripts I discovered during this, because cookbook has no tests, and designsystem test is run via the standard `test` script by `nx` due to designsystem being our default project.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

