### PR TITLE
Enable click on selected item in Segmented Control

### DIFF
--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
@@ -5,8 +5,8 @@
   (ionChange)="onSegmentSelect($event.detail.value)"
   (click)="preventWrapperClick($event)"
 >
-  <div *ngFor="let item of items" class="segment-btn-wrapper">
-    <ion-segment-button [value]="item.id">{{ item.text }}</ion-segment-button>
+  <ng-container *ngFor="let item of items">
+    <ion-segment-button [value]="item.id">{{ item.text }} </ion-segment-button>
     <kirby-badge
       *ngIf="item.badge"
       role="text"
@@ -26,7 +26,7 @@
         {{ item.badge.content }}
       </ng-template>
     </kirby-badge>
-  </div>
+  </ng-container>
 </ion-segment>
 
 <ng-container *ngIf="mode === 'chip' || mode === 'compactChip'">

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
@@ -7,25 +7,27 @@
 >
   <ng-container *ngFor="let item of items">
     <ion-segment-button [value]="item.id">{{ item.text }} </ion-segment-button>
-    <kirby-badge
-      *ngIf="item.badge"
-      role="text"
-      [attr.aria-label]="item.badge.description"
-      [themeColor]="item.badge.themeColor"
-    >
-      <ng-container *ngIf="item.badge.icon; else badgeContent">
-        <kirby-icon
-          *ngIf="item.badge.isCustomIcon; else defaultIconName"
-          [customName]="item.badge.icon"
-        ></kirby-icon>
-        <ng-template #defaultIconName>
-          <kirby-icon [name]="item.badge.icon"></kirby-icon>
+    <div class="badge-container">
+      <kirby-badge
+        *ngIf="item.badge"
+        role="text"
+        [attr.aria-label]="item.badge.description"
+        [themeColor]="item.badge.themeColor"
+      >
+        <ng-container *ngIf="item.badge.icon; else badgeContent">
+          <kirby-icon
+            *ngIf="item.badge.isCustomIcon; else defaultIconName"
+            [customName]="item.badge.icon"
+          ></kirby-icon>
+          <ng-template #defaultIconName>
+            <kirby-icon [name]="item.badge.icon"></kirby-icon>
+          </ng-template>
+        </ng-container>
+        <ng-template #badgeContent>
+          {{ item.badge.content }}
         </ng-template>
-      </ng-container>
-      <ng-template #badgeContent>
-        {{ item.badge.content }}
-      </ng-template>
-    </kirby-badge>
+      </kirby-badge>
+    </div>
   </ng-container>
 </ion-segment>
 

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -82,6 +82,7 @@ ion-segment-button {
   --margin-top: 0;
 
   min-height: utils.size('xl');
+  min-width: fit-content;
   font-weight: utils.font-weight('normal');
   font-size: utils.font-size('s');
   text-transform: none;

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -6,9 +6,8 @@
   user-select: none;
 
   --kirby-badge-elevation: #{utils.get-elevation(2)};
-  --kirby-badge-position: absolute;
   --kirby-badge-top: -#{utils.size('xxs')};
-  --kirby-badge-right: #{utils.size('xxs')};
+  --kirby-badge-right: #{utils.size('m')};
   --kirby-badge-z-index: #{utils.z('segment-badge')};
 
   &.sm {
@@ -41,14 +40,17 @@
 }
 
 ion-segment {
+  --background: #{utils.get-color('white')};
+
   display: inline-flex; // The segmented control itself is block-level, but we don't want the background to stretch
   width: auto; // The segmented control itself is block-level, but we don't want the background to stretch
   overflow: visible; // Ensures the badge is not cut off
   contain: unset; // Ensures the badge is not cut off
-
-  --background: #{utils.get-color('white')};
-
   border-radius: utils.$border-radius-round;
+
+  kirby-badge {
+    width: 0;
+  }
 }
 
 ion-segment-button {
@@ -97,8 +99,4 @@ ion-segment-button {
   &::part(indicator) {
     padding-inline: 0;
   }
-}
-
-.segment-btn-wrapper {
-  position: relative;
 }

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -69,6 +69,7 @@ ion-segment-button {
   --color-checked: #{utils.get-color('black-contrast')};
   --color-hover: #{utils.get-color('black-tint')};
   --indicator-box-shadow: none;
+  --indicator-transform: none;
   --padding-start: #{utils.size('m')};
   --padding-end: #{utils.size('m')};
   --margin-bottom: 0;

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -49,6 +49,8 @@ ion-segment {
   border-radius: utils.$border-radius-round;
 
   kirby-badge {
+    // 0 width here allows us to position the badge with top/right properties relative to the
+    // segment-button but without taking up horizontal space in the segmented control
     width: 0;
   }
 }

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -6,8 +6,9 @@
   user-select: none;
 
   --kirby-badge-elevation: #{utils.get-elevation(2)};
+  --kirby-badge-position: absolute;
   --kirby-badge-top: -#{utils.size('xxs')};
-  --kirby-badge-right: #{utils.size('m')};
+  --kirby-badge-right: #{utils.size('xxs')};
   --kirby-badge-z-index: #{utils.z('segment-badge')};
 
   &.sm {
@@ -47,12 +48,6 @@ ion-segment {
   overflow: visible; // Ensures the badge is not cut off
   contain: unset; // Ensures the badge is not cut off
   border-radius: utils.$border-radius-round;
-
-  kirby-badge {
-    // 0 width here allows us to position the badge with top/right properties relative to the
-    // segment-button but without taking up horizontal space in the segmented control
-    width: 0;
-  }
 }
 
 ion-segment-button {
@@ -107,4 +102,8 @@ ion-segment-button {
   &::part(indicator) {
     padding-inline: 0;
   }
+}
+
+.badge-container {
+  position: relative;
 }

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -59,6 +59,11 @@ ion-segment-button {
   @include interaction-state.apply-active-ionic('s');
   @include utils.accessible-target-size;
 
+  &.segment-button-checked {
+    @include interaction-state.apply-hover-ionic($make-lighter: true);
+    @include interaction-state.apply-active-ionic('s', $make-lighter: true);
+  }
+
   --border-radius: #{utils.$border-radius-round};
   --border-style: none;
   --background: none;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2265 closes #1744

## What is the new behavior?
Segmented Control now gets the correct state for hover and active when interacting with an already selected segment. 

This includes a small refactor to get rid of the wrapper element around each segment-button in the Segmented Control template, as this was the culprit for not being able to interact with the underlying segment. This `div` wrapper element with `position: relative` was originally introduced to be able to place a badge via `top/left/right` css properties, but is now removed in favor of an `ng-container` that will not clutter the DOM. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

