### PR TITLE
Remove fab sheet icon substitution logic

### DIFF
--- a/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.html
+++ b/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.html
@@ -4,7 +4,12 @@
   (click)="hideActions(fab)"
 ></ion-backdrop>
 <ion-fab #fab (click)="disabled || onFabClick(fab)">
-  <ion-fab-button [disabled]="disabled" [attr.disabled]="disabled ? true : null" tabindex="-1">
+  <ion-fab-button
+    [disabled]="disabled"
+    [attr.disabled]="disabled ? true : null"
+    tabindex="-1"
+    closeIcon="close-outline"
+  >
     <ng-content select="kirby-icon"></ng-content>
   </ion-fab-button>
   <ion-fab-list *ngIf="actionSheet" side="top" class="{{ horizontalAlignment }}">

--- a/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.ts
+++ b/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.ts
@@ -1,7 +1,6 @@
 import { DOCUMENT } from '@angular/common';
 import {
   AfterContentInit,
-  AfterViewInit,
   Component,
   ContentChild,
   ElementRef,
@@ -11,10 +10,8 @@ import {
   Renderer2,
   ViewChild,
 } from '@angular/core';
-import { IonFab, IonFabButton, IonIcon } from '@ionic/angular';
+import { IonFab, IonFabButton } from '@ionic/angular';
 
-import { Icon } from '../icon/icon-settings';
-import { kirbyIconSettings } from '../icon/kirby-icon-settings';
 import { ActionSheetComponent } from '../modal/action-sheet/action-sheet.component';
 
 @Component({
@@ -22,7 +19,7 @@ import { ActionSheetComponent } from '../modal/action-sheet/action-sheet.compone
   templateUrl: './fab-sheet.component.html',
   styleUrls: ['./fab-sheet.component.scss'],
 })
-export class FabSheetComponent implements AfterContentInit, AfterViewInit {
+export class FabSheetComponent implements AfterContentInit {
   @Input() disabled: boolean = false;
   @Input() horizontalAlignment: 'left' | 'center' | 'right' = 'right';
 
@@ -44,34 +41,6 @@ export class FabSheetComponent implements AfterContentInit, AfterViewInit {
   ionFabButton: ElementRef<HTMLElement>;
 
   constructor(private renderer: Renderer2, @Inject(DOCUMENT) private document: any) {}
-
-  ngAfterViewInit(): void {
-    const kirbyCloseIcon = kirbyIconSettings.icons.find((icon) => icon.name === 'close');
-    this.setCloseIcon(kirbyCloseIcon);
-  }
-
-  private setCloseIcon(kirbyCloseIcon: Icon, retryCount = 0) {
-    const maxRetryCount = 20;
-    const retryDelayInMs = 20;
-    const fabButtonElement = this.ionFabButton.nativeElement;
-    if (!fabButtonElement || !kirbyCloseIcon || retryCount >= maxRetryCount) {
-      return;
-    }
-    if (fabButtonElement.shadowRoot && fabButtonElement.shadowRoot.innerHTML) {
-      const closeIcon = fabButtonElement.shadowRoot.querySelector('.close-icon ion-icon');
-      if (closeIcon) {
-        const closeIconSvgLoaded = closeIcon.shadowRoot.querySelector('.icon-inner svg');
-        // prettier-ignore
-        const ionCloseIcon = (closeIcon as unknown) as IonIcon;
-        if (ionCloseIcon && closeIconSvgLoaded) {
-          ionCloseIcon.src = kirbyCloseIcon.svg;
-          return;
-        }
-      }
-    }
-    retryCount++;
-    setTimeout(() => this.setCloseIcon(kirbyCloseIcon, retryCount), retryDelayInMs);
-  }
 
   ngAfterContentInit(): void {
     if (this.actionSheet) {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue. Just a quick houskeeping task found while looking at #2258 

## What is the new behavior?
The implemented logic no longer works, it is still the original ionicon that is used. 
Therefore, the `close-outline` icon is now used instead, which is possible because the `close-outline` and our own `close` icon are visually identical.  

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

