### PR TITLE
Add SCSS files to exports in package.json

### DIFF
--- a/libs/designsystem/package.json
+++ b/libs/designsystem/package.json
@@ -23,5 +23,9 @@
     "@angular/router": ">=9.0.0",
     "rxjs": ">=6.5.3",
     "zone.js": ">=0.10.2"
+  },
+  "exports": {
+    "./scss/global-styles": "./scss/_global-styles.scss",
+    "./scss/utils": "./scss/_utils.scss"
   }
 }


### PR DESCRIPTION
I forbindelse med opgradering til Angular 13 og dermed et nyt pakkeformat skal eksporterede ting eksplicit med i package.json . Angular tilføjer automatisk javascript filer, men scss filer skal tilføjes manuelt.