### PR TITLE
Add deprecation warning for 'stock' ChartType

### DIFF
--- a/libs/designsystem/src/lib/components/chart/chart.component.ts
+++ b/libs/designsystem/src/lib/components/chart/chart.component.ts
@@ -52,7 +52,21 @@ export class ChartComponent implements AfterViewInit, OnChanges {
 
   constructor(private chartJSService: ChartJSService) {}
 
+  private throwStockDeprecationWarning() {
+    /* 
+    TODO: When `stock` ChartType has been removed - this method can be safely deleted. 
+    See issue: https://github.com/kirbydesign/designsystem/issues/2305 
+    */
+    if (this.type === 'stock') {
+      console.warn(
+        "DEPRECATION WARNING: The 'stock' ChartType will be removed in v7.0.0 of Kirby Designsystem. A new 'kirby-stock-chart' will be introduced in v7.0.0 which can be used as a replacement."
+      );
+    }
+  }
+
   ngAfterViewInit() {
+    this.throwStockDeprecationWarning();
+
     /* 
        A chart is not rendered until it has both a height and a width. 
        If ChartComponent is slotted in an ionic component it will
@@ -127,6 +141,7 @@ export class ChartComponent implements AfterViewInit, OnChanges {
   }
 
   private updateType() {
+    this.throwStockDeprecationWarning();
     this.chartJSService.updateType(this.type, this.customOptions);
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue 🥷 

## What is the new behavior?

We're currently working on #2305 which will remove the `stock` ChartType. I think we should give consumers of Kirby a heads up in v6.0.0 before removing it in v7.0.0. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [ ] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [X] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [X] Request that the changes are code-reviewed 
- [ ] ~~Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be merged to `develop` by Team Kirby.

