### PR TITLE
Short term fix for input field styles

### DIFF
--- a/libs/designsystem/src/lib/components/form-field/_form-field-inputs.shared.scss
+++ b/libs/designsystem/src/lib/components/form-field/_form-field-inputs.shared.scss
@@ -7,6 +7,7 @@ $form-field-label-height: 24px;
 
 :host(.error) {
   border: 1px solid utils.get-color('danger');
+  padding: calc(#{$form-field-input-padding} - 1px);
 }
 
 // Ensures correct position of cloned input when Ionic scrollAssist is enabled

--- a/libs/designsystem/src/lib/components/form-field/_form-field-inputs.shared.scss
+++ b/libs/designsystem/src/lib/components/form-field/_form-field-inputs.shared.scss
@@ -7,7 +7,7 @@ $form-field-label-height: 24px;
 
 :host(.error) {
   border: 1px solid utils.get-color('danger');
-  padding: calc(#{$form-field-input-padding} - 1px);
+  padding: calc(#{$form-field-input-padding} - 1px); // subtract border width from padding to maintain overall height
 }
 
 // Ensures correct position of cloned input when Ionic scrollAssist is enabled

--- a/libs/designsystem/src/lib/components/form-field/_form-field-inputs.shared.scss
+++ b/libs/designsystem/src/lib/components/form-field/_form-field-inputs.shared.scss
@@ -1,10 +1,9 @@
 @use '~@kirbydesign/core/src/scss/utils';
 
-$form-field-label-height: 24px;
 $form-field-input-font-family: var(--kirby-font-family);
-$form-field-input-font-size: utils.font-size('n');
-$form-field-input-line-height: utils.line-height('n');
-$form-field-input-padding: utils.size('s');
+$form-field-input-line-height: 1.5;
+$form-field-input-padding: 1em;
+$form-field-label-height: 24px;
 
 :host(.error) {
   border: 1px solid utils.get-color('danger');
@@ -33,26 +32,24 @@ $form-field-input-padding: utils.size('s');
   display: block;
   font-family: $form-field-input-font-family;
 
-  // font-size: $form-field-input-font-size;
-  font-size: 1em;
-
-  // line-height: $form-field-input-line-height;
-  line-height: 1.5;
+  // `font-size` should be declared in `em` units but to simplify the solution
+  // to https://github.com/kirbydesign/designsystem/issues/2301 we're using `rem`.
+  // Must be fixed by https://github.com/kirbydesign/designsystem/issues/2313
+  font-size: 1rem;
+  line-height: $form-field-input-line-height;
   outline: none;
   margin: 0;
   appearance: none;
   border-radius: utils.size('s');
   box-shadow: utils.get-elevation(2);
-
-  // padding: $form-field-input-padding;
-  padding: 1em;
+  padding: $form-field-input-padding;
   width: 100%;
 
   &:host-context(kirby-item),
   &.borderless {
     border-radius: 0;
     box-shadow: none;
-    padding: 0;
+    padding-inline: 0;
     width: auto;
   }
 

--- a/libs/designsystem/src/lib/components/form-field/_form-field-inputs.shared.scss
+++ b/libs/designsystem/src/lib/components/form-field/_form-field-inputs.shared.scss
@@ -32,14 +32,20 @@ $form-field-input-padding: utils.size('s');
   box-sizing: border-box;
   display: block;
   font-family: $form-field-input-font-family;
-  font-size: $form-field-input-font-size;
-  line-height: $form-field-input-line-height;
+
+  // font-size: $form-field-input-font-size;
+  font-size: 1em;
+
+  // line-height: $form-field-input-line-height;
+  line-height: 1.5;
   outline: none;
   margin: 0;
   appearance: none;
   border-radius: utils.size('s');
   box-shadow: utils.get-elevation(2);
-  padding: $form-field-input-padding;
+
+  // padding: $form-field-input-padding;
+  padding: 1em;
   width: 100%;
 
   &:host-context(kirby-item),

--- a/libs/designsystem/src/lib/components/form-field/directives/date/date-input.directive.spec.ts
+++ b/libs/designsystem/src/lib/components/form-field/directives/date/date-input.directive.spec.ts
@@ -115,13 +115,13 @@ describe('DateInputDirective', () => {
       expect(datemaskLineHeight).toEqual(inputLineHeight);
     });
 
-    it('should have same margin as input padding', () => {
+    it('should have same padding as input padding', () => {
       const datemask = spectator.element.parentNode.querySelector('.date-mask');
 
       const inputPadding = TestHelper.getCssProperty(spectator.element, 'padding');
-      const datemaskMargin = TestHelper.getCssProperty(datemask, 'margin');
+      const datemaskPadding = TestHelper.getCssProperty(datemask, 'padding');
 
-      expect(datemaskMargin).toEqual(inputPadding);
+      expect(datemaskPadding).toEqual(inputPadding);
     });
   });
 });

--- a/libs/designsystem/src/lib/components/form-field/input/input.component.integration.spec.ts
+++ b/libs/designsystem/src/lib/components/form-field/input/input.component.integration.spec.ts
@@ -30,7 +30,7 @@ describe('InputComponent in Item', () => {
 
     it('should render with correct padding', () => {
       expect(element).toHaveComputedStyle({
-        padding: '0px',
+        'padding-inline': '0px',
       });
     });
 

--- a/libs/designsystem/src/lib/components/form-field/input/input.component.scss
+++ b/libs/designsystem/src/lib/components/form-field/input/input.component.scss
@@ -1,6 +1,8 @@
 @use '../form-field-inputs.shared' as shared;
 @use '~@kirbydesign/core/src/scss/utils';
 
+$padding-block-size-md: shared.$form-field-input-padding * 0.5;
+
 :host {
   &[type='number'] {
     // fallback
@@ -17,7 +19,7 @@
 
 :host(.md) {
   border-radius: utils.size('m');
-  padding-block: 0.5em;
+  padding-block: $padding-block-size-md;
 }
 
 /* clean-css ignore:start */
@@ -50,6 +52,6 @@
   padding: shared.$form-field-input-padding;
 
   :host(.md) + & {
-    padding-block: 0.5em;
+    padding-block: $padding-block-size-md;
   }
 }

--- a/libs/designsystem/src/lib/components/form-field/input/input.component.scss
+++ b/libs/designsystem/src/lib/components/form-field/input/input.component.scss
@@ -13,12 +13,9 @@
     appearance: none;
     margin: 0;
   }
-
-  // height: utils.size('xxxl');
 }
 
 :host(.md) {
-  // height: utils.size('xl');
   border-radius: utils.size('m');
   padding-block: 0.5em;
 }
@@ -37,7 +34,6 @@
  */
 .date-mask-wrapper {
   position: relative;
-  font-size: 1rem;
 }
 
 :host-context(.date-mask-wrapper) {
@@ -46,19 +42,12 @@
 
 .date-mask {
   font-family: shared.$form-field-input-font-family;
-
-  // font-size: shared.$form-field-input-font-size;
-  font-size: 1em;
-
-  // line-height: shared.$form-field-input-line-height;
-  line-height: 1.5;
+  line-height: shared.$form-field-input-line-height;
   color: var(--kirby-white-contrast);
   position: absolute;
   top: 0;
   left: 0;
-
-  // margin: shared.$form-field-input-padding;
-  padding: 1em;
+  padding: shared.$form-field-input-padding;
 
   :host(.md) + & {
     padding-block: 0.5em;

--- a/libs/designsystem/src/lib/components/form-field/input/input.component.scss
+++ b/libs/designsystem/src/lib/components/form-field/input/input.component.scss
@@ -14,12 +14,13 @@
     margin: 0;
   }
 
-  height: utils.size('xxxl');
+  // height: utils.size('xxxl');
 }
 
 :host(.md) {
-  height: utils.size('xl');
+  // height: utils.size('xl');
   border-radius: utils.size('m');
+  padding-block: 0.5em;
 }
 
 /* clean-css ignore:start */
@@ -36,6 +37,7 @@
  */
 .date-mask-wrapper {
   position: relative;
+  font-size: 1rem;
 }
 
 :host-context(.date-mask-wrapper) {
@@ -44,11 +46,21 @@
 
 .date-mask {
   font-family: shared.$form-field-input-font-family;
-  font-size: shared.$form-field-input-font-size;
-  line-height: shared.$form-field-input-line-height;
+
+  // font-size: shared.$form-field-input-font-size;
+  font-size: 1em;
+
+  // line-height: shared.$form-field-input-line-height;
+  line-height: 1.5;
   color: var(--kirby-white-contrast);
   position: absolute;
   top: 0;
   left: 0;
-  margin: shared.$form-field-input-padding;
+
+  // margin: shared.$form-field-input-padding;
+  padding: 1em;
+
+  :host(.md) + & {
+    padding-block: 0.5em;
+  }
 }

--- a/libs/designsystem/src/lib/components/form-field/input/input.component.spec.ts
+++ b/libs/designsystem/src/lib/components/form-field/input/input.component.spec.ts
@@ -89,7 +89,7 @@ describe('InputComponent', () => {
 
     it('should render with correct padding', () => {
       expect(element).toHaveComputedStyle({
-        padding: '0px',
+        'padding-inline': '0px',
       });
     });
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2301 

## What is the new behavior?

Fixes visual bug: Mask/placeholder and input text has wrong position (size `md`)

At unchanged base font size there should be no visual changes. Otherwise improvement by scaling sizes properly relative to base font size.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

But UX review should try to verify that there are no visual regressions introduced.

## Are there any additional context?

**Before**

![image](https://user-images.githubusercontent.com/150451/172385520-c138fcc1-27ad-483c-881f-6863052b3590.png)

**After**

![image](https://user-images.githubusercontent.com/150451/172385327-3102b9e4-7ac5-46a6-b894-e9705cda4c1f.png)

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [x] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

