### PR TITLE
Use import instead of require for highcharts

### DIFF
--- a/libs/designsystem/src/lib/components/chart-deprecated/chart-deprecated-helper.ts
+++ b/libs/designsystem/src/lib/components/chart-deprecated/chart-deprecated-helper.ts
@@ -1,13 +1,15 @@
 import { ElementRef, Injectable } from '@angular/core';
 import { chart, Options } from 'highcharts';
 import * as Highcharts from 'highcharts';
+import more from 'highcharts/highcharts-more';
+import brokenAxis from 'highcharts/modules/broken-axis';
+import solidGauge from 'highcharts/modules/solid-gauge';
 
 // Docs on importing accessibility: https://www.highcharts.com/docs/chart-concepts/accessibility
 
-declare var require: any;
-require('highcharts/highcharts-more')(Highcharts);
-require('highcharts/modules/solid-gauge')(Highcharts);
-require('highcharts/modules/broken-axis')(Highcharts);
+more(Highcharts);
+solidGauge(Highcharts);
+brokenAxis(Highcharts);
 
 @Injectable()
 export class ChartDeprecatedHelper {


### PR DESCRIPTION
This fixes error "require is not defined" by using import instead of require.