### PR TITLE
Change modal close + supplementaryButton to md

### DIFF
--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.html
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.html
@@ -31,13 +31,13 @@
 </ion-content>
 
 <ng-template #closeButton let-icon="icon">
-  <button kirby-button attentionLevel="4" size="sm" (click)="close()">
+  <button kirby-button attentionLevel="4" size="md" (click)="close()">
     <kirby-icon [name]="icon"></kirby-icon>
   </button>
 </ng-template>
 
 <ng-template #supplementaryButton let-btn="btn">
-  <button kirby-button attentionLevel="2" size="sm" (click)="btn.action($event)">
+  <button kirby-button attentionLevel="2" size="md" (click)="btn.action($event)">
     <kirby-icon [name]="btn.iconName"></kirby-icon>
   </button>
 </ng-template>


### PR DESCRIPTION
## Which issue does this PR close?
This PR closes #2350 

## What is the new behavior?
The icon for small buttons has been made smaller in #2245. 

This means that the modal has unintentionally small buttons now, for the close icon and the supplementary button (e.g. the collapse button for the drawer. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

