### PR TITLE
🐛 Allow flag notification colors to be overridden

### DIFF
--- a/libs/core/src/scss/themes/_colors.scss
+++ b/libs/core/src/scss/themes/_colors.scss
@@ -30,6 +30,7 @@ $text-colors: (
 $focus-ring-color: rgb(77 144 254);
 $red-30: #ff878a;
 $danger-background-weak: $red-30;
+$danger-background-weak-contrast: _get-color-contrast($danger-background-weak);
 
 @function get-all-colors() {
   @return map.merge(map.merge($brand-colors, $notification-colors), $system-colors);

--- a/libs/designsystem/src/lib/components/flag/flag.component.scss
+++ b/libs/designsystem/src/lib/components/flag/flag.component.scss
@@ -22,19 +22,30 @@
   }
 }
 
-@each $color-name,
-  $color-value
-    in map.merge(
-      utils.$notification-colors,
-      (
-        'semi-light': utils.get-color('semi-light'),
-        'danger': utils.$danger-background-weak,
-      )
-    )
-{
+$_flag-notification-colors: map.merge(
+  utils.$notification-colors,
+  (
+    'semi-light': utils.get-color('semi-light'),
+  )
+);
+$_flag-notification-colors: map.remove($_flag-notification-colors, 'danger');
+
+@each $color-name, $color-value in $_flag-notification-colors {
   :host(.#{$color-name}) {
-    --kirby-flag-background-color: #{$color-value};
+    // Use utils.get-color() to assign a custom property instead of a color value.
+    // Custom properties can be overridden in consumer projects.
+    --kirby-flag-background-color: #{utils.get-color($color-name)};
     --kirby-flag-color: #{utils.get-color($color-name + '-contrast')};
-    --kirby-flag-border-color: #{$color-value};
+    --kirby-flag-border-color: #{utils.get-color($color-name)};
   }
+}
+
+// <kirby-flag> uses a different "danger" notification color.
+// Overriding `--kirby-danger` in a consumer project will not have any effect on
+// the background color for danger flags.
+// See https://github.com/kirbydesign/designsystem/issues/2041
+:host(.danger) {
+  --kirby-flag-background-color: #{utils.$danger-background-weak};
+  --kirby-flag-color: #{utils.$danger-background-weak-contrast};
+  --kirby-flag-border-color: #{utils.$danger-background-weak};
 }


### PR DESCRIPTION
Use CSS custom property instead of color value to make it possible.

Fixes https://github.com/kirbydesign/designsystem/issues/2353

## Which issue does this PR close?

This PR closes # (insert issue number here)

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

