### PR TITLE
Update minor version

### DIFF
--- a/apps/cookbook/src/app/page/header/header.component.ts
+++ b/apps/cookbook/src/app/page/header/header.component.ts
@@ -14,7 +14,7 @@ export const navigationItems: HeaderLink[] = [
   { text: 'Accessibility', route: '/home/accessibility-in-kirby' },
   {
     text: 'Changelog',
-    externalUrl: 'https://github.com/kirbydesign/designsystem/blob/main/CHANGELOG.MD',
+    externalUrl: 'https://github.com/kirbydesign/designsystem/blob/main/CHANGELOG.md',
   },
 
   { text: 'GitHub', externalUrl: 'https://github.com/kirbydesign/designsystem' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "designsystem",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "designsystem",
-      "version": "6.0.1",
+      "version": "6.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "designsystem",
-  "version": "6.0.1",
+  "version": "6.1.0",
   "description": "Kirby Design Angular Components. This library provides Angular wrappers for the @kirbydesign/core package, for smoother integration into Angular projects.",
   "engines": {
     "node": ">=16.0.0",


### PR DESCRIPTION
Minor version was not correctly updated prior to releasing v6.1.

In addition, this adds a fix for a faulty changelog link.