### PR TITLE
Apply focus styles to Action Sheet cancel button

### DIFF
--- a/libs/designsystem/src/lib/components/modal/action-sheet/action-sheet.component.scss
+++ b/libs/designsystem/src/lib/components/modal/action-sheet/action-sheet.component.scss
@@ -1,3 +1,4 @@
+@use '~@kirbydesign/core/src/scss/interaction-state';
 @use '~@kirbydesign/core/src/scss/utils';
 
 $margin-horizontal: utils.size('l');
@@ -39,9 +40,10 @@ kirby-card {
 }
 
 .cancel-btn {
+  @include interaction-state.apply-focus-visible($shadow: utils.get-elevation(8));
+
   font-weight: utils.font-weight('bold');
   margin-top: utils.size('s');
   margin-bottom: utils.size('m');
   pointer-events: auto;
-  box-shadow: utils.get-elevation(8);
 }


### PR DESCRIPTION
Closes https://github.com/kirbydesign/designsystem/issues/2340

## Which issue does this PR close?

This PR closes # (insert issue number here)

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

When the cancel button receives focus by "tabbing with keyboard" a blue focus ring appears.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

