### PR TITLE
Avoid removing focus from Segmented Control on embedded badge click

### DIFF
--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
@@ -3,7 +3,7 @@
   [value]="value?.id"
   [scrollable]="disableChangeOnSwipe"
   (ionChange)="onSegmentSelect($event.detail.value)"
-  (click)="preventWrapperClick($event)"
+  (click)="preventOutsideClick($event)"
 >
   <div *ngFor="let item of items" class="segment-btn-wrapper">
     <ion-segment-button [value]="item.id">{{ item.text }}</ion-segment-button>

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
@@ -20,9 +20,14 @@ export enum SegmentedControlMode {
 export class SegmentedControlComponent {
   constructor(private iconRegistryService: IconRegistryService) {}
 
-  preventWrapperClick(event: Event) {
+  /**
+   * Ensure that the click actually did originate from within the segment-button.
+   * We do not want to react to clicks on e.g. segment-btn-wrapper or badge.
+   */
+  preventOutsideClick(event: TouchEvent) {
     if (event.target instanceof HTMLElement) {
-      if (event.target.classList.contains('segment-btn-wrapper')) {
+      const targetIsInSegmentBtn = !!event.target.closest('ion-segment-button');
+      if (!targetIsInSegmentBtn) {
         event.stopImmediatePropagation();
       }
     }


### PR DESCRIPTION
## Which issue does this PR close?
closes #2388 closes #2349

## What is the new behavior?
I have refactored the wrapper click prevention to instead determine if the click is coming from the `ion-segment-button` or its contents. This should exclude both the wrapper, and also other elements like the badge. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

