### PR TITLE
Missing close icon in FAB-sheet 

### DIFF
--- a/apps/cookbook/src/app/showcase/fab-sheet-showcase/fab-sheet-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/fab-sheet-showcase/fab-sheet-showcase.component.html
@@ -15,12 +15,24 @@
   </fieldset>
   <cookbook-fab-sheet-example [disableFabSheet]="disableFabSheet"></cookbook-fab-sheet-example>
   <cookbook-code-viewer [html]="exampleHtml"></cookbook-code-viewer>
-  (Optional) if you need to obtain data back from the fab sheet, you can pass a callback function:
+
+  <p>
+    The floating action button is always shown with a close-icon when in its opened state. In order
+    to show the icon correctly it needs to be configured as described in
+    <a href="https://github.com/kirbydesign/designsystem#icons" class="kirby-external-icon"
+      >the project readme</a
+    >.
+  </p>
+
+  <p>
+    (Optional) if you need to obtain data back from the fab sheet, you can pass a callback function:
+  </p>
   <!-- prettier-ignore -->
   <cookbook-code-viewer language="html">(itemSelect)="onItemSelect($event)"</cookbook-code-viewer>
   where <code>onItemSelect</code> can be e.g.:
   <!-- prettier-ignore -->
   <cookbook-code-viewer language="ts">onItemSelect(item: ActionSheetItem) {{ '{' }}...{{ '}' }}</cookbook-code-viewer>
+
   <h4>Fab sheet properties:</h4>
   <cookbook-api-description-properties
     [properties]="properties"

--- a/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.html
+++ b/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.html
@@ -4,12 +4,7 @@
   (click)="hideActions(fab)"
 ></ion-backdrop>
 <ion-fab #fab (click)="disabled || onFabClick(fab)">
-  <ion-fab-button
-    [disabled]="disabled"
-    [attr.disabled]="disabled ? true : null"
-    tabindex="-1"
-    closeIcon="close-outline"
-  >
+  <ion-fab-button [disabled]="disabled" [attr.disabled]="disabled ? true : null" tabindex="-1">
     <ng-content select="kirby-icon"></ng-content>
   </ion-fab-button>
   <ion-fab-list *ngIf="actionSheet" side="top" class="{{ horizontalAlignment }}">


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2402

## What is the new behavior?
The housekeeping done in #2302 only worked in the cookbook because we have ionicons installed which meant that the ion-fab-button could correctly locate the close icon. Projects should not have to install Ionicons, so this PR introduces a workaround where we place our own close icon where ion-fab-button expects it to be. 

Therefore, the custom close icon introduced in #2302 is removed again, and a description of how to place the existing close icon as needed is added instead.

This is already how it is done in the DRB project, so it solves the problem described in #2402. With this fix installed, we now get the following close icon: 

https://user-images.githubusercontent.com/42470636/182592949-05ef9470-4b43-467b-9a75-ba87116d757f.mov


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

