### PR TITLE
✅ Add 1ms timeout

### DIFF
--- a/libs/designsystem/src/lib/testing/test-helper.ts
+++ b/libs/designsystem/src/lib/testing/test-helper.ts
@@ -147,7 +147,7 @@ export class TestHelper {
   }
 
   public static waitForResizeObserver(): Promise<void> {
-    return TestHelper.waitForTimeout();
+    return TestHelper.waitForTimeout(1);
   }
 
   public static waitForTimeout(timeoutInMs?: number): Promise<void> {


### PR DESCRIPTION
Adding a short timeout when waiting for ResizeObserver in modal helper
test seems to fix failing tests

## Which issue does this PR close?

This PR closes NO ISSUE

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

