### PR TITLE
Add missing hover and active states to tabs on desktop

### DIFF
--- a/libs/designsystem/src/lib/components/tabs/tab-button/tab-button.component.scss
+++ b/libs/designsystem/src/lib/components/tabs/tab-button/tab-button.component.scss
@@ -1,6 +1,16 @@
+@use '~@kirbydesign/core/src/scss/interaction-state';
 @use '~@kirbydesign/core/src/scss/utils';
 
 ion-tab-button {
+  @include interaction-state.apply-hover {
+    --background: #{interaction-state.get-state-color('white', 'xxxs')};
+  }
+
+  @include interaction-state.apply-active {
+    --background: #{interaction-state.get-state-color('white', 'xxs')};
+  }
+
+  transition: interaction-state.transition();
   height: 100%;
   flex: 1 1 0%;
   max-width: 168px;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2244 

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

This solution is temporary. Tabs on desktop will eventually be obsolete and replaced by the new navigation menu.

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

