### PR TITLE
Change background color on focus

### DIFF
--- a/libs/core/src/scss/interaction-state/_focus.scss
+++ b/libs/core/src/scss/interaction-state/_focus.scss
@@ -36,6 +36,26 @@
   }
 }
 
+// -----------------------------------------------------------------------------
+// In some cases a focus ring is not desirable, e.g., when buttons are stacked
+// (see Action Sheet). As an alternative use the state layer.
+// -----------------------------------------------------------------------------
+@mixin apply-focus-without-ring {
+  @include utils.not-touch {
+    &:focus,
+    &:focus:not(:focus-visible),
+    &:focus-visible {
+      // Remove the focus ring
+      box-shadow: none;
+
+      // Change background color instead
+      --state-layer-opacity: 0.08;
+    }
+
+    @content;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // The apply-focus-part mixin is used where ionics components do not allow
 // us to apply styling directly to the tabbed element, as it is hidden inside

--- a/libs/core/src/scss/interaction-state/_focus.scss
+++ b/libs/core/src/scss/interaction-state/_focus.scss
@@ -42,7 +42,7 @@
 // (see Action Sheet).
 // As an alternative change the state layer opacity - similar to hover.
 // -----------------------------------------------------------------------------
-@mixin apply-focus-visible-without-ring(
+@mixin apply-focus-visible-background(
   $loudness: interaction-state.$default-loudness-hover,
   $make-lighter: false
 ) {

--- a/libs/core/src/scss/interaction-state/_focus.scss
+++ b/libs/core/src/scss/interaction-state/_focus.scss
@@ -1,4 +1,5 @@
 @use 'interaction-state.utilities';
+@use 'layer';
 @use '../utils';
 
 // ---------------------------------------------------------------------------
@@ -38,9 +39,13 @@
 
 // -----------------------------------------------------------------------------
 // In some cases a focus ring is not desirable, e.g., when buttons are stacked
-// (see Action Sheet). As an alternative use the state layer.
+// (see Action Sheet).
+// As an alternative change the state layer opacity - similar to hover.
 // -----------------------------------------------------------------------------
-@mixin apply-focus-without-ring {
+@mixin apply-focus-visible-without-ring(
+  $loudness: interaction-state.$default-loudness-hover,
+  $make-lighter: false
+) {
   @include utils.not-touch {
     &:focus,
     &:focus:not(:focus-visible),
@@ -48,8 +53,8 @@
       // Remove the focus ring
       box-shadow: none;
 
-      // Change background color instead
-      --state-layer-opacity: 0.08;
+      // Change "background color" (state layer opacity) instead
+      @include layer.apply-state($loudness, $make-lighter);
     }
 
     @content;

--- a/libs/designsystem/src/lib/components/accordion/accordion-item.component.html
+++ b/libs/designsystem/src/lib/components/accordion/accordion-item.component.html
@@ -1,7 +1,8 @@
 <div class="content-layer">
   <div
-    (click)="isExpanded = !isExpanded"
-    (keydown.ENTER)="isExpanded = !isExpanded"
+    (click)="_onToggleExpanded($event)"
+    (keydown.ENTER)="_onToggleExpanded($event)"
+    (keydown.space)="_onToggleExpanded($event)"
     class="header"
     role="button"
     tabindex="0"

--- a/libs/designsystem/src/lib/components/accordion/accordion-item.component.html
+++ b/libs/designsystem/src/lib/components/accordion/accordion-item.component.html
@@ -3,6 +3,7 @@
     (click)="isExpanded = !isExpanded"
     class="header"
     role="button"
+    tabindex="0"
     [class.expanded]="isExpanded"
     [attr.aria-expanded]="isExpanded"
     [attr.aria-controls]="_contentId"

--- a/libs/designsystem/src/lib/components/accordion/accordion-item.component.html
+++ b/libs/designsystem/src/lib/components/accordion/accordion-item.component.html
@@ -1,6 +1,7 @@
 <div class="content-layer">
   <div
     (click)="isExpanded = !isExpanded"
+    (keydown.ENTER)="isExpanded = !isExpanded"
     class="header"
     role="button"
     tabindex="0"

--- a/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
+++ b/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
@@ -13,6 +13,9 @@ $padding: utils.size('s');
 }
 
 .header {
+  @include interaction-state.apply-focus-visible-without-ring('xxxs') {
+    outline: 0;
+  }
   @include interaction-state.apply-hover('xxxs');
   @include interaction-state.apply-active('xxs');
 

--- a/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
+++ b/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
@@ -13,7 +13,7 @@ $padding: utils.size('s');
 }
 
 .header {
-  @include interaction-state.apply-focus-visible-without-ring('xxxs') {
+  @include interaction-state.apply-focus-visible-background('xxxs') {
     outline: 0;
   }
   @include interaction-state.apply-hover('xxxs');

--- a/libs/designsystem/src/lib/components/accordion/accordion-item.component.ts
+++ b/libs/designsystem/src/lib/components/accordion/accordion-item.component.ts
@@ -24,4 +24,9 @@ export class AccordionItemComponent {
   // IDs used for a11y labelling
   _titleId = `kirby-accordion-item-title-${++uniqueId}`;
   _contentId = `kirby-accordion-item-content-${uniqueId}`;
+
+  _onToggleExpanded(event: KeyboardEvent) {
+    event.preventDefault();
+    this.isExpanded = !this.isExpanded;
+  }
 }

--- a/libs/designsystem/src/lib/components/modal/action-sheet/action-sheet.component.scss
+++ b/libs/designsystem/src/lib/components/modal/action-sheet/action-sheet.component.scss
@@ -24,7 +24,7 @@ $max-width: 375px;
   max-width: calc(#{$max-width} - var(--kirby-internal-margin-horizontal-total));
 
   button[kirby-button].no-decoration {
-    @include interaction-state.apply-focus-visible-without-ring;
+    @include interaction-state.apply-focus-visible-background;
   }
 }
 

--- a/libs/designsystem/src/lib/components/modal/action-sheet/action-sheet.component.scss
+++ b/libs/designsystem/src/lib/components/modal/action-sheet/action-sheet.component.scss
@@ -24,7 +24,7 @@ $max-width: 375px;
   max-width: calc(#{$max-width} - var(--kirby-internal-margin-horizontal-total));
 
   button[kirby-button].no-decoration {
-    @include interaction-state.apply-focus-without-ring;
+    @include interaction-state.apply-focus-visible-without-ring;
   }
 }
 

--- a/libs/designsystem/src/lib/components/modal/action-sheet/action-sheet.component.scss
+++ b/libs/designsystem/src/lib/components/modal/action-sheet/action-sheet.component.scss
@@ -22,6 +22,19 @@ $max-width: 375px;
   margin: 0 auto;
   width: calc(100vw - var(--kirby-internal-margin-horizontal-total));
   max-width: calc(#{$max-width} - var(--kirby-internal-margin-horizontal-total));
+
+  button[kirby-button].no-decoration {
+    // TODO: Move this reset/change/alternative focus into the focus partial
+    @include interaction-state.apply-focus-visible {
+      // Remove the focus ring
+      box-shadow: none !important;
+
+      // Change background color instead
+      &:focus-visible {
+        --state-layer-opacity: 0.08;
+      }
+    }
+  }
 }
 
 kirby-card {

--- a/libs/designsystem/src/lib/components/modal/action-sheet/action-sheet.component.scss
+++ b/libs/designsystem/src/lib/components/modal/action-sheet/action-sheet.component.scss
@@ -24,16 +24,7 @@ $max-width: 375px;
   max-width: calc(#{$max-width} - var(--kirby-internal-margin-horizontal-total));
 
   button[kirby-button].no-decoration {
-    // TODO: Move this reset/change/alternative focus into the focus partial
-    @include interaction-state.apply-focus-visible {
-      // Remove the focus ring
-      box-shadow: none !important;
-
-      // Change background color instead
-      &:focus-visible {
-        --state-layer-opacity: 0.08;
-      }
-    }
+    @include interaction-state.apply-focus-without-ring;
   }
 }
 

--- a/libs/designsystem/src/lib/components/tabs/tab-button/tab-button.component.scss
+++ b/libs/designsystem/src/lib/components/tabs/tab-button/tab-button.component.scss
@@ -1,6 +1,14 @@
 @use '~@kirbydesign/core/src/scss/utils';
 
 ion-tab-button {
+  // TODO: Uncomment when https://github.com/kirbydesign/designsystem/pull/2419 is merged
+  // &.ion-focused {
+  //   @include interaction-state.apply-focus-visible-without-ring {
+  //     --background: #{interaction-state.get-state-color('white', 'xxxs')};
+  //     --background-focused-opacity: 0;
+  //   }
+  // }
+
   height: 100%;
   flex: 1 1 0%;
   max-width: 168px;

--- a/libs/designsystem/src/lib/components/tabs/tab-button/tab-button.component.scss
+++ b/libs/designsystem/src/lib/components/tabs/tab-button/tab-button.component.scss
@@ -2,13 +2,12 @@
 @use '~@kirbydesign/core/src/scss/utils';
 
 ion-tab-button {
-  // TODO: Uncomment when https://github.com/kirbydesign/designsystem/pull/2419 is merged
-  // &.ion-focused {
-  //   @include interaction-state.apply-focus-visible-without-ring {
-  //     --background: #{interaction-state.get-state-color('white', 'xxxs')};
-  //     --background-focused-opacity: 0;
-  //   }
-  // }
+  &.ion-focused {
+    @include interaction-state.apply-focus-visible-without-ring {
+      --background: #{interaction-state.get-state-color('white', 'xxxs')};
+      --background-focused-opacity: 0;
+    }
+  }
 
   @include interaction-state.apply-hover {
     --background: #{interaction-state.get-state-color('white', 'xxxs')};

--- a/libs/designsystem/src/lib/components/tabs/tab-button/tab-button.component.scss
+++ b/libs/designsystem/src/lib/components/tabs/tab-button/tab-button.component.scss
@@ -3,7 +3,7 @@
 
 ion-tab-button {
   &.ion-focused {
-    @include interaction-state.apply-focus-visible-without-ring {
+    @include interaction-state.apply-focus-visible-background {
       --background: #{interaction-state.get-state-color('white', 'xxxs')};
       --background-focused-opacity: 0;
     }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2236 

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

Applies alternative focus style. Instead of displaying focus ring the background color is changed by adjusting the state layer opacity.

- [x] Action sheet options
- [x] Accordion
- [x] Tabs on desktop view - awaiting https://github.com/kirbydesign/designsystem/pull/2419

Dropdown will be solved by https://github.com/kirbydesign/designsystem/issues/2342

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

