### PR TITLE
Enhancement/Add option to specify which dates should be enabled in the calendar

### DIFF
--- a/apps/cookbook/src/app/examples/calendar-example/calendar-card-example.component.html
+++ b/apps/cookbook/src/app/examples/calendar-example/calendar-card-example.component.html
@@ -5,6 +5,7 @@
     [disablePastDates]="disablePastDates"
     [disableFutureDates]="disableFutureDates"
     [disabledDates]="setDisabledDates ? disabledDates : null"
+    [enabledDates]="setEnabledDates ? enabledDates : null"
     [minDate]="setMinDate ? minDate : null"
     [maxDate]="setMaxDate ? maxDate : null"
     [todayDate]="setTodayDate ? todayDate : null"

--- a/apps/cookbook/src/app/examples/calendar-example/calendar-card-example.component.ts
+++ b/apps/cookbook/src/app/examples/calendar-example/calendar-card-example.component.ts
@@ -13,6 +13,7 @@ export class CalendarCardExampleComponent implements OnChanges {
   @Input() disablePastDates = false;
   @Input() disableFutureDates = false;
   @Input() setDisabledDates = false;
+  @Input() setEnabledDates = false;
   @Input() setMinDate = false;
   @Input() setMaxDate = false;
   @Input() setTodayDate = false;
@@ -23,6 +24,7 @@ export class CalendarCardExampleComponent implements OnChanges {
   maxDate: Date;
   todayDate: Date;
   disabledDates: Date[];
+  enabledDates: Date[];
   yearNavigatorOptions = { from: -6, to: 3 };
   timeZoneName = Intl.DateTimeFormat().resolvedOptions().timeZone;
   constructor() {
@@ -72,6 +74,10 @@ export class CalendarCardExampleComponent implements OnChanges {
     this.todayDate = addDays(today, 3); // artificial but works for demo
 
     this.disabledDates = [3, 5, 7, 10, 15, 25, 28, 35].map((daysFromToday) =>
+      addDays(today, daysFromToday)
+    );
+
+    this.enabledDates = [3, 5, 7, 10, 15, 25, 28, 35].map((daysFromToday) =>
       addDays(today, daysFromToday)
     );
   }

--- a/apps/cookbook/src/app/showcase/calendar-showcase/calendar-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/calendar-showcase/calendar-showcase.component.html
@@ -12,6 +12,7 @@
         [disablePastDates]="disablePastDates"
         [disableFutureDates]="disableFutureDates"
         [setDisabledDates]="setDisabledDates"
+        [setEnabledDates]="setEnabledDates"
         [setMinDate]="setMinDate"
         [setMaxDate]="setMaxDate"
         [setTodayDate]="setTodayDate"
@@ -26,6 +27,7 @@
           <kirby-checkbox [(checked)]="disablePastDates" text="Disable past dates"></kirby-checkbox>
           <kirby-checkbox [(checked)]="disableFutureDates" text="Disable future dates"></kirby-checkbox>
           <kirby-checkbox [(checked)]="setDisabledDates" text="Set disabled dates"></kirby-checkbox>
+          <kirby-checkbox [(checked)]="setEnabledDates" text="Set enabled dates"></kirby-checkbox>
           <kirby-checkbox [(checked)]="setMinDate" text="Set min date ({{minDate | date:'dd-MM-yyyy':(useTimezoneUTC ? 'UTC' : undefined)}})"></kirby-checkbox>
           <kirby-checkbox [(checked)]="setMaxDate" text="Set max date ({{maxDate | date:'dd-MM-yyyy':(useTimezoneUTC ? 'UTC' : undefined)}})"></kirby-checkbox>
           <kirby-checkbox [(checked)]="setTodayDate" text="Set today date ({{todayDate | date:'dd-MM-yyyy':(useTimezoneUTC ? 'UTC' : undefined)}})"></kirby-checkbox>

--- a/apps/cookbook/src/app/showcase/calendar-showcase/calendar-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/calendar-showcase/calendar-showcase.component.ts
@@ -92,7 +92,15 @@ export class CalendarShowcaseComponent {
     },
     {
       name: 'disabledDates',
-      description: '(Optional) Array of dates that should not be selectable.',
+      description:
+        '(Optional) Array of dates that should not be selectable. Should not be used together with enabledDates.',
+      defaultValue: 'null',
+      type: ['Date[]'],
+    },
+    {
+      name: 'enabledDates',
+      description:
+        '(Optional) Array of dates that should be selectable. Should not be used together with disabledDates.',
       defaultValue: 'null',
       type: ['Date[]'],
     },

--- a/apps/cookbook/src/app/showcase/calendar-showcase/calendar-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/calendar-showcase/calendar-showcase.component.ts
@@ -18,6 +18,7 @@ export class CalendarShowcaseComponent {
   setMaxDate = false;
   setTodayDate = false;
   setDisabledDates = false;
+  setEnabledDates = false;
   useTimezoneUTC = false;
   showYearNavigator = false;
   minDate: Date;

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.spec.ts
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.spec.ts
@@ -70,6 +70,7 @@ describe('CalendarComponent', () => {
     expect(headerTexts).toEqual(['M', 'T', 'W', 'T', 'F', 'S', 'S']);
 
     const dayTexts = trimmedTexts('.day.current-month');
+
     expect(dayTexts.slice(0, 5)).toEqual(['1', '2', '3', '4', '5']);
     expect(dayTexts.length).toEqual(31);
   });
@@ -85,48 +86,58 @@ describe('CalendarComponent', () => {
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
 
     spectator.click(SEL_NAV_BACK);
+
     verifyMonthAndYear('July 1997');
+
     spectator.click(SEL_NAV_FORWARD);
+
     verifyMonthAndYear('August 1997');
+
     spectator.click(SEL_NAV_FORWARD);
     verifyMonthAndYear('September 1997');
+
     spectator.click(SEL_NAV_FORWARD);
     spectator.click(SEL_NAV_FORWARD);
     spectator.click(SEL_NAV_FORWARD);
     spectator.click(SEL_NAV_FORWARD);
+
     verifyMonthAndYear('January 1998');
   });
 
   it('should not be possible to navigate to any month preceding minDate, if specified', () => {
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
     spectator.setInput('minDate', localMidnightDate('1997-06-15'));
+    spectator.click(SEL_NAV_BACK);
+    spectator.click(SEL_NAV_BACK);
 
-    spectator.click(SEL_NAV_BACK);
-    spectator.click(SEL_NAV_BACK);
     verifyMonthAndYear('June 1997');
     expect(spectator.query(SEL_NAV_BACK)).toBeDisabled();
+
     spectator.click(SEL_NAV_BACK);
+
     verifyMonthAndYear('June 1997');
   });
 
   it('should not be possible to navigate to any month exceeding maxDate, if specified', () => {
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
     spectator.setInput('maxDate', localMidnightDate('1997-10-01'));
+    spectator.click(SEL_NAV_FORWARD);
+    spectator.click(SEL_NAV_FORWARD);
 
-    spectator.click(SEL_NAV_FORWARD);
-    spectator.click(SEL_NAV_FORWARD);
     verifyMonthAndYear('October 1997');
     expect(spectator.query(SEL_NAV_FORWARD)).toBeDisabled();
+
     spectator.click(SEL_NAV_FORWARD);
+
     verifyMonthAndYear('October 1997');
   });
 
   it('should emit a dateChange event when a valid date is clicked', () => {
-    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
-
     const captured = captureDateChangeEvents();
 
+    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
     clickDayOfMonth(14);
+
     expect(captured.event).toEqual(localMidnightDate('1997-08-14'));
   });
 
@@ -139,148 +150,152 @@ describe('CalendarComponent', () => {
   });
 
   it('should not emit a dateChange event if disableWeekends is true and a weekend date is clicked', () => {
-    spectator.setInput('disableWeekends', true);
-    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
-
     const captured = captureDateChangeEvents();
 
+    spectator.setInput('disableWeekends', true);
+    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
     clickDayOfMonth(24); // August 24th is a Sunday
+
     expect(captured.event).toBeUndefined();
   });
 
   it('should not emit a dateChange event if disablePastDates is true and a date in the past is clicked', () => {
+    const captured = captureDateChangeEvents();
+
     spectator.setInput('disablePastDates', true);
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
     spectator.setInput('todayDate', localMidnightDate('1997-08-29'));
-
-    const captured = captureDateChangeEvents();
-
     clickDayOfMonth(1); // August 1st is in the past
+
     expect(captured.event).toBeUndefined();
   });
 
   it('should not emit a dateChange event if disableFutureDates is true and a date in the future is clicked', () => {
+    const captured = captureDateChangeEvents();
+
     spectator.setInput('disableFutureDates', true);
     spectator.setInput('todayDate', localMidnightDate('1997-08-29'));
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
-
-    const captured = captureDateChangeEvents();
-
     clickDayOfMonth(31); // August 31st is in the future
+
     expect(captured.event).toBeUndefined();
   });
 
   it('should not emit a dateChange event if clicking a date that was passed in disabledDates', () => {
-    spectator.setInput('disabledDates', ['1997-08-25', '1997-08-26'].map(localMidnightDate));
-    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
-
     const captured = captureDateChangeEvents();
 
+    spectator.setInput('disabledDates', ['1997-08-25', '1997-08-26'].map(localMidnightDate));
+    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
     clickDayOfMonth(26); // August 26st was explicitly disabled
+
     expect(captured.event).toBeUndefined();
   });
 
   it('should not emit a dateChange event if clicking a date that was not passed in enabledDates', () => {
-    spectator.setInput('enabledDates', ['1997-08-25', '1997-08-26'].map(localMidnightDate));
-    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
-
     const captured = captureDateChangeEvents();
 
+    spectator.setInput('enabledDates', ['1997-08-25', '1997-08-26'].map(localMidnightDate));
+    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
     clickDayOfMonth(27); // August 27st was implicitly disabled
+
     expect(captured.event).toBeUndefined();
   });
 
   it('should emit a dateChange event if clicking a date that was passed in enabledDates', () => {
-    spectator.setInput('enabledDates', ['1997-08-25', '1997-08-26'].map(localMidnightDate));
-    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
-
     const captured = captureDateChangeEvents();
 
+    spectator.setInput('enabledDates', ['1997-08-25', '1997-08-26'].map(localMidnightDate));
+    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
     clickDayOfMonth(26); // August 26st was explicitly enabled
+
     expect(captured.event).toBeTruthy();
   });
 
   it('should not emit a dateChange event if clicking the already selected date', () => {
-    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
-
     const captured = captureDateChangeEvents();
 
+    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
     clickDayOfMonth(29);
+
     expect(captured.event).toBeUndefined();
   });
 
   it('should always emit a dateChange event when clicking today if alwaysEnableToday is set to true', () => {
+    const captured = captureDateChangeEvents();
     const today = localMidnightDate('1997-08-28');
+
     spectator.setInput('disabledDates', [today]);
     spectator.setInput('todayDate', today);
     spectator.setInput('alwaysEnableToday', true);
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
-
-    const captured = captureDateChangeEvents();
-
     clickDayOfMonth(28); // August 28th is was disabled but we override
+
     expect(captured.event).toEqual(today);
   });
 
   it('should emit dateChange event as UTC midnights when timezone is set to UTC', () => {
-    spectator.setInput('timezone', 'UTC');
-    spectator.setInput('selectedDate', utcMidnightDate('1997-08-29'));
-
     const captured = captureDateChangeEvents();
 
+    spectator.setInput('timezone', 'UTC');
+    spectator.setInput('selectedDate', utcMidnightDate('1997-08-29'));
     clickDayOfMonth(14);
+
     expect(captured.event).toEqual(utcMidnightDate('1997-08-14'));
   });
 
   it('should emit dateSelect event when clicking a date that is not already selected', () => {
-    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
-
     const captured = captureDateSelectEvents();
 
+    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
     clickDayOfMonth(14);
+
     expect(captured.event).toEqual(localMidnightDate('1997-08-14'));
   });
 
   it('should emit dateSelect event when clicking the already selected date', () => {
-    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
-
     const captured = captureDateSelectEvents();
 
+    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
     clickDayOfMonth(29);
+
     expect(captured.event).toEqual(localMidnightDate('1997-08-29'));
   });
 
   it('should emit dateSelect event as UTC midnights when timezone is set to UTC', () => {
-    spectator.setInput('timezone', 'UTC');
-    spectator.setInput('selectedDate', utcMidnightDate('1997-08-29'));
-
     const captured = captureDateSelectEvents();
 
+    spectator.setInput('timezone', 'UTC');
+    spectator.setInput('selectedDate', utcMidnightDate('1997-08-29'));
     clickDayOfMonth(14);
+
     expect(captured.event).toEqual(utcMidnightDate('1997-08-14'));
   });
 
-  it('should be tolerant of date input (selectedDate, todayDate, minDate, maxDate, and disabledDates) as both UTC midnight and local time midnight', () => {
+  it('should be tolerant of date input (selectedDate, todayDate, minDate, maxDate, disabledDates and enabledDates) as both UTC midnight and local time midnight', () => {
     const localDate = localMidnightDate('1997-08-29');
     const utcDate = utcMidnightDate('1997-08-29');
 
     spectator.setInput('selectedDate', localDate);
     expect(spectator.component.selectedDate).toEqual(localDate);
+
     spectator.setInput('selectedDate', utcDate);
     expect(spectator.component.selectedDate).toEqual(localDate);
 
     spectator.setInput('todayDate', localDate);
     expect(spectator.component.todayDate).toEqual(localDate);
+
     spectator.setInput('todayDate', utcDate);
     expect(spectator.component.todayDate).toEqual(localDate);
 
     spectator.setInput('minDate', localDate);
     expect(spectator.component.minDate).toEqual(localDate);
+
     spectator.setInput('minDate', utcDate);
     expect(spectator.component.minDate).toEqual(localDate);
 
     spectator.setInput('maxDate', localDate);
     expect(spectator.component.maxDate).toEqual(localDate);
+
     spectator.setInput('maxDate', utcDate);
     expect(spectator.component.maxDate).toEqual(localDate);
 
@@ -289,11 +304,13 @@ describe('CalendarComponent', () => {
 
     spectator.setInput('disabledDates', localDates);
     expect(spectator.component.disabledDates).toEqual(localDates);
+
     spectator.setInput('disabledDates', utcDates);
     expect(spectator.component.disabledDates).toEqual(localDates);
 
     spectator.setInput('enabledDates', localDates);
     expect(spectator.component.enabledDates).toEqual(localDates);
+
     spectator.setInput('enabledDates', utcDates);
     expect(spectator.component.enabledDates).toEqual(localDates);
   });
@@ -400,8 +417,8 @@ describe('CalendarComponent', () => {
 
       it('should change year on navigation', () => {
         const firstNavigatedYearIndex = spectator.component.navigatedYear;
-        spectator.setInput('selectedDate', new Date(todayDateYear, 11, 31));
 
+        spectator.setInput('selectedDate', new Date(todayDateYear, 11, 31));
         spectator.component._changeMonth(1);
 
         expect(spectator.component.activeYear).toEqual('2022');
@@ -410,6 +427,7 @@ describe('CalendarComponent', () => {
 
       it('should emit selected year on navigation', () => {
         const captured = captureYearSelectEvents();
+
         spectator.triggerEventHandler(DropdownComponent, 'change', '2040');
 
         expect(captured.event).toEqual(2040);

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.spec.ts
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.spec.ts
@@ -56,7 +56,6 @@ describe('CalendarComponent', () => {
   it('should initially render the current month if selectedDate is not specified', () => {
     const currentDay = startOfDay(new Date());
     const currentMonth = startOfMonth(new Date());
-
     verifyMonthAndYear(format(currentMonth, 'MMMM yyyy'));
     expect(spectator.query('.day.today')).toHaveText(format(currentDay, 'd'));
   });
@@ -64,13 +63,10 @@ describe('CalendarComponent', () => {
   it('should initially render the month of selectedDate if specified', () => {
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
 
-    verifyMonthAndYear('August 1997');
-
     const headerTexts = trimmedTexts('th');
-    expect(headerTexts).toEqual(['M', 'T', 'W', 'T', 'F', 'S', 'S']);
-
     const dayTexts = trimmedTexts('.day.current-month');
-
+    verifyMonthAndYear('August 1997');
+    expect(headerTexts).toEqual(['M', 'T', 'W', 'T', 'F', 'S', 'S']);
     expect(dayTexts.slice(0, 5)).toEqual(['1', '2', '3', '4', '5']);
     expect(dayTexts.length).toEqual(31);
   });
@@ -94,6 +90,7 @@ describe('CalendarComponent', () => {
     verifyMonthAndYear('August 1997');
 
     spectator.click(SEL_NAV_FORWARD);
+
     verifyMonthAndYear('September 1997');
 
     spectator.click(SEL_NAV_FORWARD);
@@ -107,6 +104,7 @@ describe('CalendarComponent', () => {
   it('should not be possible to navigate to any month preceding minDate, if specified', () => {
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
     spectator.setInput('minDate', localMidnightDate('1997-06-15'));
+
     spectator.click(SEL_NAV_BACK);
     spectator.click(SEL_NAV_BACK);
 
@@ -121,6 +119,7 @@ describe('CalendarComponent', () => {
   it('should not be possible to navigate to any month exceeding maxDate, if specified', () => {
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
     spectator.setInput('maxDate', localMidnightDate('1997-10-01'));
+
     spectator.click(SEL_NAV_FORWARD);
     spectator.click(SEL_NAV_FORWARD);
 
@@ -134,8 +133,8 @@ describe('CalendarComponent', () => {
 
   it('should emit a dateChange event when a valid date is clicked', () => {
     const captured = captureDateChangeEvents();
-
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
+
     clickDayOfMonth(14);
 
     expect(captured.event).toEqual(localMidnightDate('1997-08-14'));
@@ -151,9 +150,9 @@ describe('CalendarComponent', () => {
 
   it('should not emit a dateChange event if disableWeekends is true and a weekend date is clicked', () => {
     const captured = captureDateChangeEvents();
-
     spectator.setInput('disableWeekends', true);
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
+
     clickDayOfMonth(24); // August 24th is a Sunday
 
     expect(captured.event).toBeUndefined();
@@ -161,10 +160,10 @@ describe('CalendarComponent', () => {
 
   it('should not emit a dateChange event if disablePastDates is true and a date in the past is clicked', () => {
     const captured = captureDateChangeEvents();
-
     spectator.setInput('disablePastDates', true);
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
     spectator.setInput('todayDate', localMidnightDate('1997-08-29'));
+
     clickDayOfMonth(1); // August 1st is in the past
 
     expect(captured.event).toBeUndefined();
@@ -172,10 +171,10 @@ describe('CalendarComponent', () => {
 
   it('should not emit a dateChange event if disableFutureDates is true and a date in the future is clicked', () => {
     const captured = captureDateChangeEvents();
-
     spectator.setInput('disableFutureDates', true);
     spectator.setInput('todayDate', localMidnightDate('1997-08-29'));
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
+
     clickDayOfMonth(31); // August 31st is in the future
 
     expect(captured.event).toBeUndefined();
@@ -183,9 +182,9 @@ describe('CalendarComponent', () => {
 
   it('should not emit a dateChange event if clicking a date that was passed in disabledDates', () => {
     const captured = captureDateChangeEvents();
-
     spectator.setInput('disabledDates', ['1997-08-25', '1997-08-26'].map(localMidnightDate));
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
+
     clickDayOfMonth(26); // August 26st was explicitly disabled
 
     expect(captured.event).toBeUndefined();
@@ -193,9 +192,9 @@ describe('CalendarComponent', () => {
 
   it('should not emit a dateChange event if clicking a date that was not passed in enabledDates', () => {
     const captured = captureDateChangeEvents();
-
     spectator.setInput('enabledDates', ['1997-08-25', '1997-08-26'].map(localMidnightDate));
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
+
     clickDayOfMonth(27); // August 27st was implicitly disabled
 
     expect(captured.event).toBeUndefined();
@@ -203,9 +202,9 @@ describe('CalendarComponent', () => {
 
   it('should emit a dateChange event if clicking a date that was passed in enabledDates', () => {
     const captured = captureDateChangeEvents();
-
     spectator.setInput('enabledDates', ['1997-08-25', '1997-08-26'].map(localMidnightDate));
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
+
     clickDayOfMonth(26); // August 26st was explicitly enabled
 
     expect(captured.event).toBeTruthy();
@@ -213,8 +212,8 @@ describe('CalendarComponent', () => {
 
   it('should not emit a dateChange event if clicking the already selected date', () => {
     const captured = captureDateChangeEvents();
-
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
+
     clickDayOfMonth(29);
 
     expect(captured.event).toBeUndefined();
@@ -223,11 +222,11 @@ describe('CalendarComponent', () => {
   it('should always emit a dateChange event when clicking today if alwaysEnableToday is set to true', () => {
     const captured = captureDateChangeEvents();
     const today = localMidnightDate('1997-08-28');
-
     spectator.setInput('disabledDates', [today]);
     spectator.setInput('todayDate', today);
     spectator.setInput('alwaysEnableToday', true);
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
+
     clickDayOfMonth(28); // August 28th is was disabled but we override
 
     expect(captured.event).toEqual(today);
@@ -235,9 +234,9 @@ describe('CalendarComponent', () => {
 
   it('should emit dateChange event as UTC midnights when timezone is set to UTC', () => {
     const captured = captureDateChangeEvents();
-
     spectator.setInput('timezone', 'UTC');
     spectator.setInput('selectedDate', utcMidnightDate('1997-08-29'));
+
     clickDayOfMonth(14);
 
     expect(captured.event).toEqual(utcMidnightDate('1997-08-14'));
@@ -245,8 +244,8 @@ describe('CalendarComponent', () => {
 
   it('should emit dateSelect event when clicking a date that is not already selected', () => {
     const captured = captureDateSelectEvents();
-
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
+
     clickDayOfMonth(14);
 
     expect(captured.event).toEqual(localMidnightDate('1997-08-14'));
@@ -254,8 +253,8 @@ describe('CalendarComponent', () => {
 
   it('should emit dateSelect event when clicking the already selected date', () => {
     const captured = captureDateSelectEvents();
-
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
+
     clickDayOfMonth(29);
 
     expect(captured.event).toEqual(localMidnightDate('1997-08-29'));
@@ -263,9 +262,9 @@ describe('CalendarComponent', () => {
 
   it('should emit dateSelect event as UTC midnights when timezone is set to UTC', () => {
     const captured = captureDateSelectEvents();
-
     spectator.setInput('timezone', 'UTC');
     spectator.setInput('selectedDate', utcMidnightDate('1997-08-29'));
+
     clickDayOfMonth(14);
 
     expect(captured.event).toEqual(utcMidnightDate('1997-08-14'));

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.spec.ts
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.spec.ts
@@ -180,6 +180,26 @@ describe('CalendarComponent', () => {
     expect(captured.event).toBeUndefined();
   });
 
+  it('should not emit a dateChange event if clicking a date that was not passed in enabledDates', () => {
+    spectator.setInput('enabledDates', ['1997-08-25', '1997-08-26'].map(localMidnightDate));
+    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
+
+    const captured = captureDateChangeEvents();
+
+    clickDayOfMonth(27); // August 27st was implicitly disabled
+    expect(captured.event).toBeUndefined();
+  });
+
+  it('should emit a dateChange event if clicking a date that was passed in enabledDates', () => {
+    spectator.setInput('enabledDates', ['1997-08-25', '1997-08-26'].map(localMidnightDate));
+    spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
+
+    const captured = captureDateChangeEvents();
+
+    clickDayOfMonth(26); // August 26st was explicitly enabled
+    expect(captured.event).toBeTruthy();
+  });
+
   it('should not emit a dateChange event if clicking the already selected date', () => {
     spectator.setInput('selectedDate', localMidnightDate('1997-08-29'));
 
@@ -271,6 +291,11 @@ describe('CalendarComponent', () => {
     expect(spectator.component.disabledDates).toEqual(localDates);
     spectator.setInput('disabledDates', utcDates);
     expect(spectator.component.disabledDates).toEqual(localDates);
+
+    spectator.setInput('enabledDates', localDates);
+    expect(spectator.component.enabledDates).toEqual(localDates);
+    spectator.setInput('enabledDates', utcDates);
+    expect(spectator.component.enabledDates).toEqual(localDates);
   });
 
   it('should render days from Monday to Sunday', () => {

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.ts
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.ts
@@ -102,6 +102,7 @@ export class CalendarComponent implements OnInit, AfterViewInit, OnChanges {
   private activeMonth: Date;
   private _selectedDate: Date;
   private _disabledDates: Date[] = [];
+  private _enabledDates: Date[] = [];
   private _todayDate: Date;
   private _minDate: Date;
   private _maxDate: Date;
@@ -129,6 +130,14 @@ export class CalendarComponent implements OnInit, AfterViewInit, OnChanges {
 
   @Input() set disabledDates(value: Date[]) {
     this._disabledDates = (value || []).map((date) => this.normalizeDate(date));
+  }
+
+  get enabledDates(): Date[] {
+    return this._enabledDates;
+  }
+
+  @Input() set enabledDates(value: Date[]) {
+    this._enabledDates = (value || []).map((date) => this.normalizeDate(date));
   }
 
   get todayDate(): Date {
@@ -233,6 +242,7 @@ export class CalendarComponent implements OnInit, AfterViewInit, OnChanges {
       changes.disablePastDates ||
       changes.disableFutureDates ||
       changes.disabledDates ||
+      changes.enabledDates ||
       changes.minDate ||
       changes.maxDate ||
       changes.todayDate ||
@@ -301,9 +311,14 @@ export class CalendarComponent implements OnInit, AfterViewInit, OnChanges {
   }
 
   private isDisabledDate(date: Date): boolean {
-    return this.disabledDates.some((disabledDate) => {
-      return isSameDay(disabledDate, date);
-    });
+    return this.disabledDates.some((disabledDate) => isSameDay(disabledDate, date));
+  }
+
+  private isEnabledDate(date: Date): boolean {
+    return (
+      this._enabledDates.length === 0 ||
+      this.enabledDates.some((enabledDate) => isSameDay(enabledDate, date))
+    );
   }
 
   refreshActiveMonth() {
@@ -346,7 +361,7 @@ export class CalendarComponent implements OnInit, AfterViewInit, OnChanges {
       isFuture: isAfter(date, today),
       isWeekend: isWeekend(date),
       isCurrentMonth: isSameMonth(date, monthStart),
-      isDisabled: this.isDisabledDate(date),
+      isDisabled: this.isDisabledDate(date) || !this.isEnabledDate(date),
     };
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2412

## What is the new behavior?

Adds a new input to the calendar component, so it can receive an array of dates that should be enabled and disables the remaining dates.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

