### PR TITLE
Fix backdrop showing up when fab is closed

### DIFF
--- a/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.html
+++ b/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.html
@@ -1,5 +1,5 @@
 <ion-backdrop
-  [visible]="actionSheet && isFabSheetOpen"
+  *ngIf="actionSheet && isFabSheetOpen"
   (ionBackdropTap)="hideActions(fab)"
   (click)="hideActions(fab)"
 ></ion-backdrop>

--- a/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.html
+++ b/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.html
@@ -1,5 +1,5 @@
 <ion-backdrop
-  *ngIf="actionSheet && isFabSheetOpen"
+  [visible]="actionSheet && isFabSheetOpen"
   (ionBackdropTap)="hideActions(fab)"
   (click)="hideActions(fab)"
 ></ion-backdrop>

--- a/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.ts
+++ b/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.ts
@@ -2,6 +2,7 @@ import { DOCUMENT } from '@angular/common';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ContentChild,
   ElementRef,
@@ -42,7 +43,11 @@ export class FabSheetComponent implements AfterContentInit {
   @ViewChild(IonFabButton, { static: true, read: ElementRef })
   ionFabButton: ElementRef<HTMLElement>;
 
-  constructor(private renderer: Renderer2, @Inject(DOCUMENT) private document: any) {}
+  constructor(
+    private renderer: Renderer2,
+    private changeDetectorRef: ChangeDetectorRef,
+    @Inject(DOCUMENT) private document: any
+  ) {}
 
   ngAfterContentInit(): void {
     if (this.actionSheet) {
@@ -59,12 +64,17 @@ export class FabSheetComponent implements AfterContentInit {
 
   onFabClick(fab: IonFab) {
     this._isFabSheetOpen = fab.activated;
-    this._isBackdropVisible = fab.activated;
 
     if (this._isFabSheetOpen) {
       this.renderer.addClass(this.document.body, 'fab-sheet-active');
     } else {
       this.renderer.removeClass(this.document.body, 'fab-sheet-active');
     }
+
+    // Postpone backdrop visibility update to allow for animation of opacity
+    setTimeout(() => {
+      this._isBackdropVisible = this.isFabSheetOpen;
+      this.changeDetectorRef.markForCheck();
+    });
   }
 }

--- a/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.ts
+++ b/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.ts
@@ -2,7 +2,6 @@ import { DOCUMENT } from '@angular/common';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   ContentChild,
   ElementRef,
@@ -43,11 +42,7 @@ export class FabSheetComponent implements AfterContentInit {
   @ViewChild(IonFabButton, { static: true, read: ElementRef })
   ionFabButton: ElementRef<HTMLElement>;
 
-  constructor(
-    private renderer: Renderer2,
-    private changeDetectorRef: ChangeDetectorRef,
-    @Inject(DOCUMENT) private document: any
-  ) {}
+  constructor(private renderer: Renderer2, @Inject(DOCUMENT) private document: any) {}
 
   ngAfterContentInit(): void {
     if (this.actionSheet) {
@@ -63,17 +58,13 @@ export class FabSheetComponent implements AfterContentInit {
   }
 
   onFabClick(fab: IonFab) {
-    this._isFabSheetOpen = !fab.activated;
+    this._isFabSheetOpen = fab.activated;
+    this._isBackdropVisible = fab.activated;
+
     if (this._isFabSheetOpen) {
       this.renderer.addClass(this.document.body, 'fab-sheet-active');
     } else {
       this.renderer.removeClass(this.document.body, 'fab-sheet-active');
     }
-
-    // Postpone backdrop visibility update to allow for animation of opacity
-    setTimeout(() => {
-      this._isBackdropVisible = this.isFabSheetOpen;
-      this.changeDetectorRef.markForCheck();
-    });
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2452

## What is the new behavior?
The backdrop should now be in sync with the action sheet, so it shows whenever the action sheet is opened. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

