### PR TITLE
Add NPM automation token to workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,9 @@ jobs:
         run: |
           git config user.name "Kirby Bot"
           git config user.email "<>"
+      - name: Create npm config
+        run: |
+          npm config set //registry.npmjs.org/:_authToken ${{secrets.NPM_PUBLISH_TOKEN}}
       - name: Check if core has been modified
         id: modified-files
         uses: dorny/paths-filter@v2.9.2
@@ -33,11 +36,6 @@ jobs:
           filters: |
             core:
               - 'libs/core/**'
-      - name: Create npm config
-        if: steps.modified-files.outputs.core == 'true'
-        run: |
-          cd libs/core 
-          echo '//registry.npmjs.org/:_authToken=${{secrets.NPM_PUBLISH_TOKEN}}' > ~/.npmrc
       - name: Version bump core and update core dependency version in designsystem
         id: bump-core
         if: steps.modified-files.outputs.core == 'true'
@@ -56,8 +54,6 @@ jobs:
           npm run build:core
           cd libs/core
           npm publish --access public
-      - name: Create npm config
-        run: echo '//registry.npmjs.org/:_authToken=${{secrets.NPM_PUBLISH_TOKEN}}' > ~/.npmrc
       - name: Bump designsystem package
         run: npm version patch -m ":bookmark:Bumping version to %s (designsystem)"
       - name: Build designsystem package and publish to npm


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2338 

## What is the new behavior?

Add npm automation token to github publish workflow in preparation of enabling 2FA.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

The npm-user 'bankdata' must define an automation access token and the token must be defined as a secret in git-hub with the name NPM_PUBLISH_TOKEN.

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [X] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [X] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

