### PR TITLE
Use alternative hover and active on dark Cards

### DIFF
--- a/apps/cookbook/src/app/examples/card-example/examples/card-background-image-example/card-background-image-example.component.html
+++ b/apps/cookbook/src/app/examples/card-example/examples/card-background-image-example/card-background-image-example.component.html
@@ -3,6 +3,7 @@
   backgroundImageUrl="https://images.unsplash.com/photo-1560840067-ddcaeb7831d2"
   themeColor="dark"
   (click)="noop()"
+  [hasDarkBackgroundColor]="true"
 >
   <h3>Example using input property to set background</h3>
   <p>

--- a/apps/cookbook/src/app/examples/card-example/examples/card-css-background-image-example/card-css-background-image-example.component.html
+++ b/apps/cookbook/src/app/examples/card-example/examples/card-css-background-image-example/card-css-background-image-example.component.html
@@ -1,4 +1,4 @@
-<kirby-card [hasPadding]="true" themeColor="dark" (click)="noop()">
+<kirby-card [hasPadding]="true" themeColor="dark" (click)="noop()" [hasDarkBackgroundColor]="true">
   <h3>Example using custom css property to set background</h3>
   <p>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae

--- a/apps/cookbook/src/app/examples/card-example/examples/card-themecolor-example/card-themecolor-example.component.html
+++ b/apps/cookbook/src/app/examples/card-example/examples/card-themecolor-example/card-themecolor-example.component.html
@@ -6,7 +6,12 @@
   </div>
 </kirby-card>
 
-<kirby-card [hasPadding]="true" themeColor="secondary">
+<kirby-card
+  [hasPadding]="true"
+  themeColor="secondary"
+  (click)="noop()"
+  [hasDarkBackgroundColor]="true"
+>
   <kirby-card-header title="Secondary" subtitle='themeColor="secondary"'></kirby-card-header>
   <div>
     Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae

--- a/apps/cookbook/src/app/examples/card-example/examples/card-themecolor-example/card-themecolor-example.component.ts
+++ b/apps/cookbook/src/app/examples/card-example/examples/card-themecolor-example/card-themecolor-example.component.ts
@@ -1,8 +1,11 @@
 import { Component } from '@angular/core';
+import { noop } from 'rxjs';
 
 @Component({
   selector: 'cookbook-card-themecolor-example',
   templateUrl: './card-themecolor-example.component.html',
   styleUrls: ['./card-themecolor-example.component.scss'],
 })
-export class CardThemecolorExampleComponent {}
+export class CardThemecolorExampleComponent {
+  noop: () => void = noop;
+}

--- a/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.ts
@@ -61,6 +61,13 @@ export class CardShowcaseComponent {
         'dark',
       ],
     },
+    {
+      name: 'hasDarkBackgroundColor',
+      description:
+        'Use this to make the hover and active interaction states be lighter instead of darker (which is the default)',
+      defaultValue: 'false',
+      type: ['boolean'],
+    },
   ];
 
   customCssPropertiesColumns: ApiDescriptionPropertyColumns = {

--- a/libs/designsystem/src/lib/components/card/card.component.scss
+++ b/libs/designsystem/src/lib/components/card/card.component.scss
@@ -53,6 +53,11 @@
       @include interaction-state.apply-focus-visible($shadow: utils.get-elevation(4));
     }
 
+    &.interaction-state-make-lighter-and-louder {
+      @include interaction-state.apply-hover('xxs', $make-lighter: true);
+      @include interaction-state.apply-active('s', $make-lighter: true);
+    }
+
     outline: none;
   }
 }

--- a/libs/designsystem/src/lib/components/card/card.component.ts
+++ b/libs/designsystem/src/lib/components/card/card.component.ts
@@ -56,6 +56,10 @@ export class CardComponent implements OnInit, OnDestroy {
     this.highlighted = value === 'highlighted';
   }
 
+  @HostBinding('class.interaction-state-make-lighter-and-louder')
+  @Input()
+  hasDarkBackgroundColor: boolean;
+
   constructor(
     private elementRef: ElementRef,
     private resizeObserverService: ResizeObserverService,


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2443 

## What is the new behavior?

This enhancement lets users specify if card has a dark background color. If true the interaction states :hover and :active will be lighter and louder instead of the default "make it darker" and and more subtle "less loud".

Disclaimer: This is almost a one-off thing and the implementation does not allow for any flexibility. It's either or. Users also has to apply the property themselves - it does not apply automagically. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

