### PR TITLE
Always close accordion when disabled

### DIFF
--- a/libs/designsystem/src/lib/components/accordion/accordion-item.component.ts
+++ b/libs/designsystem/src/lib/components/accordion/accordion-item.component.ts
@@ -1,5 +1,5 @@
 import { animate, state, style, transition, trigger } from '@angular/animations';
-import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/core';
 
 // Counter for generating unique element ids
 let uniqueId = 0;
@@ -17,13 +17,13 @@ let uniqueId = 0;
     ]),
   ],
 })
-export class AccordionItemComponent implements OnInit {
+export class AccordionItemComponent implements OnChanges {
   @Input() title: string;
   @Input() isExpanded: boolean = false;
   @Input() isDisabled: boolean = false;
   @Input() disabledTitle: string;
 
-  ngOnInit(): void {
+  ngOnChanges(): void {
     if (this.isDisabled) {
       this.isExpanded = false;
     }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2498

## What is the new behavior?
The accordion now collapses and removes expanded styles when isDisabled is set to true after initialization. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.
