### PR TITLE
Fixed bug: toggles inside Kirby item placed too high

### DIFF
--- a/libs/designsystem/src/lib/components/toggle/toggle.component.scss
+++ b/libs/designsystem/src/lib/components/toggle/toggle.component.scss
@@ -1,6 +1,10 @@
 @use '~@kirbydesign/core/src/scss/interaction-state';
 @use '~@kirbydesign/core/src/scss/utils';
 
+:host {
+  display: inline-flex;
+}
+
 ion-toggle {
   @include interaction-state.apply-focus-part($part: 'track') {
     // Overflow and contain style needed to make focus ring visible as per ionic docs


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2441 

## What is the new behavior?
Fixed the gap between ion-toggle and kirby-toggle, that occurred since the ion-toggle behaved as an inline element. The new behavior is making kirby-toggle display inline-flex, which eliminates the gap without changing the outwards behaviour of kirby toggle. 

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

