### PR TITLE
Fix memory leak in kirby-page

### DIFF
--- a/libs/designsystem/src/lib/components/page/page.component.spec.ts
+++ b/libs/designsystem/src/lib/components/page/page.component.spec.ts
@@ -12,7 +12,7 @@ import { FitHeadingDirective } from '../../directives/fit-heading/fit-heading.di
 import { TestHelper } from '../../testing/test-helper';
 import { WindowRef } from '../../types/window-ref';
 import { ModalNavigationService } from '../modal/services/modal-navigation.service';
-import { TabsComponent } from '../tabs';
+import { selectedTabClickEvent, TabsComponent } from '../tabs';
 
 import { PageComponent, PageContentComponent } from './page.component';
 
@@ -297,6 +297,17 @@ describe('PageComponent', () => {
 
     it('should not be available when "refresh" is not subscribed to', () => {
       expect(spectator.query(IonRefresher)).toBeNull();
+    });
+  });
+
+  describe('tab navigation', () => {
+    it('should scroll to top when tab is clicked', () => {
+      const scrollToTopSpy = jasmine.createSpy();
+      (spectator.component as any).content.scrollToTop = scrollToTopSpy;
+
+      window.dispatchEvent(new Event(selectedTabClickEvent));
+
+      expect(scrollToTopSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/libs/designsystem/src/lib/components/page/page.component.ts
+++ b/libs/designsystem/src/lib/components/page/page.component.ts
@@ -186,7 +186,7 @@ export class PageComponent
   @Output() refresh = new EventEmitter<PullToRefreshEvent>();
   @Output() backButtonClick = new EventEmitter<Event>();
 
-  @ViewChild(IonContent, { static: true }) private content: IonContent;
+  @ViewChild(IonContent, { static: true }) private content?: IonContent;
   @ViewChild(IonContent, { static: true, read: ElementRef })
   private ionContentElement: ElementRef<HTMLIonContentElement>;
   @ViewChild(IonHeader, { static: true, read: ElementRef })
@@ -250,7 +250,6 @@ export class PageComponent
     private renderer: Renderer2,
     private router: Router,
     private changeDetectorRef: ChangeDetectorRef,
-    private windowRef: WindowRef,
     private modalNavigationService: ModalNavigationService,
     @Optional() @SkipSelf() private tabsComponent: TabsComponent
   ) {}
@@ -294,10 +293,6 @@ export class PageComponent
       }
     });
 
-    this.windowRef.nativeWindow.addEventListener(selectedTabClickEvent, () => {
-      this.content.scrollToTop(KirbyAnimation.Duration.LONG);
-    });
-
     this.interceptBackButtonClicksSetup();
   }
 
@@ -313,9 +308,6 @@ export class PageComponent
     this.ngOnDestroy$.complete();
 
     this.pageTitleIntersectionObserverRef.disconnect();
-    this.windowRef.nativeWindow.removeEventListener(selectedTabClickEvent, () => {
-      this.content.scrollToTop(KirbyAnimation.Duration.LONG);
-    });
   }
 
   delegateRefreshEvent(event: any): void {
@@ -447,5 +439,12 @@ export class PageComponent
   @HostListener('window:keyboardWillHide')
   _onKeyboardWillHide() {
     this.ionContentElement.nativeElement.style.setProperty('--keyboard-offset', '0px');
+  }
+
+  @HostListener(`window:${selectedTabClickEvent}`)
+  _onSelectedTabClick() {
+    if (this.content) {
+      this.content.scrollToTop(KirbyAnimation.Duration.LONG);
+    }
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2521 

## What is the new behavior?

kirby-page correctly removes event listeners from window.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Are there any additional context?

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [X] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [X] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [X] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

