### PR TITLE
Using kirby black on ion-tool bar and ion-content instead of using black

### DIFF
--- a/libs/designsystem/src/lib/components/page/page.component.scss
+++ b/libs/designsystem/src/lib/components/page/page.component.scss
@@ -23,6 +23,7 @@ ion-toolbar {
   --padding-end: #{utils.size('xxxs')};
   --padding-top: 0;
   --padding-bottom: 0;
+  --ion-toolbar-color: #{utils.get-color('black')};
 
   /*
   * This overrides Ionic's default ios styling for the position of secondary action buttons which are to the left of content: https://ionicframework.com/docs/api/toolbar#buttons
@@ -140,6 +141,7 @@ ion-content {
   --padding-start: var(--page-content-padding-start, #{utils.size('s')});
   --padding-end: var(--page-content-padding-end, #{utils.size('s')});
   --background: #{utils.get-color('background-color')};
+  --color: #{utils.get-color('black')};
 
   .content-inner {
     max-width: var(--page-content-max-width, utils.$page-content-max-width);


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2033 

## What is the new behavior?
Now using kirby black for page-title and toolbar instead of black
<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

