### PR TITLE
Update EmptyState cookbook example to include custom icon documentation

### DIFF
--- a/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.component.html
+++ b/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.component.html
@@ -14,7 +14,7 @@
 </kirby-empty-state>
 <hr />
 <kirby-empty-state
-  iconName="help"
+  customIconName="football"
   title="No items"
   subtitle="You don't have any items. Call support to add some items to your account."
 ></kirby-empty-state>

--- a/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
-import { ApiDescriptionProperty } from '~/app/shared/api-description/api-description-properties/api-description-properties.component';
-
 import exampleHtml from '../../examples/empty-state-example/empty-state-example.component.html?raw';
+import { ApiDescriptionProperty } from '~/app/shared/api-description/api-description-properties/api-description-properties.component';
 
 @Component({
   selector: 'cookbook-empty-state-showcase',
@@ -14,6 +13,12 @@ export class EmptyStateShowcaseComponent {
     {
       name: 'iconName',
       description: 'Name of the icon (see icons).',
+      defaultValue: 'null',
+      type: ['string'],
+    },
+    {
+      name: 'customIconName',
+      description: 'Name of the custom icon (see icons for custom icon example).',
       defaultValue: 'null',
       type: ['string'],
     },


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2508

## What is the new behavior?

The Empty State cookbook page now includes documentation and example of custom icon usage.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

