### PR TITLE
Refactor dropdown styles

### DIFF
--- a/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
+++ b/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
@@ -37,7 +37,7 @@ $min-screen-width: 375px;
     }
   }
 
-  & button {
+  button {
     position: relative;
     margin: 0;
     outline: none;
@@ -77,7 +77,7 @@ $min-screen-width: 375px;
       opacity: 1;
     }
 
-    & > button {
+    > button {
       box-shadow: utils.get-elevation(8);
     }
   }
@@ -110,8 +110,7 @@ kirby-popover {
 
 kirby-card {
   max-height: $dropdown-max-height;
-  margin-top: utils.size('xxxs');
-  margin-bottom: utils.size('xxxs');
+  margin-block: utils.size('xxxs');
   overflow-y: auto;
   box-shadow: utils.get-elevation(8);
   min-width: $min-screen-width-small - $margin-horizontal-total;

--- a/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
+++ b/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
@@ -37,7 +37,7 @@ $min-screen-width: 375px;
     }
   }
 
-  button {
+  > button {
     position: relative;
     margin: 0;
     outline: none;

--- a/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
+++ b/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
@@ -57,7 +57,6 @@ $min-screen-width: 375px;
 
   kirby-card {
     display: none;
-    opacity: 0;
     position: absolute;
     z-index: utils.z('dropdown');
   }
@@ -71,7 +70,6 @@ $min-screen-width: 375px;
   &.is-open {
     kirby-card {
       display: block;
-      opacity: 1;
     }
 
     & > button {
@@ -118,12 +116,6 @@ kirby-card {
 
   max-width: calc(100vw - #{$margin-horizontal-total});
 }
-
-// :host(.is-open) {
-//   & > button {
-//     box-shadow: utils.get-elevation(8);
-//   }
-// }
 
 :host-context(kirby-calendar) {
   > button {

--- a/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
+++ b/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
@@ -57,6 +57,10 @@ $min-screen-width: 375px;
 
   kirby-card {
     display: none;
+
+    // Opacity is used to prevent visible flicker,
+    // if a dropdown has to change horizontal or vertical direction
+    opacity: 0;
     position: absolute;
     z-index: utils.z('dropdown');
   }
@@ -70,6 +74,7 @@ $min-screen-width: 375px;
   &.is-open {
     kirby-card {
       display: block;
+      opacity: 1;
     }
 
     & > button {

--- a/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
+++ b/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
@@ -36,23 +36,23 @@ $min-screen-width: 375px;
       border-color: utils.get-color('danger');
     }
   }
-}
 
-:host > button {
-  position: relative;
-  margin: 0;
-  outline: none;
-  width: 100%;
+  & button {
+    position: relative;
+    margin: 0;
+    outline: none;
+    width: 100%;
 
-  // Temporary fix for button-width as attention level 3 has border,
-  // and attention level 2 does not:
-  &.attention-level2 {
-    border: 1px solid transparent;
-  }
+    // Temporary fix for button-width as attention level 3 has border,
+    // and attention level 2 does not:
+    &.attention-level2 {
+      border: 1px solid transparent;
+    }
 
-  .text {
-    overflow: hidden;
-    text-overflow: ellipsis;
+    .text {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
 }
 

--- a/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
+++ b/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
@@ -73,6 +73,10 @@ $min-screen-width: 375px;
       display: block;
       opacity: 1;
     }
+
+    & > button {
+      box-shadow: utils.get-elevation(8);
+    }
   }
 
   &.popout-left {
@@ -115,11 +119,11 @@ kirby-card {
   max-width: calc(100vw - #{$margin-horizontal-total});
 }
 
-:host(.is-open) {
-  & > button {
-    box-shadow: utils.get-elevation(8);
-  }
-}
+// :host(.is-open) {
+//   & > button {
+//     box-shadow: utils.get-elevation(8);
+//   }
+// }
 
 :host-context(kirby-calendar) {
   > button {

--- a/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
+++ b/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
@@ -115,15 +115,6 @@ kirby-card {
   max-width: calc(100vw - #{$margin-horizontal-total});
 }
 
-:host(.with-popover) {
-  &.is-open {
-    kirby-card {
-      display: block;
-      position: relative;
-    }
-  }
-}
-
 :host(.is-open) {
   & > button {
     box-shadow: utils.get-elevation(8);

--- a/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
+++ b/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
@@ -54,27 +54,7 @@ $min-screen-width: 375px;
       text-overflow: ellipsis;
     }
   }
-}
 
-kirby-popover {
-  --max-height: #{$dropdown-max-height};
-}
-
-kirby-card {
-  max-height: $dropdown-max-height;
-  margin-top: utils.size('xxxs');
-  margin-bottom: utils.size('xxxs');
-  overflow-y: auto;
-  box-shadow: utils.get-elevation(8);
-  min-width: $min-screen-width-small - $margin-horizontal-total;
-  @include utils.media('>=small') {
-    min-width: $min-screen-width - $margin-horizontal-total;
-  }
-
-  max-width: calc(100vw - #{$margin-horizontal-total});
-}
-
-:host(:not(.with-popover)) {
   kirby-card {
     display: none;
     opacity: 0;
@@ -117,10 +97,29 @@ kirby-card {
   }
 }
 
+kirby-popover {
+  --max-height: #{$dropdown-max-height};
+}
+
+kirby-card {
+  max-height: $dropdown-max-height;
+  margin-top: utils.size('xxxs');
+  margin-bottom: utils.size('xxxs');
+  overflow-y: auto;
+  box-shadow: utils.get-elevation(8);
+  min-width: $min-screen-width-small - $margin-horizontal-total;
+  @include utils.media('>=small') {
+    min-width: $min-screen-width - $margin-horizontal-total;
+  }
+
+  max-width: calc(100vw - #{$margin-horizontal-total});
+}
+
 :host(.with-popover) {
   &.is-open {
     kirby-card {
       display: block;
+      position: relative;
     }
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2230

## What is the new behavior?
This PR doesn't introduce new behaviour. Its purpose is to make the dropdown styles more simple and therefore easier to maintain in the future.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?
The issue refers to this [comment](https://github.com/kirbydesign/designsystem/pull/2217#discussion_r865802488), which has some suggestions on things that could be improved. There is a couple of things I wasn't able to do:

1. Removing the `is-opening` class. Without it the logic to change the horizontal or vertical direction of the dropdown breaks. We need to refactor the logic for the dropdown directions, if we want to remove this class. That is out of scope for this issue and I think that the time is better spent on other issues. 
2.  Move `kirby-calendar` specific styles to the calendar's stylesheet. The dropdown is used for the `year navigator` in the calendar, which appears in the top right of the calendar when `Show year navigator` is checked. As far as I understand, then the issue is that from the stylesheet of the calendar, it is not possible to write styles that reaches into the child component (in this case the dropdown), without using the deprecated `::ng-deep` selector.

Notes:
The comment also asks why we are controlling opacity. If the opacity is not controlled like we do, then the user will see a noticeable flicker, when the dropdown opens and has to change direction. E.g. the user will see the dropdown open downwards and then open upwards, after it calculates that it is outside the viewport, when opening downwards.

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

