### PR TITLE
Upgrade Sass and update all tilde imports

### DIFF
--- a/apps/cookbook/src/app/examples/_examples.shared.scss
+++ b/apps/cookbook/src/app/examples/_examples.shared.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: block;

--- a/apps/cookbook/src/app/examples/avatar-example/examples/avatar-examples.shared.scss
+++ b/apps/cookbook/src/app/examples/avatar-example/examples/avatar-examples.shared.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: flex;

--- a/apps/cookbook/src/app/examples/avatar-example/examples/badge.scss
+++ b/apps/cookbook/src/app/examples/avatar-example/examples/badge.scss
@@ -1,5 +1,5 @@
 @use 'avatar-examples.shared.scss';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   padding: utils.size('l');

--- a/apps/cookbook/src/app/examples/badge-example/badge-example.component.scss
+++ b/apps/cookbook/src/app/examples/badge-example/badge-example.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   height: 100%;

--- a/apps/cookbook/src/app/examples/badge-example/examples/badge-example-shared.scss
+++ b/apps/cookbook/src/app/examples/badge-example/examples/badge-example-shared.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   kirby-badge:first-child {

--- a/apps/cookbook/src/app/examples/button-example/button-example.component.scss
+++ b/apps/cookbook/src/app/examples/button-example/button-example.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 kirby-card {
   margin-bottom: utils.size('m');

--- a/apps/cookbook/src/app/examples/calendar-example/calendar-card-example.component.scss
+++ b/apps/cookbook/src/app/examples/calendar-example/calendar-card-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 kirby-card {
   z-index: 3; // Ensure dropdown opens over configuration checkboxes

--- a/apps/cookbook/src/app/examples/card-example/card-example.component.scss
+++ b/apps/cookbook/src/app/examples/card-example/card-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 kirby-card {
   position: relative;

--- a/apps/cookbook/src/app/examples/card-example/examples/card-clickable-example/card-clickable-example.component.scss
+++ b/apps/cookbook/src/app/examples/card-example/examples/card-clickable-example/card-clickable-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 .card-content {
   padding: utils.size('s');

--- a/apps/cookbook/src/app/examples/card-example/examples/card-css-background-image-example/card-css-background-image-example.component.scss
+++ b/apps/cookbook/src/app/examples/card-example/examples/card-css-background-image-example/card-css-background-image-example.component.scss
@@ -3,7 +3,7 @@
   has to be stored in a seperate scss file. Otherwise the preprocessor
   won't kick in.
  */
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 kirby-card {
   --kirby-card-background-image: linear-gradient(

--- a/apps/cookbook/src/app/examples/card-example/examples/card-css-background-image-example/card-css-background-image-example.component.ts
+++ b/apps/cookbook/src/app/examples/card-example/examples/card-css-background-image-example/card-css-background-image-example.component.ts
@@ -3,7 +3,7 @@ import { noop } from 'rxjs';
 
 const config = {
   selector: 'cookbook-card-css-background-image-example',
-  style: `@use '~@kirbydesign/core/src/scss/utils';
+  style: `@use '@kirbydesign/core/src/scss/utils';
 
 kirby-card {
   min-height: 300px;

--- a/apps/cookbook/src/app/examples/card-example/examples/card-elevations-example/card-elevations-example.component.scss
+++ b/apps/cookbook/src/app/examples/card-example/examples/card-elevations-example/card-elevations-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: grid;

--- a/apps/cookbook/src/app/examples/card-example/examples/card-themecolor-example/card-themecolor-example.component.scss
+++ b/apps/cookbook/src/app/examples/card-example/examples/card-themecolor-example/card-themecolor-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: grid;

--- a/apps/cookbook/src/app/examples/charts-example/charts-example.component.scss
+++ b/apps/cookbook/src/app/examples/charts-example/charts-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: flex;

--- a/apps/cookbook/src/app/examples/checkbox-radio-sizes-example.scss
+++ b/apps/cookbook/src/app/examples/checkbox-radio-sizes-example.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 $height-measure-width: 80px;
 $default-size: map.get(utils.$checkbox-radio-sizes, 'md');

--- a/apps/cookbook/src/app/examples/dropdown-example/dropdown-example.component.scss
+++ b/apps/cookbook/src/app/examples/dropdown-example/dropdown-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: block;

--- a/apps/cookbook/src/app/examples/example-configuration-wrapper/example-configuration-wrapper.component.scss
+++ b/apps/cookbook/src/app/examples/example-configuration-wrapper/example-configuration-wrapper.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: inline-block;

--- a/apps/cookbook/src/app/examples/examples.component.scss
+++ b/apps/cookbook/src/app/examples/examples.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:list';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 @mixin kirby-keys($start-index, $additional-keys: ()) {
   $keys: list.join(('K', 'I', 'R', 'B', 'Y'), $additional-keys);

--- a/apps/cookbook/src/app/examples/flag-example/examples/flag-examples.shared.scss
+++ b/apps/cookbook/src/app/examples/flag-example/examples/flag-examples.shared.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: flex;

--- a/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.scss
+++ b/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 kirby-page-content > * {
   display: block;

--- a/apps/cookbook/src/app/examples/grid-layout-example/grid-layout-extended-example/grid-layout-extended-example.component.scss
+++ b/apps/cookbook/src/app/examples/grid-layout-example/grid-layout-extended-example/grid-layout-extended-example.component.scss
@@ -1,6 +1,6 @@
 @use 'sass:math';
 
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 /* Configure grid properties */
 $columns: 12;

--- a/apps/cookbook/src/app/examples/grid-layout-example/grid-layout-multiple-containers-example/grid-layout-multiple-containers-example.component.scss
+++ b/apps/cookbook/src/app/examples/grid-layout-example/grid-layout-multiple-containers-example/grid-layout-multiple-containers-example.component.scss
@@ -1,6 +1,6 @@
 @use 'sass:math';
 
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 /* Configure grid properties */
 $columns: 12;

--- a/apps/cookbook/src/app/examples/grid-layout-example/grid-layout-single-container-example/grid-layout-single-container-example.component.scss
+++ b/apps/cookbook/src/app/examples/grid-layout-example/grid-layout-single-container-example/grid-layout-single-container-example.component.scss
@@ -1,6 +1,6 @@
 @use 'sass:math';
 
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 /* Configure grid properties */
 $columns: 12;

--- a/apps/cookbook/src/app/examples/icon-example/icon-example.component.scss
+++ b/apps/cookbook/src/app/examples/icon-example/icon-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 h2 {
   margin-top: utils.size('l');

--- a/apps/cookbook/src/app/examples/item-example/item-example.component.scss
+++ b/apps/cookbook/src/app/examples/item-example/item-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: block;

--- a/apps/cookbook/src/app/examples/link-example/examples/link-examples.shared.scss
+++ b/apps/cookbook/src/app/examples/link-example/examples/link-examples.shared.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: block;

--- a/apps/cookbook/src/app/examples/list-example/list-example.component.scss
+++ b/apps/cookbook/src/app/examples/list-example/list-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   padding: 2px;

--- a/apps/cookbook/src/app/examples/list-experimental-example/list-experimental-example.component.scss
+++ b/apps/cookbook/src/app/examples/list-experimental-example/list-experimental-example.component.scss
@@ -1,6 +1,6 @@
 @use 'sass:map';
-@use '~@kirbydesign/core/src/scss/utils';
-@use '~@kirbydesign/core/src/scss/base/list';
+@use '@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/base/list';
 
 :host {
   display: flex;

--- a/apps/cookbook/src/app/examples/list-no-shape-example/list-no-shape-example.component.scss
+++ b/apps/cookbook/src/app/examples/list-no-shape-example/list-no-shape-example.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 kirby-card {
   width: map.get(utils.$breakpoints, small);

--- a/apps/cookbook/src/app/examples/list-swipe-example/list-swipe-example.component.scss
+++ b/apps/cookbook/src/app/examples/list-swipe-example/list-swipe-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 $item-height: utils.size('xxxl');
 $dot-size: utils.size('xxs');

--- a/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.scss
+++ b/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 .example-properties {
   display: none;

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.scss
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   kirby-checkbox {

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-default.component.scss
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-default.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 cookbook-example-configuration-wrapper {
   margin-top: utils.size('xl');

--- a/apps/cookbook/src/app/examples/modal-example/modal-example.component.scss
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example.component.scss
@@ -1,5 +1,5 @@
 @use '../examples.shared';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 h1 {
   text-align: center;

--- a/apps/cookbook/src/app/examples/page-example/fixed-footer-tabs/fixed-footer-tabs-example.component.scss
+++ b/apps/cookbook/src/app/examples/page-example/fixed-footer-tabs/fixed-footer-tabs-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 $app-header-max-width: 1024px;
 

--- a/apps/cookbook/src/app/examples/progress-circle-example/progress-circle-example.component.scss
+++ b/apps/cookbook/src/app/examples/progress-circle-example/progress-circle-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: flex;

--- a/apps/cookbook/src/app/examples/radio-example/examples/ng-forms.shared.scss
+++ b/apps/cookbook/src/app/examples/radio-example/examples/ng-forms.shared.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: flex;

--- a/apps/cookbook/src/app/examples/reorder-list-example/reorder-list-example.component.scss
+++ b/apps/cookbook/src/app/examples/reorder-list-example/reorder-list-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 .section-header {
   padding: 0 utils.size('s') utils.size('xxs') utils.size('xxs');

--- a/apps/cookbook/src/app/examples/section-header-example/section-header-example.component.scss
+++ b/apps/cookbook/src/app/examples/section-header-example/section-header-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: block;

--- a/apps/cookbook/src/app/examples/segmented-control-example/default/default.scss
+++ b/apps/cookbook/src/app/examples/segmented-control-example/default/default.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: block;

--- a/apps/cookbook/src/app/examples/segmented-control-example/segmented-control-example.component.scss
+++ b/apps/cookbook/src/app/examples/segmented-control-example/segmented-control-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: block;

--- a/apps/cookbook/src/app/examples/segmented-control-example/with-badge/with-badge.scss
+++ b/apps/cookbook/src/app/examples/segmented-control-example/with-badge/with-badge.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: block;

--- a/apps/cookbook/src/app/examples/tabs-example/tabs-example.component.scss
+++ b/apps/cookbook/src/app/examples/tabs-example/tabs-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 $app-header-max-width: 1024px;
 

--- a/apps/cookbook/src/app/examples/toggle-button-example/toggle-button-example.component.scss
+++ b/apps/cookbook/src/app/examples/toggle-button-example/toggle-button-example.component.scss
@@ -1,5 +1,5 @@
 @use '../examples.shared';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 kirby-toggle-button {
   margin-right: utils.size('m');

--- a/apps/cookbook/src/app/examples/toggle-example/toggle-example.component.scss
+++ b/apps/cookbook/src/app/examples/toggle-example/toggle-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   kirby-toggle {

--- a/apps/cookbook/src/app/examples/virtual-scroll-example/virtual-scroll-list-example/virtual-scroll-list-example.component.scss
+++ b/apps/cookbook/src/app/examples/virtual-scroll-example/virtual-scroll-list-example/virtual-scroll-list-example.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: block;

--- a/apps/cookbook/src/app/guides/guides.component.scss
+++ b/apps/cookbook/src/app/guides/guides.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 table {
   border-spacing: 0;

--- a/apps/cookbook/src/app/home/home.component.scss
+++ b/apps/cookbook/src/app/home/home.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 /* stylelint-disable declaration-block-no-redundant-longhand-properties */
 

--- a/apps/cookbook/src/app/intro/intro.component.scss
+++ b/apps/cookbook/src/app/intro/intro.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 img {
   max-width: 100%;

--- a/apps/cookbook/src/app/iphone/iphone.component.scss
+++ b/apps/cookbook/src/app/iphone/iphone.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 /* stylelint-disable custom-property-pattern */
 .container {

--- a/apps/cookbook/src/app/page/footer/footer.component.scss
+++ b/apps/cookbook/src/app/page/footer/footer.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   grid-area: footer;

--- a/apps/cookbook/src/app/page/header/header.component.scss
+++ b/apps/cookbook/src/app/page/header/header.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 $logo-size-mobile: utils.size('xl');
 $logo-size-desktop: 2 * utils.size('l');

--- a/apps/cookbook/src/app/page/side-nav/side-nav.component.scss
+++ b/apps/cookbook/src/app/page/side-nav/side-nav.component.scss
@@ -1,5 +1,5 @@
-@use '~@kirbydesign/core/src/scss/utils';
-@use '~@kirbydesign/core/src/scss/opt-out';
+@use '@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/opt-out';
 
 $link-padding: 5px;
 $link-border-radius: 3px;

--- a/apps/cookbook/src/app/shared/api-description/api-description.shared.scss
+++ b/apps/cookbook/src/app/shared/api-description/api-description.shared.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 // We need this for api-description to avoid breaking mobile.
 :host {

--- a/apps/cookbook/src/app/shared/code-viewer/code-viewer.component.scss
+++ b/apps/cookbook/src/app/shared/code-viewer/code-viewer.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 h4 {
   margin: utils.size('s') 0;

--- a/apps/cookbook/src/app/showcase/_showcase.shared.scss
+++ b/apps/cookbook/src/app/showcase/_showcase.shared.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 h2:not(:first-child) {
   margin-top: utils.size('l');

--- a/apps/cookbook/src/app/showcase/accordion-showcase/accordion-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/accordion-showcase/accordion-showcase.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 h2:not(:first-child) {
   margin-top: utils.size('l');

--- a/apps/cookbook/src/app/showcase/button-showcase/button-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/button-showcase/button-showcase.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 h2 {
   margin-top: utils.size('xl');

--- a/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 h4 {
   padding-top: utils.size('s');

--- a/apps/cookbook/src/app/showcase/colors-showcase/colors-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/colors-showcase/colors-showcase.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 @each $color-name, $color-value in utils.get-all-colors() {
   .#{$color-name} {

--- a/apps/cookbook/src/app/showcase/dropdown-showcase/dropdown-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/dropdown-showcase/dropdown-showcase.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 h2:not(:first-child) {
   margin-top: utils.size('l');

--- a/apps/cookbook/src/app/showcase/fonts-showcase/fonts-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/fonts-showcase/fonts-showcase.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 code {
   background-color: utils.get-color('medium');

--- a/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 h2:not(:first-child) {
   margin-top: utils.size('l');

--- a/apps/cookbook/src/app/showcase/item-showcase/item-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/item-showcase/item-showcase.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   > h2:not(:first-child) {

--- a/apps/cookbook/src/app/showcase/list-load-on-demand-showcase/list-load-on-demand-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/list-load-on-demand-showcase/list-load-on-demand-showcase.component.scss
@@ -1,5 +1,5 @@
 @use '../showcase.shared';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 .example-wrapper {
   display: flex;

--- a/apps/cookbook/src/app/showcase/list-showcase/list-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/list-showcase/list-showcase.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 .page-example {
   display: flex;

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.scss
@@ -1,5 +1,5 @@
 @use '../showcase.shared';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 cookbook-iphone {
   float: right;

--- a/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 .page-example {
   display: flex;

--- a/apps/cookbook/src/app/showcase/progress-circle-showcase/progress-circle-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/progress-circle-showcase/progress-circle-showcase.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 h2:not(:first-child) {
   margin-top: utils.size('l');

--- a/apps/cookbook/src/app/showcase/radio-showcase/radio-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/radio-showcase/radio-showcase.component.scss
@@ -1,5 +1,5 @@
 @use '../showcase.shared';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 h3 {
   margin-top: utils.size('l');

--- a/apps/cookbook/src/app/showcase/range-showcase/range-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/range-showcase/range-showcase.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 @use '../showcase.shared';
 
 cookbook-example-viewer {

--- a/apps/cookbook/src/app/showcase/reorder-list-showcase/reorder-list-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/reorder-list-showcase/reorder-list-showcase.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 .example-wrapper {
   display: flex;

--- a/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 h2:not(:first-child),
 h3:not(:first-child) {

--- a/apps/cookbook/src/app/showcase/showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/showcase.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 $icon-size: utils.size('s');
 

--- a/apps/cookbook/src/app/showcase/tabs-showcase/tabs-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/tabs-showcase/tabs-showcase.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 .tabs-example {
   display: flex;

--- a/apps/cookbook/src/app/showcase/toggle-button-showcase/toggle-button-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/toggle-button-showcase/toggle-button-showcase.component.scss
@@ -1,5 +1,5 @@
 @use '../showcase.shared';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 cookbook-toggle-button-example {
   padding: 0;

--- a/apps/cookbook/src/styles.scss
+++ b/apps/cookbook/src/styles.scss
@@ -2,8 +2,8 @@
   You can add global styles to this file, and also import other style files
 */
 // Import common styles
-@use '~@kirbydesign/core/src/scss/global-styles';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/global-styles';
+@use '@kirbydesign/core/src/scss/utils';
 
 body,
 html {

--- a/apps/flows/src/app/transaction-details-flow/for-you/for-you.component.scss
+++ b/apps/flows/src/app/transaction-details-flow/for-you/for-you.component.scss
@@ -1,6 +1,6 @@
 @use 'sass:math';
 
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   position: absolute;

--- a/apps/flows/src/app/transaction-details-flow/transaction-details/transaction-details.component.scss
+++ b/apps/flows/src/app/transaction-details-flow/transaction-details/transaction-details.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 .spacing {
   margin-block: utils.size('s');

--- a/apps/flows/src/styles.scss
+++ b/apps/flows/src/styles.scss
@@ -1,7 +1,7 @@
 /* You can add global styles to this file, and also import other style files */
 
-@use '~@kirbydesign/core/src/scss/global-styles';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/global-styles';
+@use '@kirbydesign/core/src/scss/utils';
 
 html {
   background-color: var(--kirby-background-color);

--- a/libs/core/src/scss/base/_list.scss
+++ b/libs/core/src/scss/base/_list.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 @mixin rounded($border-radius: utils.$border-radius) {
   @include rounded-top($border-radius);

--- a/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
+++ b/libs/designsystem/src/lib/components/accordion/accordion-item.component.scss
@@ -1,5 +1,5 @@
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 $divider-color: utils.get-color('medium');
 $padding: utils.size('s');

--- a/libs/designsystem/src/lib/components/avatar/avatar.component.scss
+++ b/libs/designsystem/src/lib/components/avatar/avatar.component.scss
@@ -1,6 +1,6 @@
 @use 'sass:map';
 @use 'sass:math';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 $diameter-xsmall: map.get(utils.$avatar-sizes, 'xs');
 $diameter-small: map.get(utils.$avatar-sizes, 's');

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -1,8 +1,8 @@
 @use 'sass:map';
 @use 'sass:meta';
 
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 $button-width: (
   sm: 44px,

--- a/libs/designsystem/src/lib/components/calendar/calendar.component.scss
+++ b/libs/designsystem/src/lib/components/calendar/calendar.component.scss
@@ -1,5 +1,5 @@
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 $month-navigator-width: 80px;
 

--- a/libs/designsystem/src/lib/components/card/card-footer/card-footer.component.scss
+++ b/libs/designsystem/src/lib/components/card/card-footer/card-footer.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: block;

--- a/libs/designsystem/src/lib/components/card/card-header/card-header.component.scss
+++ b/libs/designsystem/src/lib/components/card/card-header/card-header.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: block;

--- a/libs/designsystem/src/lib/components/card/card.component.scss
+++ b/libs/designsystem/src/lib/components/card/card.component.scss
@@ -1,5 +1,5 @@
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   --kirby-card-main-background-color: #{utils.get-color('white')};

--- a/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
+++ b/libs/designsystem/src/lib/components/checkbox/checkbox.component.scss
@@ -1,6 +1,6 @@
 @use 'sass:map';
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 $border-radius: 6px;
 $checkbox-icon-size: utils.size('m');

--- a/libs/designsystem/src/lib/components/chip/chip.component.scss
+++ b/libs/designsystem/src/lib/components/chip/chip.component.scss
@@ -1,5 +1,5 @@
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   @include interaction-state.initialize-layer;

--- a/libs/designsystem/src/lib/components/data-table/table/table.component.scss
+++ b/libs/designsystem/src/lib/components/data-table/table/table.component.scss
@@ -1,5 +1,5 @@
-@use '~@kirbydesign/core/src/scss/utils';
-@use '~@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
 
 // Color variables
 $divider-color: utils.get-color('medium');

--- a/libs/designsystem/src/lib/components/divider/divider.component.scss
+++ b/libs/designsystem/src/lib/components/divider/divider.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host-context(kirby-card),
 :host-context(.kirby-color-brightness-white) {

--- a/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
+++ b/libs/designsystem/src/lib/components/dropdown/dropdown.component.scss
@@ -1,5 +1,5 @@
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 $dropdown-max-height: 8 * utils.$dropdown-item-height;
 $margin-horizontal-total: 2 * utils.size('s');

--- a/libs/designsystem/src/lib/components/empty-state/empty-state.component.scss
+++ b/libs/designsystem/src/lib/components/empty-state/empty-state.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 article {
   max-width: 330px;

--- a/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.scss
+++ b/libs/designsystem/src/lib/components/fab-sheet/fab-sheet.component.scss
@@ -1,5 +1,5 @@
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 $fab-sheet-margin: utils.size('s');
 

--- a/libs/designsystem/src/lib/components/flag/flag.component.scss
+++ b/libs/designsystem/src/lib/components/flag/flag.component.scss
@@ -1,7 +1,7 @@
 @use 'sass:list';
 @use 'sass:map';
 @use 'sass:math';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 // returns the total target height including padding and borders
 @function _calculate-line-height(

--- a/libs/designsystem/src/lib/components/form-field/_form-field-inputs.shared.scss
+++ b/libs/designsystem/src/lib/components/form-field/_form-field-inputs.shared.scss
@@ -1,5 +1,5 @@
-@use '~@kirbydesign/core/src/scss/utils';
-@use '~@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
 
 $form-field-input-font-family: var(--kirby-font-family);
 $form-field-input-line-height: 1.5;

--- a/libs/designsystem/src/lib/components/form-field/form-field-message/form-field-message.component.scss
+++ b/libs/designsystem/src/lib/components/form-field/form-field-message/form-field-message.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   font-style: italic;

--- a/libs/designsystem/src/lib/components/form-field/form-field.component.scss
+++ b/libs/designsystem/src/lib/components/form-field/form-field.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: block;

--- a/libs/designsystem/src/lib/components/form-field/input/input.component.scss
+++ b/libs/designsystem/src/lib/components/form-field/input/input.component.scss
@@ -1,6 +1,6 @@
 @use '../form-field-inputs.shared' as shared;
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 $padding-block-size-md: shared.$form-field-input-padding * 0.5;
 

--- a/libs/designsystem/src/lib/components/form-field/textarea/textarea.component.scss
+++ b/libs/designsystem/src/lib/components/form-field/textarea/textarea.component.scss
@@ -1,6 +1,6 @@
 @use '../form-field-inputs.shared';
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   @include interaction-state.apply-hover {

--- a/libs/designsystem/src/lib/components/grid/grid.component.scss
+++ b/libs/designsystem/src/lib/components/grid/grid.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: grid;

--- a/libs/designsystem/src/lib/components/icon/icon.component.scss
+++ b/libs/designsystem/src/lib/components/icon/icon.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: inline-flex;

--- a/libs/designsystem/src/lib/components/item-sliding/item-sliding.shared.scss
+++ b/libs/designsystem/src/lib/components/item-sliding/item-sliding.shared.scss
@@ -6,7 +6,7 @@
   When the old template driven list is deprecated however - this should 
   just be used directly in item-sliding.component.scss.
  */
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 ion-item-option {
   @each $color-name, $color-value in utils.$main-colors {

--- a/libs/designsystem/src/lib/components/item/_item.utils.scss
+++ b/libs/designsystem/src/lib/components/item/_item.utils.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 @mixin item-typography() {
   @include utils.slotted(h1, h2, h3, h4, h5, h6, p, data) {

--- a/libs/designsystem/src/lib/components/item/item.component.scss
+++ b/libs/designsystem/src/lib/components/item/item.component.scss
@@ -1,6 +1,6 @@
 @use 'sass:map';
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 @use 'item.utils';
 
 :host {

--- a/libs/designsystem/src/lib/components/item/label/label.component.scss
+++ b/libs/designsystem/src/lib/components/item/label/label.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 @use '../item.utils';
 @use '../../section-header/section-header.utils';
 

--- a/libs/designsystem/src/lib/components/list/list-experimental/list-experimental.component.scss
+++ b/libs/designsystem/src/lib/components/list/list-experimental/list-experimental.component.scss
@@ -1,5 +1,5 @@
-@use '~@kirbydesign/core/src/scss/utils';
-@use '~@kirbydesign/core/src/scss/base/list';
+@use '@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/base/list';
 
 :host {
   display: block;

--- a/libs/designsystem/src/lib/components/list/list-header/list-header.component.scss
+++ b/libs/designsystem/src/lib/components/list/list-header/list-header.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   background-color: transparent;

--- a/libs/designsystem/src/lib/components/list/list-item/list-item.component.scss
+++ b/libs/designsystem/src/lib/components/list/list-item/list-item.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 $divider-color: utils.get-color('background-color');
 

--- a/libs/designsystem/src/lib/components/list/list.component.scss
+++ b/libs/designsystem/src/lib/components/list/list.component.scss
@@ -1,5 +1,5 @@
 @use 'sass:map';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 @use '../item-sliding/item-sliding.shared.scss';
 
 $divider-color: utils.get-color('background-color');

--- a/libs/designsystem/src/lib/components/loading-overlay/loading-overlay.component.scss
+++ b/libs/designsystem/src/lib/components/loading-overlay/loading-overlay.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: block;

--- a/libs/designsystem/src/lib/components/modal/action-sheet/action-sheet.component.scss
+++ b/libs/designsystem/src/lib/components/modal/action-sheet/action-sheet.component.scss
@@ -1,5 +1,5 @@
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 $margin-horizontal: utils.size('l');
 $margin-horizontal-narrow: utils.size('s');

--- a/libs/designsystem/src/lib/components/modal/alert/alert.component.scss
+++ b/libs/designsystem/src/lib/components/modal/alert/alert.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 article {
   overflow: hidden;

--- a/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.scss
+++ b/libs/designsystem/src/lib/components/modal/footer/modal-footer.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 $padding-horizontal: utils.size('s');
 $padding-vertical: utils.size('xxs');

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/compact/modal-compact-wrapper.component.scss
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/compact/modal-compact-wrapper.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 // Global modal styling can be found at scss/base/_ionic.scss
 

--- a/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.scss
+++ b/libs/designsystem/src/lib/components/modal/modal-wrapper/modal-wrapper.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 // Global modal styling can be found at scss/base/_ionic.scss
 

--- a/libs/designsystem/src/lib/components/page-local-navigation/page-local-navigation.component.scss
+++ b/libs/designsystem/src/lib/components/page-local-navigation/page-local-navigation.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 $tab-item-text-max-width: 100px;
 $bottom-border-height: 1px;

--- a/libs/designsystem/src/lib/components/page/page-footer/page-footer.component.scss
+++ b/libs/designsystem/src/lib/components/page/page-footer/page-footer.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 $padding-horizontal: utils.size('s');
 $padding-vertical: utils.size('xxs');

--- a/libs/designsystem/src/lib/components/page/page.component.scss
+++ b/libs/designsystem/src/lib/components/page/page.component.scss
@@ -1,5 +1,5 @@
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 /*
  * Page Header

--- a/libs/designsystem/src/lib/components/popover/popover.component.scss
+++ b/libs/designsystem/src/lib/components/popover/popover.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: none;

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.scss
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle-ring.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 .circle {
   stroke: utils.get-color('semi-light');

--- a/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.scss
+++ b/libs/designsystem/src/lib/components/progress-circle/progress-circle.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: inline-block;

--- a/libs/designsystem/src/lib/components/radio/radio.component.scss
+++ b/libs/designsystem/src/lib/components/radio/radio.component.scss
@@ -1,7 +1,7 @@
 @use 'sass:color';
 @use 'sass:map';
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 $radio-icon-padding: utils.size('xxxxs');
 $radio-icon-size: utils.size('m');

--- a/libs/designsystem/src/lib/components/range/range.component.scss
+++ b/libs/designsystem/src/lib/components/range/range.component.scss
@@ -1,5 +1,5 @@
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 $tick-height: 6px;
 $tick-width: 6px;

--- a/libs/designsystem/src/lib/components/reorder-list/reorder-list.component.scss
+++ b/libs/designsystem/src/lib/components/reorder-list/reorder-list.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 ion-backdrop {
   opacity: 0.3;

--- a/libs/designsystem/src/lib/components/router-outlet/router-outlet.component.scss
+++ b/libs/designsystem/src/lib/components/router-outlet/router-outlet.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   left: 0;

--- a/libs/designsystem/src/lib/components/section-header/_section-header.utils.scss
+++ b/libs/designsystem/src/lib/components/section-header/_section-header.utils.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 /*
 * This mixin is applied both in the section-header styles, for using 

--- a/libs/designsystem/src/lib/components/section-header/section-header.component.scss
+++ b/libs/designsystem/src/lib/components/section-header/section-header.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 @use './section-header.utils';
 
 :host {

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -1,5 +1,5 @@
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: block;

--- a/libs/designsystem/src/lib/components/slide-button/slide-button.component.scss
+++ b/libs/designsystem/src/lib/components/slide-button/slide-button.component.scss
@@ -1,5 +1,5 @@
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 $slide-button-container-width: 256px;
 $slide-button-spacing: 2px;

--- a/libs/designsystem/src/lib/components/spinner/spinner.component.scss
+++ b/libs/designsystem/src/lib/components/spinner/spinner.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 .spinner {
   overflow: hidden;

--- a/libs/designsystem/src/lib/components/tabs/tab-button/tab-button.component.scss
+++ b/libs/designsystem/src/lib/components/tabs/tab-button/tab-button.component.scss
@@ -1,7 +1,7 @@
 @use 'sass:math';
 
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 ion-tab-button {
   &.ion-focused {

--- a/libs/designsystem/src/lib/components/tabs/tabs.component.scss
+++ b/libs/designsystem/src/lib/components/tabs/tabs.component.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host(:not(.tab-bar-bottom-hidden)) {
   --kirby-page-footer-safe-area-bottom: 0px;

--- a/libs/designsystem/src/lib/components/toggle/toggle.component.scss
+++ b/libs/designsystem/src/lib/components/toggle/toggle.component.scss
@@ -1,5 +1,5 @@
-@use '~@kirbydesign/core/src/scss/interaction-state';
-@use '~@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/interaction-state';
+@use '@kirbydesign/core/src/scss/utils';
 
 :host {
   display: inline-flex;

--- a/libs/designsystem/src/lib/testing/styles.scss
+++ b/libs/designsystem/src/lib/testing/styles.scss
@@ -1,4 +1,4 @@
-@use '~@kirbydesign/core/src/scss/global-styles';
+@use '@kirbydesign/core/src/scss/global-styles';
 
 // Ensure height of test window for modal viewport resize observer to work:
 body,

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
         "postcss-url": "^10.1.1",
         "prettier": "2.6.2",
         "resize-observer-polyfill": "1.5.1",
-        "sass": "^1.43.4",
+        "sass": "^1.55.0",
         "stylelint": "^14.6.1",
         "stylelint-config-prettier-scss": "0.0.1",
         "stylelint-config-standard-scss": "^3.0.0",
@@ -20427,9 +20427,10 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.54.9",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.55.0.tgz",
+      "integrity": "sha512-Pk+PMy7OGLs9WaxZGJMn7S96dvlyVBwwtToX895WmCpAOr5YiJYEUJfiJidMuKb613z2xNWcXCHEuOvjZbqC6A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -36369,7 +36370,9 @@
       "version": "2.1.2"
     },
     "sass": {
-      "version": "1.54.9",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.55.0.tgz",
+      "integrity": "sha512-Pk+PMy7OGLs9WaxZGJMn7S96dvlyVBwwtToX895WmCpAOr5YiJYEUJfiJidMuKb613z2xNWcXCHEuOvjZbqC6A==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "postcss-url": "^10.1.1",
     "prettier": "2.6.2",
     "resize-observer-polyfill": "1.5.1",
-    "sass": "^1.43.4",
+    "sass": "^1.55.0",
     "stylelint": "^14.6.1",
     "stylelint-config-prettier-scss": "0.0.1",
     "stylelint-config-standard-scss": "^3.0.0",


### PR DESCRIPTION
Tilde imports have been deprecated in Sass loader for a long time and will throw warnings when we upgrade to Angular 14. Removing the tilde charater `~` from the path in all @use statements fixes this.

By doing this in a separate PR we can reduce clutter in the Angular 14 upgrade PR.

## Which issue does this PR close?

This PR closes #2569 

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

Run `npm install`

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

