### PR TITLE
Add modal showcase to flow apps

### DIFF
--- a/apps/flows/src/app/app-routing.module.ts
+++ b/apps/flows/src/app/app-routing.module.ts
@@ -8,6 +8,7 @@ import { ForYouComponent } from './transaction-details-flow/for-you/for-you.comp
 import { TransactionDetailsFlowComponent } from './transaction-details-flow/transaction-details-flow.component';
 import { TransactionDetailsComponent } from './transaction-details-flow/transaction-details/transaction-details.component';
 import { TransactionsComponent } from './transaction-details-flow/transactions/transactions.component';
+import { HomePageComponent } from './transfer-and-pay-flow/home-page/home-page.component';
 
 const routes: Routes = [
   {
@@ -44,6 +45,21 @@ const routes: Routes = [
             component: TransactionDetailsComponent,
           },
         ],
+      },
+    ],
+  },
+  {
+    path: 'transfer-and-pay-flow',
+    component: TransactionDetailsFlowComponent,
+    children: [
+      {
+        path: '',
+        redirectTo: 'home-page',
+        pathMatch: 'full',
+      },
+      {
+        path: 'home-page',
+        component: HomePageComponent,
       },
     ],
   },

--- a/apps/flows/src/app/app.module.ts
+++ b/apps/flows/src/app/app.module.ts
@@ -18,7 +18,8 @@ import { HomePageComponent } from './transfer-and-pay-flow/home-page/home-page.c
 import { TransferAndPayModalComponent } from './transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component';
 import { TransferAndPayFlowComponent } from './transfer-and-pay-flow/transfer-and-pay-flow.component';
 import { ChooseRecieverComponent } from './transfer-and-pay-flow/choose-reciever/choose-reciever.component';
-
+import { FormsModule } from '@angular/forms';
+import { ChooseOwnAccountComponent } from './transfer-and-pay-flow/choose-own-account/choose-own-account.component';
 @NgModule({
   declarations: [
     AppComponent,
@@ -35,8 +36,9 @@ import { ChooseRecieverComponent } from './transfer-and-pay-flow/choose-reciever
     TransferAndPayModalComponent,
     TransferAndPayFlowComponent,
     ChooseRecieverComponent,
+    ChooseOwnAccountComponent,
   ],
-  imports: [BrowserModule, AppRoutingModule, KirbyModule],
+  imports: [BrowserModule, AppRoutingModule, KirbyModule, FormsModule],
   providers: [],
   bootstrap: [AppComponent],
 })

--- a/apps/flows/src/app/app.module.ts
+++ b/apps/flows/src/app/app.module.ts
@@ -14,6 +14,10 @@ import { ForYouComponent } from './transaction-details-flow/for-you/for-you.comp
 import { TransactionDetailsFlowComponent } from './transaction-details-flow/transaction-details-flow.component';
 import { TransactionDetailsComponent } from './transaction-details-flow/transaction-details/transaction-details.component';
 import { TransactionsComponent } from './transaction-details-flow/transactions/transactions.component';
+import { HomePageComponent } from './transfer-and-pay-flow/home-page/home-page.component';
+import { TransferAndPayModalComponent } from './transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component';
+import { TransferAndPayFlowComponent } from './transfer-and-pay-flow/transfer-and-pay-flow.component';
+import { ChooseRecieverComponent } from './transfer-and-pay-flow/choose-reciever/choose-reciever.component';
 
 @NgModule({
   declarations: [
@@ -27,6 +31,10 @@ import { TransactionsComponent } from './transaction-details-flow/transactions/t
     TransactionDetailsComponent,
     ForYouComponent,
     AccountComponent,
+    HomePageComponent,
+    TransferAndPayModalComponent,
+    TransferAndPayFlowComponent,
+    ChooseRecieverComponent,
   ],
   imports: [BrowserModule, AppRoutingModule, KirbyModule],
   providers: [],

--- a/apps/flows/src/app/home/home.component.html
+++ b/apps/flows/src/app/home/home.component.html
@@ -52,8 +52,11 @@
               size="md"
               shadow="true"
             ></kirby-avatar>
-            <h2 class="card-title">Navigate to Transfer and pay</h2>
-            <p>Modal Showcase</p>
+            <h2 class="card-title">Transfer and pay - Modals in Modal</h2>
+            <p>
+              Showcase of a standard flow of transfering money between own accounts or to others by
+              opening a modal that can open even more modals.
+            </p>
           </kirby-card>
         </article>
       </div>

--- a/apps/flows/src/app/home/home.component.html
+++ b/apps/flows/src/app/home/home.component.html
@@ -42,7 +42,19 @@
       </div>
       <div class="grid-item half-at-tablet-up">
         <article>
-          <kirby-card hasPadding="true" mode="highlighted"> </kirby-card>
+          <kirby-card
+            hasPadding="true"
+            mode="highlighted"
+            (click)="navigate('transfer-and-pay-flow')"
+          >
+            <kirby-avatar
+              imageSrc="https://picsum.photos/100?random=3"
+              size="md"
+              shadow="true"
+            ></kirby-avatar>
+            <h2 class="card-title">Navigate to Transfer and pay</h2>
+            <p>Modal Showcase</p>
+          </kirby-card>
         </article>
       </div>
       <div class="grid-item half-at-tablet-up">

--- a/apps/flows/src/app/transfer-and-pay-flow/choose-own-account/choose-own-account.component.html
+++ b/apps/flows/src/app/transfer-and-pay-flow/choose-own-account/choose-own-account.component.html
@@ -1,1 +1,0 @@
-<p>choose-own-account works!</p>

--- a/apps/flows/src/app/transfer-and-pay-flow/choose-own-account/choose-own-account.component.html
+++ b/apps/flows/src/app/transfer-and-pay-flow/choose-own-account/choose-own-account.component.html
@@ -1,0 +1,1 @@
+<p>choose-own-account works!</p>

--- a/apps/flows/src/app/transfer-and-pay-flow/choose-own-account/choose-own-account.component.spec.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/choose-own-account/choose-own-account.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChooseOwnAccountComponent } from './choose-own-account.component';
+
+describe('ChooseOwnAccountComponent', () => {
+  let component: ChooseOwnAccountComponent;
+  let fixture: ComponentFixture<ChooseOwnAccountComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ChooseOwnAccountComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChooseOwnAccountComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/flows/src/app/transfer-and-pay-flow/choose-own-account/choose-own-account.component.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/choose-own-account/choose-own-account.component.ts
@@ -3,7 +3,6 @@ import { Component, OnInit } from '@angular/core';
 @Component({
   selector: 'flows-choose-own-account',
   templateUrl: './choose-own-account.component.html',
-  styleUrls: ['./choose-own-account.component.scss'],
 })
 export class ChooseOwnAccountComponent implements OnInit {
   constructor() {}

--- a/apps/flows/src/app/transfer-and-pay-flow/choose-own-account/choose-own-account.component.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/choose-own-account/choose-own-account.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'flows-choose-own-account',
+  templateUrl: './choose-own-account.component.html',
+  styleUrls: ['./choose-own-account.component.scss'],
+})
+export class ChooseOwnAccountComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/apps/flows/src/app/transfer-and-pay-flow/choose-own-account/choose-own-account.component.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/choose-own-account/choose-own-account.component.ts
@@ -4,8 +4,6 @@ import { Component, OnInit } from '@angular/core';
   selector: 'flows-choose-own-account',
   templateUrl: './choose-own-account.component.html',
 })
-export class ChooseOwnAccountComponent implements OnInit {
+export class ChooseOwnAccountComponent {
   constructor() {}
-
-  ngOnInit(): void {}
 }

--- a/apps/flows/src/app/transfer-and-pay-flow/choose-reciever/choose-reciever.component.html
+++ b/apps/flows/src/app/transfer-and-pay-flow/choose-reciever/choose-reciever.component.html
@@ -1,0 +1,5 @@
+<p>Choose reciever works!</p>
+
+<button kirby-button attentionLevel="2">Own account</button>
+<button kirby-button>Other</button>
+<button kirby-button>Pay bill</button>

--- a/apps/flows/src/app/transfer-and-pay-flow/choose-reciever/choose-reciever.component.html
+++ b/apps/flows/src/app/transfer-and-pay-flow/choose-reciever/choose-reciever.component.html
@@ -1,5 +1,3 @@
-<p>Choose reciever works!</p>
-
 <button kirby-button attentionLevel="2">Own account</button>
 <button kirby-button>Other</button>
 <button kirby-button>Pay bill</button>

--- a/apps/flows/src/app/transfer-and-pay-flow/choose-reciever/choose-reciever.component.spec.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/choose-reciever/choose-reciever.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChooseRecieverComponent } from './choose-reciever.component';
+
+describe('ListOfRecieverComponent', () => {
+  let component: ChooseRecieverComponent;
+  let fixture: ComponentFixture<ChooseRecieverComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ChooseRecieverComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChooseRecieverComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/flows/src/app/transfer-and-pay-flow/choose-reciever/choose-reciever.component.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/choose-reciever/choose-reciever.component.ts
@@ -3,7 +3,6 @@ import { Component, OnInit } from '@angular/core';
 @Component({
   selector: 'flows-choose-reciever',
   templateUrl: './choose-reciever.component.html',
-  styleUrls: ['./choose-reciever.component.scss'],
 })
 export class ChooseRecieverComponent implements OnInit {
   constructor() {}

--- a/apps/flows/src/app/transfer-and-pay-flow/choose-reciever/choose-reciever.component.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/choose-reciever/choose-reciever.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'flows-choose-reciever',
+  templateUrl: './choose-reciever.component.html',
+  styleUrls: ['./choose-reciever.component.scss'],
+})
+export class ChooseRecieverComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/apps/flows/src/app/transfer-and-pay-flow/choose-reciever/choose-reciever.component.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/choose-reciever/choose-reciever.component.ts
@@ -4,8 +4,6 @@ import { Component, OnInit } from '@angular/core';
   selector: 'flows-choose-reciever',
   templateUrl: './choose-reciever.component.html',
 })
-export class ChooseRecieverComponent implements OnInit {
+export class ChooseRecieverComponent {
   constructor() {}
-
-  ngOnInit(): void {}
 }

--- a/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.html
+++ b/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.html
@@ -1,0 +1,11 @@
+<kirby-page title="Homepage" defaultBackHref="/">
+  <div *kirbyPageContent>
+    <div class="container">
+      <div (click)="showModal()" class="grid">
+        <kirby-card class="align-center" [hasPadding]="true" themeColor="secondary"
+          ><kirby-icon name="swap"></kirby-icon><br />Pay and transfer</kirby-card
+        >
+      </div>
+    </div>
+  </div>
+</kirby-page>

--- a/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.html
+++ b/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.html
@@ -4,7 +4,7 @@
       <div (click)="showModal()">
         <kirby-card class="align-center" [hasPadding]="true" themeColor="secondary">
           <kirby-icon name="swap"></kirby-icon>
-          <br />Pay and transfer
+          <br /><label>Pay and transfer</label>
         </kirby-card>
       </div>
     </div>

--- a/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.html
+++ b/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.html
@@ -1,10 +1,11 @@
 <kirby-page title="Homepage" defaultBackHref="/">
   <div *kirbyPageContent>
-    <div class="container">
-      <div (click)="showModal()" class="grid">
-        <kirby-card class="align-center" [hasPadding]="true" themeColor="secondary"
-          ><kirby-icon name="swap"></kirby-icon><br />Pay and transfer</kirby-card
-        >
+    <div class="container-middle">
+      <div (click)="showModal()">
+        <kirby-card class="align-center" [hasPadding]="true" themeColor="secondary">
+          <kirby-icon name="swap"></kirby-icon>
+          <br />Pay and transfer
+        </kirby-card>
       </div>
     </div>
   </div>

--- a/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.html
+++ b/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.html
@@ -4,7 +4,7 @@
       <div (click)="showModal()">
         <kirby-card class="align-center" [hasPadding]="true" themeColor="secondary">
           <kirby-icon name="swap"></kirby-icon>
-          <br /><label>Pay and transfer</label>
+          <br /><label>Transfer and pay</label>
         </kirby-card>
       </div>
     </div>

--- a/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.scss
+++ b/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.scss
@@ -2,12 +2,10 @@
   text-align: center;
 }
 
-.container {
-  display: flex;
-}
-
-.grid {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+.container-middle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin-right: -50%;
+  transform: translate(-50%, -50%);
 }

--- a/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.scss
+++ b/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.scss
@@ -1,0 +1,13 @@
+.align-center {
+  text-align: center;
+}
+
+.container {
+  display: flex;
+}
+
+.grid {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.spec.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HomePageComponent } from './home-page.component';
+
+describe('HomePageComponent', () => {
+  let component: HomePageComponent;
+  let fixture: ComponentFixture<HomePageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [HomePageComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HomePageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.ts
@@ -1,0 +1,27 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { ModalConfig, ModalController } from '@kirbydesign/designsystem';
+import { TransferAndPayModalComponent } from '../transfer-and-pay-modal/transfer-and-pay-modal.component';
+
+@Component({
+  selector: 'flows-home-page',
+  templateUrl: './home-page.component.html',
+  styleUrls: ['./home-page.component.scss'],
+})
+export class HomePageComponent implements OnInit {
+  constructor(private modalController: ModalController) {}
+
+  showModal() {
+    const config: ModalConfig = {
+      flavor: 'modal',
+      component: TransferAndPayModalComponent,
+      componentProps: {
+        prop1: 'value1',
+        prop2: 'value2',
+      },
+    };
+    this.modalController.showModal(config);
+  }
+
+  ngOnInit(): void {}
+}

--- a/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.ts
@@ -7,7 +7,7 @@ import { TransferAndPayModalComponent } from '../transfer-and-pay-modal/transfer
   templateUrl: './home-page.component.html',
   styleUrls: ['./home-page.component.scss'],
 })
-export class HomePageComponent implements OnInit {
+export class HomePageComponent {
   constructor(private modalController: ModalController) {}
 
   showModal() {
@@ -17,6 +17,4 @@ export class HomePageComponent implements OnInit {
     };
     this.modalController.showModal(config);
   }
-
-  ngOnInit(): void {}
 }

--- a/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
 import { ModalConfig, ModalController } from '@kirbydesign/designsystem';
 import { TransferAndPayModalComponent } from '../transfer-and-pay-modal/transfer-and-pay-modal.component';
 

--- a/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/home-page/home-page.component.ts
@@ -14,10 +14,6 @@ export class HomePageComponent implements OnInit {
     const config: ModalConfig = {
       flavor: 'modal',
       component: TransferAndPayModalComponent,
-      componentProps: {
-        prop1: 'value1',
-        prop2: 'value2',
-      },
     };
     this.modalController.showModal(config);
   }

--- a/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-flow.component.html
+++ b/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-flow.component.html
@@ -1,0 +1,15 @@
+<kirby-app>
+  <kirby-tab-bar>
+    <button kirby-button (click)="onTabSelect()">
+      <kirby-icon name="person-outline"></kirby-icon>
+      <kirby-icon name="person" selected-tab></kirby-icon>
+      For you
+    </button>
+
+    <button kirby-button (click)="onTabSelect()">
+      <kirby-icon name="accounts-outline"></kirby-icon>
+      <kirby-icon name="accounts" selected-tab></kirby-icon>
+      Account
+    </button>
+  </kirby-tab-bar>
+</kirby-app>

--- a/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-flow.component.html
+++ b/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-flow.component.html
@@ -1,12 +1,12 @@
 <kirby-app>
   <kirby-tab-bar>
-    <button kirby-button (click)="onTabSelect()">
+    <button kirby-button>
       <kirby-icon name="person-outline"></kirby-icon>
       <kirby-icon name="person" selected-tab></kirby-icon>
       For you
     </button>
 
-    <button kirby-button (click)="onTabSelect()">
+    <button kirby-button>
       <kirby-icon name="accounts-outline"></kirby-icon>
       <kirby-icon name="accounts" selected-tab></kirby-icon>
       Account

--- a/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-flow.component.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-flow.component.ts
@@ -5,17 +5,6 @@ import { ToastController, ToastConfig } from '@kirbydesign/designsystem';
   selector: 'kirbydesign-transfer-and-pay-flow',
   templateUrl: './transfer-and-pay-flow.component.html',
 })
-export class TransferAndPayFlowComponent implements OnInit {
-  constructor(private toastController: ToastController) {}
-
-  onTabSelect(): void {
-    const config: ToastConfig = {
-      message: 'Your toast message',
-      messageType: 'success',
-      durationInMs: 10000,
-    };
-    this.toastController.showToast(config);
-  }
-
-  ngOnInit(): void {}
+export class TransferAndPayFlowComponent {
+  constructor() {}
 }

--- a/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-flow.component.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-flow.component.ts
@@ -1,0 +1,21 @@
+import { Component, OnInit } from '@angular/core';
+import { ToastController, ToastConfig } from '@kirbydesign/designsystem';
+
+@Component({
+  selector: 'kirbydesign-transfer-and-pay-flow',
+  templateUrl: './transfer-and-pay-flow.component.html',
+})
+export class TransferAndPayFlowComponent implements OnInit {
+  constructor(private toastController: ToastController) {}
+
+  onTabSelect(): void {
+    const config: ToastConfig = {
+      message: 'Your toast message',
+      messageType: 'success',
+      durationInMs: 10000,
+    };
+    this.toastController.showToast(config);
+  }
+
+  ngOnInit(): void {}
+}

--- a/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.html
+++ b/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.html
@@ -6,7 +6,7 @@
     type="text"
     #input
     [(ngModel)]="currency"
-    (input)="onChange()"
+    (input)="onCurrencyEntered()"
   />
   <span class="small-text">Kr.</span>
 </div>

--- a/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.html
+++ b/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.html
@@ -1,0 +1,16 @@
+<kirby-page-title>Transfer and pay</kirby-page-title>
+
+<div class="align-center"><input type="number" /> <span>Kr.</span></div>
+
+<kirby-modal-footer>
+  <!-- <div class="container"> -->
+  <!-- <div class="grid" (click)="showModalChoose()" >
+            <p>Fra</p>
+            <p>Accounts</p>
+    </div>
+     <kirby-divider></kirby-divider> 
+    <div>
+    <button class="align-center" kirby-button (click)="showModalChoose()">Choose reciever</button> -->
+  <!-- </div> -->
+  <!-- </div> -->
+</kirby-modal-footer>

--- a/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.html
+++ b/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.html
@@ -14,12 +14,12 @@
 <kirby-modal-footer>
   <div class="container-over">
     <div class="grid" (click)="showModalChooseOwnAccount()">
-      <p>Fra</p>
+      <p>From</p>
       <p>Accounts</p>
     </div>
     <kirby-divider></kirby-divider>
     <div class="container-under">
-      <button kirby-button (click)="showModalChooseReciever()">Choose reciever</button>
+      <button kirby-button (click)="showModalChooseReciever()">Choose receiver</button>
     </div>
   </div>
 </kirby-modal-footer>

--- a/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.html
+++ b/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.html
@@ -1,16 +1,25 @@
 <kirby-page-title>Transfer and pay</kirby-page-title>
-
-<div class="align-center"><input type="number" /> <span>Kr.</span></div>
+<div>
+  <input
+    class="large-text"
+    maxlength="14"
+    type="text"
+    #input
+    [(ngModel)]="currency"
+    (input)="onChange()"
+  />
+  <span class="small-text">Kr.</span>
+</div>
 
 <kirby-modal-footer>
-  <!-- <div class="container"> -->
-  <!-- <div class="grid" (click)="showModalChoose()" >
-            <p>Fra</p>
-            <p>Accounts</p>
+  <div class="container-over">
+    <div class="grid" (click)="showModalChooseOwnAccount()">
+      <p>Fra</p>
+      <p>Accounts</p>
     </div>
-     <kirby-divider></kirby-divider> 
-    <div>
-    <button class="align-center" kirby-button (click)="showModalChoose()">Choose reciever</button> -->
-  <!-- </div> -->
-  <!-- </div> -->
+    <kirby-divider></kirby-divider>
+    <div class="container-under">
+      <button kirby-button (click)="showModalChooseReciever()">Choose reciever</button>
+    </div>
+  </div>
 </kirby-modal-footer>

--- a/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.html
+++ b/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.html
@@ -1,14 +1,14 @@
 <kirby-page-title>Transfer and pay</kirby-page-title>
 <div>
   <input
-    class="large-text"
+    class="currency-input currency-input_large-text"
     maxlength="14"
     type="text"
     #input
     [(ngModel)]="currency"
     (input)="onCurrencyEntered()"
   />
-  <span class="small-text">Kr.</span>
+  <span class="currency-input_small-text">Kr.</span>
 </div>
 
 <kirby-modal-footer>

--- a/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.scss
+++ b/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.scss
@@ -3,12 +3,26 @@
   justify-content: space-between;
 }
 
-input {
+.currency-input {
   margin-left: auto;
   margin-right: auto;
   all: unset;
   text-align: right;
   width: 80%;
+
+  &_ {
+    &large-text {
+      font-size: 100px;
+    }
+
+    &medium-text {
+      font-size: 75px;
+    }
+
+    &small-text {
+      font-size: 50px;
+    }
+  }
 }
 
 input::-webkit-outer-spin-button,
@@ -29,16 +43,4 @@ input::-webkit-inner-spin-button {
 /* stylelint-disable selector-pseudo-element-no-unknown */
 ::ng-deep ion-footer {
   box-sizing: border-box;
-}
-
-.large-text {
-  font-size: 100px;
-}
-
-.medium-text {
-  font-size: 75px;
-}
-
-.small-text {
-  font-size: 50px;
 }

--- a/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.scss
+++ b/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.scss
@@ -1,0 +1,26 @@
+.align-center {
+  display: flex;
+  justify-content: center;
+}
+
+.grid {
+  display: flex;
+  justify-content: space-between;
+}
+
+input {
+  margin-left: auto;
+  margin-right: auto;
+  all: unset;
+  text-align: right;
+}
+
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  appearance: none;
+  margin: 0;
+}
+
+.container {
+  width: 90%;
+}

--- a/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.scss
+++ b/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.scss
@@ -1,8 +1,3 @@
-.align-center {
-  display: flex;
-  justify-content: center;
-}
-
 .grid {
   display: flex;
   justify-content: space-between;
@@ -13,6 +8,7 @@ input {
   margin-right: auto;
   all: unset;
   text-align: right;
+  width: 80%;
 }
 
 input::-webkit-outer-spin-button,
@@ -21,6 +17,28 @@ input::-webkit-inner-spin-button {
   margin: 0;
 }
 
-.container {
-  width: 90%;
+.container-over {
+  width: 80%;
+}
+
+.container-under {
+  display: flex;
+  justify-content: center;
+}
+
+/* stylelint-disable selector-pseudo-element-no-unknown */
+::ng-deep ion-footer {
+  box-sizing: border-box;
+}
+
+.large-text {
+  font-size: 100px;
+}
+
+.medium-text {
+  font-size: 75px;
+}
+
+.small-text {
+  font-size: 50px;
 }

--- a/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.spec.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TransferAndPayModalComponent } from './transfer-and-pay-modal.component';
+
+describe('TransferAndPayModalComponent', () => {
+  let component: TransferAndPayModalComponent;
+  let fixture: ComponentFixture<TransferAndPayModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TransferAndPayModalComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TransferAndPayModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.ts
@@ -40,16 +40,16 @@ export class TransferAndPayModalComponent {
 
   onCurrencyEntered(): void {
     if (this.currency.length > 5) {
-      this.input.nativeElement.classList.remove('medium-text');
-      this.input.nativeElement.classList.add('large-text');
+      this.input.nativeElement.classList.remove('currency-input_medium-text');
+      this.input.nativeElement.classList.add('currency-input_large-text');
     }
     if (this.currency.length > 7) {
-      this.input.nativeElement.classList.remove('small-text');
-      this.input.nativeElement.classList.add('medium-text');
+      this.input.nativeElement.classList.remove('currency-input_small-text');
+      this.input.nativeElement.classList.add('currency-input_medium-text');
     }
     if (this.currency.length > 9) {
-      this.input.nativeElement.classList.remove('medium-text');
-      this.input.nativeElement.classList.add('small-text');
+      this.input.nativeElement.classList.remove('currency-input_medium-text');
+      this.input.nativeElement.classList.add('currency-input_small-text');
     }
   }
 }

--- a/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.ts
@@ -1,6 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { ModalConfig, ModalController } from '@kirbydesign/designsystem';
 import { ChooseRecieverComponent } from '../choose-reciever/choose-reciever.component';
+import { ChooseOwnAccountComponent } from '../choose-own-account/choose-own-account.component';
+
 @Component({
   selector: 'flows-transfer-and-pay-modal',
   templateUrl: './transfer-and-pay-modal.component.html',
@@ -9,7 +11,12 @@ import { ChooseRecieverComponent } from '../choose-reciever/choose-reciever.comp
 export class TransferAndPayModalComponent implements OnInit {
   constructor(private modalController: ModalController) {}
 
-  showModalChoose() {
+  ngOnInit(): void {}
+
+  @ViewChild('input') input: ElementRef<HTMLInputElement>;
+  currency: string;
+
+  showModalChooseReciever() {
     const config: ModalConfig = {
       flavor: 'drawer',
       component: ChooseRecieverComponent,
@@ -21,5 +28,30 @@ export class TransferAndPayModalComponent implements OnInit {
     this.modalController.showModal(config);
   }
 
-  ngOnInit(): void {}
+  showModalChooseOwnAccount() {
+    const config: ModalConfig = {
+      flavor: 'drawer',
+      component: ChooseOwnAccountComponent,
+      componentProps: {
+        prop1: 'value1',
+        prop2: 'value2',
+      },
+    };
+    this.modalController.showModal(config);
+  }
+
+  onChange(): void {
+    if (this.currency.length > 5) {
+      this.input.nativeElement.classList.remove('medium-text');
+      this.input.nativeElement.classList.add('large-text');
+    }
+    if (this.currency.length > 7) {
+      this.input.nativeElement.classList.remove('small-text');
+      this.input.nativeElement.classList.add('medium-text');
+    }
+    if (this.currency.length > 9) {
+      this.input.nativeElement.classList.remove('medium-text');
+      this.input.nativeElement.classList.add('small-text');
+    }
+  }
 }

--- a/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit } from '@angular/core';
+import { ModalConfig, ModalController } from '@kirbydesign/designsystem';
+import { ChooseRecieverComponent } from '../choose-reciever/choose-reciever.component';
+@Component({
+  selector: 'flows-transfer-and-pay-modal',
+  templateUrl: './transfer-and-pay-modal.component.html',
+  styleUrls: ['./transfer-and-pay-modal.component.scss'],
+})
+export class TransferAndPayModalComponent implements OnInit {
+  constructor(private modalController: ModalController) {}
+
+  showModalChoose() {
+    const config: ModalConfig = {
+      flavor: 'drawer',
+      component: ChooseRecieverComponent,
+      componentProps: {
+        prop1: 'value1',
+        prop2: 'value2',
+      },
+    };
+    this.modalController.showModal(config);
+  }
+
+  ngOnInit(): void {}
+}

--- a/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.ts
+++ b/apps/flows/src/app/transfer-and-pay-flow/transfer-and-pay-modal/transfer-and-pay-modal.component.ts
@@ -8,12 +8,10 @@ import { ChooseOwnAccountComponent } from '../choose-own-account/choose-own-acco
   templateUrl: './transfer-and-pay-modal.component.html',
   styleUrls: ['./transfer-and-pay-modal.component.scss'],
 })
-export class TransferAndPayModalComponent implements OnInit {
+export class TransferAndPayModalComponent {
   constructor(private modalController: ModalController) {}
 
-  ngOnInit(): void {}
-
-  @ViewChild('input') input: ElementRef<HTMLInputElement>;
+  @ViewChild('input') public input: ElementRef<HTMLInputElement>;
   currency: string;
 
   showModalChooseReciever() {
@@ -40,7 +38,7 @@ export class TransferAndPayModalComponent implements OnInit {
     this.modalController.showModal(config);
   }
 
-  onChange(): void {
+  onCurrencyEntered(): void {
     if (this.currency.length > 5) {
       this.input.nativeElement.classList.remove('medium-text');
       this.input.nativeElement.classList.add('large-text');


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2547 

## What is the new behavior?

Added new user flow journey to flow app home page with description of the user flow. Button for transfer and pay added on transfer and pay flow homepage, that opens a modal with input field for currency. From this modal you can open "choose own account" modal and "choose receiver" modal.

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

