### PR TITLE
Prevent the full app from overscrolling as of iOS 16

### DIFF
--- a/libs/core/src/scss/_global-styles.scss
+++ b/libs/core/src/scss/_global-styles.scss
@@ -7,6 +7,15 @@
 @use 'base/link';
 @use 'base/html-list';
 
+// As of iOS 16 it is needed to set overflow: hidden on the html tag,
+// otherwise the whole application will overscroll. See issue: https://github.com/kirbydesign/designsystem/issues/2534.
+// It is a WebKit issue that is being worked on and the fix will likely be released in iOS 16.2 or 16.3. See comment: https://github.com/apache/cordova-ios/issues/1244#issuecomment-1246935718.
+// We should be able to remove the styling below, when the fix is released.
+
+html {
+  overflow: hidden;
+}
+
 :root,
 :host {
   --kirby-font-family: 'Roboto';


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2534

## What is the new behavior?
The whole app is not overscrolling on devices running on iOS 16

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

