### PR TITLE
Added configuration to remove white line around tooltip box.

### DIFF
--- a/libs/designsystem/src/lib/components/charts/shared/chart-config-service/configs/type.config.ts
+++ b/libs/designsystem/src/lib/components/charts/shared/chart-config-service/configs/type.config.ts
@@ -183,6 +183,9 @@ export const CHART_TYPES_CONFIG: ChartTypesConfig = {
             labelColor: (tooltipItem: TooltipItem<keyof ChartTypeRegistry>) => {
               return {
                 backgroundColor: tooltipItem.dataset.borderColor,
+                borderColor: getThemeColorHexString('semi-light'),
+                borderWidth: 2, // This value must be exactly 2. If it is less, a white "border" will appear, if greater than, a shadow around the box will be shown.
+                // An issue has been created, requesting a test to check this value doesn´t change: https://github.com/kirbydesign/designsystem/issues/2578
               } as TooltipLabelStyle;
             },
           },


### PR DESCRIPTION
## Which issue does this PR close?
This PR closes #2179

## What is the new behavior?
borderWidth & borderColor has been added to remove the white line around the boxes. borderWidth is set to 2, which is a fixed value, ensuring the box doesn´t get a "shadow" around it.

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this

 PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?
How it look now:
<img width="150" alt="Screenshot 2022-11-03 at 10 29 33" src="https://user-images.githubusercontent.com/114976818/199687979-130d5c34-ec44-4eed-b773-b2cf9cca2dc9.png">

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [-] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)". See https://github.com/kirbydesign/designsystem/issues/2578
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

