### PR TITLE
Moved Guides´ routing to a separate module

### DIFF
--- a/apps/cookbook/src/app/guides/guides-routing.module.ts
+++ b/apps/cookbook/src/app/guides/guides-routing.module.ts
@@ -1,0 +1,35 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { GridLayoutExtendedComponent } from './grid-layout/grid-layout-extended/grid-layout-extended.component';
+import { GridLayoutMultipleContainersComponent } from './grid-layout/grid-layout-multiple-containers/grid-layout-multiple-containers.component';
+import { GridLayoutSingleContainerComponent } from './grid-layout/grid-layout-single-container/grid-layout-single-container.component';
+import { GuidesComponent } from './guides.component';
+import { VirtualScrollListComponent } from './virtual-scroll/virtual-scroll-list/virtual-scroll-list.component';
+
+const routes = [
+  {
+    path: '',
+    component: GuidesComponent,
+  },
+  {
+    path: 'virtual-scroll-list',
+    component: VirtualScrollListComponent,
+  },
+  {
+    path: 'grid-layout-single-container',
+    component: GridLayoutSingleContainerComponent,
+  },
+  {
+    path: 'grid-layout-multiple-containers',
+    component: GridLayoutMultipleContainersComponent,
+  },
+  {
+    path: 'grid-layout-extended',
+    component: GridLayoutExtendedComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule, RouterModule.forChild(routes)],
+})
+export class GuidesRouterModule {}

--- a/apps/cookbook/src/app/guides/guides.module.ts
+++ b/apps/cookbook/src/app/guides/guides.module.ts
@@ -11,6 +11,7 @@ import { CodeViewerModule } from '../shared/code-viewer/code-viewer.module';
 import { GridLayoutExtendedComponent } from './grid-layout/grid-layout-extended/grid-layout-extended.component';
 import { GridLayoutMultipleContainersComponent } from './grid-layout/grid-layout-multiple-containers/grid-layout-multiple-containers.component';
 import { GridLayoutSingleContainerComponent } from './grid-layout/grid-layout-single-container/grid-layout-single-container.component';
+import { GuidesRouterModule } from './guides-routing.module';
 import { GuidesComponent } from './guides.component';
 import { VirtualScrollListComponent } from './virtual-scroll/virtual-scroll-list/virtual-scroll-list.component';
 
@@ -22,33 +23,11 @@ const guidesComponents = [
   VirtualScrollListComponent,
 ];
 
-const routes = [
-  {
-    path: '',
-    component: GuidesComponent,
-  },
-  {
-    path: 'virtual-scroll-list',
-    component: VirtualScrollListComponent,
-  },
-  {
-    path: 'grid-layout-single-container',
-    component: GridLayoutSingleContainerComponent,
-  },
-  {
-    path: 'grid-layout-multiple-containers',
-    component: GridLayoutMultipleContainersComponent,
-  },
-  {
-    path: 'grid-layout-extended',
-    component: GridLayoutExtendedComponent,
-  },
-];
-
 @NgModule({
   imports: [
     CommonModule,
-    RouterModule.forChild(routes),
+    GuidesRouterModule,
+    RouterModule,
     KirbyModule,
     IphoneModule,
     CodeViewerModule,


### PR DESCRIPTION
By moving routing to a seperate module, routing to default route in giudes works

## Which issue does this PR close?

This PR closes #2582

## What is the new behavior?
When routing to `#/home/guides`, the guides page is actually shown

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [-] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [-] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

