### PR TITLE
Prevent icon wiggle in kirby-item in Safari

### DIFF
--- a/libs/designsystem/src/lib/components/item/item.component.scss
+++ b/libs/designsystem/src/lib/components/item/item.component.scss
@@ -66,7 +66,7 @@
       text-align: right;
     }
 
-    --transition: #{interaction-state.transition()};
+    --transition: #{interaction-state.transition('background-color')};
   }
 
   &.sm ion-item {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2450

## What is the new behavior?
Icons in `kirby-item` with `[selected]="true"` will no longer wiggle on hover in Safari.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?
The bug was caused by the transition that was applied to the item on hover. The default transition for `ion-item` is applied to `background-color` and `opacity`. In Kirby we set the transition to apply to `all`. This PR only applies transition to `background-color` as the icon wiggle in Safari was caused by the `opacity` transition.

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

