### PR TITLE
Prevent instantiation of multiple modals, when another modal is being instantiated but not completed

### DIFF
--- a/libs/designsystem/src/lib/components/modal/services/modal.helper.ts
+++ b/libs/designsystem/src/lib/components/modal/services/modal.helper.ts
@@ -25,7 +25,17 @@ export class ModalHelper {
     private alertHelper: AlertHelper
   ) {}
 
+  /* 
+    isModalOpening is used to prevent additional instantiations
+    of modals, while a modal is already being instatiated, but not completed.
+    This is the recommended approach by one of the maintainers of Ionic:
+    https://github.com/ionic-team/ionic-framework/issues/23327#issuecomment-847028058
+  */
+  private isModalOpening = false;
+
   public async showModalWindow(config: ModalConfig, alertConfig?: AlertConfig): Promise<Overlay> {
+    if (this.isModalOpening) return;
+
     config.flavor = config.flavor || 'modal';
     const modalPresentingElement = await this.getPresentingElement(config.flavor);
 
@@ -60,6 +70,8 @@ export class ModalHelper {
       };
     }
 
+    this.isModalOpening = true;
+
     const ionModal = await this.ionicModalController.create({
       component: config.flavor === 'compact' ? ModalCompactWrapperComponent : ModalWrapperComponent,
       cssClass: [
@@ -89,6 +101,8 @@ export class ModalHelper {
     }
 
     await ionModal.present();
+
+    this.isModalOpening = false;
 
     return {
       dismiss: ionModal.dismiss.bind(ionModal),


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #1733

## What is the new behavior?
When the button to open a modal is clicked twice rapidly, then only one modal will open, instead of two.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?
This fix is implemented with a boolean (`isModalOpening`) that controls whether the `ionicModalController.create` method should be called or not, based on if the promise of the previous call is resolved. This approach is recommended by one of the maintainers of Ionic: https://github.com/ionic-team/ionic-framework/issues/23327#issuecomment-847028058

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

