### PR TITLE
Allow empty constructors in eslint

### DIFF
--- a/eslintrc-custom-overrides.json
+++ b/eslintrc-custom-overrides.json
@@ -6,7 +6,12 @@
         "prefer-const": "warn",
         "prefer-rest-params": "error",
         "prefer-spread": "error",
-        "no-empty-function": "warn",
+        "no-empty-function": [
+          "warn",
+          {
+            "allow": ["constructors"]
+          }
+        ],
         "no-extra-boolean-cast": "warn",
         "no-nested-ternary": "warn",
         "no-useless-escape": "warn",


### PR DESCRIPTION
## Which issue does this PR close?
This PR closes no issue

## What is the new behavior?
Angular quite often has empty constructors due to dependency injection, so this warning is not really helpful. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


