### PR TITLE
Add eslint rule to prevent focused tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,8 @@
 {
   "root": true,
-  "extends": ["prettier"],
+  "extends": ["prettier", "plugin:jasmine/recommended"],
   "ignorePatterns": ["**/*"],
-  "plugins": ["@nrwl/nx", "prettier"],
+  "plugins": ["@nrwl/nx", "prettier", "jasmine"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "root": true,
-  "extends": ["prettier", "plugin:jasmine/recommended"],
+  "extends": ["prettier"],
   "ignorePatterns": ["**/*"],
   "plugins": ["@nrwl/nx", "prettier", "jasmine"],
   "overrides": [
@@ -45,7 +45,8 @@
         "@angular-eslint/no-outputs-metadata-property": "error",
         "@angular-eslint/use-lifecycle-interface": "error",
         "@angular-eslint/use-pipe-transform-interface": "error",
-        "import/order": "warn"
+        "import/order": "warn",
+        "jasmine/no-focused-tests": 2
       },
       "plugins": ["eslint-plugin-import", "@angular-eslint/eslint-plugin", "@typescript-eslint"]
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,8 @@
         "coveralls": "3.0.2",
         "eslint": "~8.12.0",
         "eslint-config-prettier": "8.1.0",
-        "eslint-plugin-import": "*",
+        "eslint-plugin-import": "latest",
+        "eslint-plugin-jasmine": "^4.1.3",
         "eslint-plugin-prettier": "^4.2.1",
         "fs-extra": "^8.1.0",
         "husky": "^3.0.9",
@@ -10328,6 +10329,16 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eslint-plugin-jasmine": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jasmine/-/eslint-plugin-jasmine-4.1.3.tgz",
+      "integrity": "sha512-q8j8KnLH/4uwmPELFZvEyfEcuCuGxXScJaRdqHjOjz064GcfX6aoFbzy5VohZ5QYk2+WvoqMoqDSb9nRLf89GQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8",
+        "npm": ">=6"
+      }
     },
     "node_modules/eslint-plugin-prettier": {
       "version": "4.2.1",
@@ -29641,6 +29652,12 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-jasmine": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jasmine/-/eslint-plugin-jasmine-4.1.3.tgz",
+      "integrity": "sha512-q8j8KnLH/4uwmPELFZvEyfEcuCuGxXScJaRdqHjOjz064GcfX6aoFbzy5VohZ5QYk2+WvoqMoqDSb9nRLf89GQ==",
+      "dev": true
     },
     "eslint-plugin-prettier": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "eslint": "~8.12.0",
     "eslint-config-prettier": "8.1.0",
     "eslint-plugin-import": "latest",
+    "eslint-plugin-jasmine": "^4.1.3",
     "eslint-plugin-prettier": "^4.2.1",
     "fs-extra": "^8.1.0",
     "husky": "^3.0.9",


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2641

## What is the new behavior?
A new ESLint rule will now mark focused tests as errors.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

