### PR TITLE
Fix generateMock script after Angular 15 upgrade

### DIFF
--- a/tools/generate-mocks/generate-mocks.ts
+++ b/tools/generate-mocks/generate-mocks.ts
@@ -469,7 +469,7 @@ export class ${mockClassName} {${propertiesString}${methodsString}}
     componentMetaData.className = className;
 
     if (classDeclaration && ts.canHaveDecorators(classDeclaration)) {
-      ts.getDecorators(classDeclaration).forEach((decorator) => {
+      ts.getDecorators(classDeclaration)?.forEach((decorator) => {
         if (ts.isCallExpression(decorator.expression)) {
           if (ts.isIdentifier(decorator.expression.expression)) {
             const decoratorName = decorator.expression.expression.getText();
@@ -592,7 +592,7 @@ export class ${mockClassName} {${propertiesString}${methodsString}}
   ): { type: 'Input' | 'Output'; bindingProperty: string } {
     const inputOutputDecorator = { type: undefined, bindingProperty: undefined };
     if (propertyDeclaration && ts.canHaveDecorators(propertyDeclaration)) {
-      ts.getDecorators(propertyDeclaration).forEach((decorator) => {
+      ts.getDecorators(propertyDeclaration)?.forEach((decorator) => {
         if (ts.isCallExpression(decorator.expression)) {
           if (ts.isIdentifier(decorator.expression.expression)) {
             const decoratorName = decorator.expression.expression.getText();


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue, it is a hotfix after https://github.com/kirbydesign/designsystem/issues/2538

When testing locally it might be necessary to run `npm run transpile:generate-mocks` first, as that will update the generateMocks.js file that actually handles the mock generation and this file is not checked into git.