### PR TITLE
Apply focus ring to the segmented control only when using tab navigation

### DIFF
--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -18,6 +18,11 @@
 
       --padding-start: #{utils.size('s')};
       --padding-end: #{utils.size('s')};
+
+      @include interaction-state.apply-focus-visible {
+        outline: none;
+        border-radius: utils.$border-radius-round;
+      }
     }
   }
 
@@ -78,7 +83,10 @@ ion-segment {
 }
 
 ion-segment-button {
-  @include interaction-state.apply-focus-part($part: 'native');
+  @include interaction-state.apply-focus-visible {
+    outline: none;
+    border-radius: utils.$border-radius-round;
+  }
   @include interaction-state.apply-hover-ionic;
   @include interaction-state.apply-active-ionic('s');
   @include utils.accessible-target-size;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2556

## What is the new behavior?
The segmented control only get a focus ring when using tab navigation, and not on mouse click.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

