### PR TITLE
Slides use Ion hook for initial slide position

### DIFF
--- a/libs/designsystem/src/lib/components/slides/slides.component.spec.ts
+++ b/libs/designsystem/src/lib/components/slides/slides.component.spec.ts
@@ -1,20 +1,9 @@
 import { Component } from '@angular/core';
 import { fakeAsync } from '@angular/core/testing';
-import { IonSlide, IonSlides } from '@ionic/angular';
+import { IonSlide } from '@ionic/angular';
 import { byTestId, createHostFactory, HostComponent, SpectatorHost } from '@ngneat/spectator';
 
 import { SlideDirective, SlidesComponent } from './slides.component';
-
-class IonSlidesFake extends IonSlides {
-  getSwiper = () =>
-    Promise.resolve({
-      on: () => {},
-      params: {
-        slidesPerView: 1,
-      },
-    });
-  slideTo = (_index: number, _speed?: number, _runCallbacks?: boolean) => Promise.resolve();
-}
 
 describe('SlidesComponent', () => {
   let spectator: SpectatorHost<SlidesComponent, HostComponent>;
@@ -38,7 +27,7 @@ describe('SlidesComponent', () => {
   const createHost = createHostFactory({
     component: SlidesComponent,
     host: KirbySlidesHostComponent,
-    declarations: [IonSlidesFake, IonSlide, SlideDirective],
+    declarations: [IonSlide, SlideDirective],
   });
 
   beforeEach(() => {
@@ -63,14 +52,11 @@ describe('SlidesComponent', () => {
     expect(spectator.component.slidesOptions).toEqual(new KirbySlidesHostComponent().slidesOptions);
   });
 
-  it('should call slideTo with 4', () => {
-    // Arrange
-    spyOn(spectator.component.ionSlides, 'slideTo');
+  it('should call slideTo with 2', () => {
+    const slideToSpy = spyOn(spectator.component, 'slideTo');
 
-    // Act
     spectator.component.slideTo(2);
 
-    // Assert
-    expect(spectator.component.ionSlides.slideTo).toHaveBeenCalledWith(2);
+    expect(slideToSpy).toHaveBeenCalledWith(2);
   });
 });

--- a/libs/designsystem/src/lib/components/slides/slides.component.ts
+++ b/libs/designsystem/src/lib/components/slides/slides.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, EventEmitter } from '@angular/core';
+import { EventEmitter } from '@angular/core';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -19,7 +19,12 @@ export class SlideDirective {}
 @Component({
   selector: 'kirby-slides',
   template: `
-    <ion-slides [options]="slidesOptions" #ionslides (ionSlideDidChange)="onSlideChanged()">
+    <ion-slides
+      [options]="slidesOptions"
+      #ionslides
+      (ionSlideDidChange)="onSlideChanged()"
+      (ionSlidesDidLoad)="slideTo(0)"
+    >
       <ion-slide *ngFor="let slide of slides; let i = index">
         <ng-container
           *ngTemplateOutlet="slideTemplate; context: { $implicit: slide, index: i }"
@@ -29,7 +34,7 @@ export class SlideDirective {}
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SlidesComponent implements AfterViewInit {
+export class SlidesComponent {
   @ViewChild('ionslides', { static: false }) ionSlides: IonSlides;
   @Input() slidesOptions: any;
   @Input() slides: any[];
@@ -37,10 +42,6 @@ export class SlidesComponent implements AfterViewInit {
 
   @ContentChild(SlideDirective, { static: true, read: TemplateRef })
   public slideTemplate: TemplateRef<any>;
-
-  ngAfterViewInit() {
-    this.slideTo(0);
-  }
 
   onSlideChanged() {
     this.ionSlides.getActiveIndex().then((selectedIndex) => {
@@ -51,7 +52,7 @@ export class SlidesComponent implements AfterViewInit {
     });
   }
 
-  slideTo(index: number) {
+  public slideTo(index: number) {
     this.ionSlides.slideTo(index);
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes - No issue created

## What is the new behavior?
No new behaviour. 
An underlying change has been made to how slides set the initial slide position
<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?
No
<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [-] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [-] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

