### PR TITLE
Kirby page sticky content shouldn't be transparent

### DIFF
--- a/libs/designsystem/src/lib/components/page/page.component.scss
+++ b/libs/designsystem/src/lib/components/page/page.component.scss
@@ -263,7 +263,7 @@ ion-content {
     margin: 0 auto;
   }
 
-  &::before {
+  &.content-pinned::before {
     // Background
     content: '';
     position: absolute;

--- a/libs/designsystem/src/lib/components/page/page.component.scss
+++ b/libs/designsystem/src/lib/components/page/page.component.scss
@@ -263,7 +263,21 @@ ion-content {
     margin: 0 auto;
   }
 
-  &.content-pinned::before {
+  &::before {
+    // Background
+    content: '';
+    position: absolute;
+
+    // Adjust for padding of ion-content to stretch divider to full width.
+    left: calc(-1 * $ion-content-padding-start);
+    right: calc(-1 * $ion-content-padding-end);
+    bottom: 0;
+    top: 0;
+    z-index: 0;
+    background-color: #{utils.get-color('background-color')};
+  }
+
+  &.content-pinned::after {
     // Divider
     content: '';
     position: absolute;

--- a/libs/designsystem/src/lib/components/page/page.component.scss
+++ b/libs/designsystem/src/lib/components/page/page.component.scss
@@ -274,7 +274,7 @@ ion-content {
     bottom: 0;
     top: 0;
     z-index: 0;
-    background-color: #{utils.get-color('background-color')};
+    background-color: var(--kirby-background-color);
   }
 
   &.content-pinned::after {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2685 

## What is the new behavior?

This PR adds a pseudo element behind the sticky content that expands 16px to the left and right with the same logic as with the divider. This was we can cover the entire area with a background-color without changing the layout.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

Most context should be available in the initial issue.

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [ ] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

