### PR TITLE
Solution for tab item shift on hover and badge margin

### DIFF
--- a/apps/cookbook/src/app/examples/page-example/tab-navigation/page-tab-nav-example.component.html
+++ b/apps/cookbook/src/app/examples/page-example/tab-navigation/page-tab-nav-example.component.html
@@ -5,21 +5,21 @@
 >
   <kirby-tab-navigation *kirbyPageStickyContent>
     <kirby-tab-navigation-item>
-      <span>Item 1</span>
+      <span text>Item 1</span>
     </kirby-tab-navigation-item>
     <kirby-tab-navigation-item>
-      <span>Item 2</span>
+      <span text>Item 2</span>
       <kirby-badge themeColor="warning">
         <kirby-icon name="attach"></kirby-icon>
       </kirby-badge>
     </kirby-tab-navigation-item>
     <kirby-tab-navigation-item>
-      <span>Item 3</span>
+      <span text>Item 3</span>
       <kirby-badge themeColor="success">3</kirby-badge>
     </kirby-tab-navigation-item>
-    <kirby-tab-navigation-item><span>Item 4</span></kirby-tab-navigation-item>
-    <kirby-tab-navigation-item><span>Item 5 longer</span></kirby-tab-navigation-item>
-    <kirby-tab-navigation-item><span>Item 6 longer</span></kirby-tab-navigation-item>
+    <kirby-tab-navigation-item><span text>Item 4</span></kirby-tab-navigation-item>
+    <kirby-tab-navigation-item><span text>Item 5 longer</span></kirby-tab-navigation-item>
+    <kirby-tab-navigation-item><span text>Item 6 longer</span></kirby-tab-navigation-item>
   </kirby-tab-navigation>
   <kirby-page-content>
     <p>

--- a/libs/designsystem/src/lib/components/tab-navigation/tab-navigation-item/tab-navigation-item.component.scss
+++ b/libs/designsystem/src/lib/components/tab-navigation/tab-navigation-item/tab-navigation-item.component.scss
@@ -34,6 +34,7 @@ $divider-max-width-breakpoint: utils.$page-content-max-width + (utils.size('s') 
 
 .tab-item-inner {
   display: flex;
+  gap: utils.size('xxxs');
   align-items: center;
   justify-content: center;
   white-space: nowrap;
@@ -45,10 +46,6 @@ $divider-max-width-breakpoint: utils.$page-content-max-width + (utils.size('s') 
 
 /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
 :host ::ng-deep .tab-item-inner {
-  kirby-badge {
-    margin-left: utils.size('xxxs');
-  }
-
   span {
     max-width: $tab-item-text-max-width;
     overflow: hidden;

--- a/libs/designsystem/src/lib/components/tab-navigation/tab-navigation-item/tab-navigation-item.component.scss
+++ b/libs/designsystem/src/lib/components/tab-navigation/tab-navigation-item/tab-navigation-item.component.scss
@@ -44,24 +44,21 @@ $divider-max-width-breakpoint: utils.$page-content-max-width + (utils.size('s') 
   user-select: none;
 }
 
+// Restrict cascade of styles to all child elements of component - see https://blog.angular-university.io/angular-host-context/
 /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
-:host ::ng-deep .tab-item-inner {
-  span {
-    max-width: $tab-item-text-max-width;
-    overflow: hidden;
-    text-overflow: ellipsis;
+:host ::ng-deep span[text] {
+  max-width: $tab-item-text-max-width;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
-    // The larger line-height ensures no vertical layout shifts when changing the span's text content from bold to normal font-weight.
-    // See lines 75-79
-    line-height: utils.size('m');
-  }
+  // The larger line-height ensures no vertical layout shifts when changing the span's text content from bold to normal font-weight.
+  line-height: utils.size('m');
 
   // Using the before selector to insert a hidden pseudo-element with the same text content in bold,
   // ensures no horizontal layout shifts when changing the visible span's text content from bold to normal font-weight.
-  // See lines 75-79
-  span::before {
+  &::before {
     display: block;
-    content: attr(text);
+    content: attr(data-text);
     font-weight: bold;
     height: 0;
     overflow: hidden;

--- a/libs/designsystem/src/lib/components/tab-navigation/tab-navigation-item/tab-navigation-item.component.ts
+++ b/libs/designsystem/src/lib/components/tab-navigation/tab-navigation-item/tab-navigation-item.component.ts
@@ -1,15 +1,40 @@
-import { Component, HostBinding } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import {
+  AfterViewInit,
+  Component,
+  ContentChild,
+  ContentChildren,
+  ElementRef,
+  HostBinding,
+  Inject,
+  Query,
+} from '@angular/core';
 
 @Component({
   selector: 'kirby-tab-navigation-item',
   templateUrl: './tab-navigation-item.component.html',
   styleUrls: ['./tab-navigation-item.component.scss'],
 })
-export class TabNavigationItemComponent {
+export class TabNavigationItemComponent implements AfterViewInit {
   @HostBinding('attr.tabindex')
   tabIndex = 0;
 
-  constructor() {
+  private readonly labelTextElementSelector = 'span[text]';
+  private readonly labelTextElementContentAttribute = 'data-text';
+
+  constructor(private elementRef: ElementRef<HTMLElement>) {
     /* */
+  }
+
+  ngAfterViewInit(): void {
+    const labelTextElement = this.elementRef.nativeElement.querySelector(
+      this.labelTextElementSelector
+    );
+    if (labelTextElement) {
+      labelTextElement.setAttribute(
+        this.labelTextElementContentAttribute,
+        labelTextElement.textContent
+      );
+    }
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2714

## What is the new behavior?

- A text attribute has been added to the span label element identifying the text part of the label. 
- The left margin of badge has been replaced with a gap setting on the flex layout of the content.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

