### PR TITLE
Generate missing mocks

### DIFF
--- a/libs/designsystem/testing-base/src/lib/components/index.ts
+++ b/libs/designsystem/testing-base/src/lib/components/index.ts
@@ -44,7 +44,9 @@ export {
   MockPageComponent,
   MockPageContentComponent,
   MockPageTitleComponent,
+  MockPageStickyContentDirective,
 } from './mock.page.component';
+export { MockPageLocalNavigationComponent } from './mock.page-local-navigation.component';
 export { MockPopoverComponent } from './mock.popover.component';
 export { MockProgressCircleComponent } from './mock.progress-circle.component';
 export { MockRadioGroupComponent } from './mock.radio-group.component';
@@ -59,6 +61,8 @@ export { MockSlideDirective, MockSlidesComponent } from './mock.slides.component
 export { MockSpinnerComponent } from './mock.spinner.component';
 export { MockTabButtonComponent } from './mock.tab-button.component';
 export { MockTabsComponent } from './mock.tabs.component';
+export { MockTableComponent } from './mock.table.component';
+export { MockTableRowComponent } from './mock.table-row.component';
 export { MockTextareaComponent } from './mock.textarea.component';
 export { MockToggleButtonComponent } from './mock.toggle-button.component';
 export { MockToggleComponent } from './mock.toggle.component';

--- a/libs/designsystem/testing-base/src/lib/components/mock.dropdown.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.dropdown.component.ts
@@ -16,6 +16,7 @@ import { DropdownComponent, HorizontalDirection } from '@kirbydesign/designsyste
 export class MockDropdownComponent {
   @Input() items: string[] | any[];
   @Input() selectedIndex: number;
+  @Input() focusedIndex: number;
   @Input() itemTextProperty: string;
   @Input() placeholder: string;
   @Input() popout: HorizontalDirection | `${HorizontalDirection}`;

--- a/libs/designsystem/testing-base/src/lib/components/mock.page-local-navigation.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.page-local-navigation.component.ts
@@ -1,0 +1,22 @@
+import { Component, EventEmitter, forwardRef, Input, Output } from '@angular/core';
+
+import { LocalNavigationItem, PageLocalNavigationComponent } from '@kirbydesign/designsystem';
+
+// #region AUTO-GENERATED - PLEASE DON'T EDIT CONTENT WITHIN!
+@Component({
+  selector: 'kirby-page-local-navigation',
+  template: '<ng-content></ng-content>',
+  providers: [
+    {
+      provide: PageLocalNavigationComponent,
+      useExisting: forwardRef(() => MockPageLocalNavigationComponent),
+    },
+  ],
+})
+export class MockPageLocalNavigationComponent {
+  @Input() items: LocalNavigationItem[];
+  @Input() selectedIndex: number;
+  @Output() selectedIndexChange = new EventEmitter<number>();
+}
+
+// #endregion

--- a/libs/designsystem/testing-base/src/lib/components/mock.page.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.page.component.ts
@@ -7,6 +7,7 @@ import {
   PageContentComponent,
   PageContentDirective,
   PageProgressComponent,
+  PageStickyContentDirective,
   PageSubtitleDirective,
   PageTitleComponent,
   PageTitleDirective,

--- a/libs/designsystem/testing-base/src/lib/components/mock.page.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.page.component.ts
@@ -77,6 +77,17 @@ export class MockPageContentDirective {
   @Input('kirbyPageContent') config: fixedConfig;
 }
 
+@Directive({
+  selector: '[kirbyPageStickyContent]',
+  providers: [
+    {
+      provide: PageStickyContentDirective,
+      useExisting: forwardRef(() => MockPageStickyContentDirective),
+    },
+  ],
+})
+export class MockPageStickyContentDirective {}
+
 @Component({
   selector: 'kirby-page-progress',
   template: '<ng-content></ng-content>',

--- a/libs/designsystem/testing-base/src/lib/components/mock.table-row.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.table-row.component.ts
@@ -1,0 +1,21 @@
+import { Component, forwardRef, Input } from '@angular/core';
+
+import { TableRowComponent } from '@kirbydesign/designsystem';
+
+// #region AUTO-GENERATED - PLEASE DON'T EDIT CONTENT WITHIN!
+@Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'tr[kirby-tr]',
+  template: '<ng-content></ng-content>',
+  providers: [
+    {
+      provide: TableRowComponent,
+      useExisting: forwardRef(() => MockTableRowComponent),
+    },
+  ],
+})
+export class MockTableRowComponent {
+  @Input() selectable: boolean;
+}
+
+// #endregion

--- a/libs/designsystem/testing-base/src/lib/components/mock.table.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.table.component.ts
@@ -1,0 +1,21 @@
+import { Component, forwardRef, Input } from '@angular/core';
+
+import { TableComponent } from '@kirbydesign/designsystem';
+
+// #region AUTO-GENERATED - PLEASE DON'T EDIT CONTENT WITHIN!
+@Component({
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: 'table[kirby-table]',
+  template: '<ng-content></ng-content>',
+  providers: [
+    {
+      provide: TableComponent,
+      useExisting: forwardRef(() => MockTableComponent),
+    },
+  ],
+})
+export class MockTableComponent {
+  @Input() fixedLayout: boolean;
+}
+
+// #endregion

--- a/libs/designsystem/testing-base/src/lib/mock-components.ts
+++ b/libs/designsystem/testing-base/src/lib/mock-components.ts
@@ -11,6 +11,8 @@ import { MockCardComponent } from './components/mock.card.component';
 import { MockChartComponent } from './components/mock.chart.component';
 import { MockBaseChartComponent } from './components/mock.base-chart.component';
 import { MockCheckboxComponent } from './components/mock.checkbox.component';
+import { MockTableComponent } from './components/mock.table.component';
+import { MockTableRowComponent } from './components/mock.table-row.component';
 import { MockDividerComponent } from './components/mock.divider.component';
 import { MockDropdownComponent } from './components/mock.dropdown.component';
 import { MockEmptyStateComponent } from './components/mock.empty-state.component';
@@ -43,11 +45,13 @@ import {
   MockPageContentComponent,
   MockPageContentDirective,
   MockPageProgressComponent,
+  MockPageStickyContentDirective,
   MockPageSubtitleDirective,
   MockPageTitleComponent,
   MockPageTitleDirective,
   MockPageToolbarTitleDirective,
 } from './components/mock.page.component';
+import { MockPageLocalNavigationComponent } from './components/mock.page-local-navigation.component';
 import { MockPopoverComponent } from './components/mock.popover.component';
 import { MockProgressCircleComponent } from './components/mock.progress-circle.component';
 import { MockRadioGroupComponent } from './components/mock.radio-group.component';
@@ -77,6 +81,8 @@ export const MOCK_COMPONENTS = [
   MockChartComponent,
   MockBaseChartComponent,
   MockCheckboxComponent,
+  MockTableComponent,
+  MockTableRowComponent,
   MockDividerComponent,
   MockDropdownComponent,
   MockEmptyStateComponent,
@@ -107,11 +113,13 @@ export const MOCK_COMPONENTS = [
   MockPageToolbarTitleDirective,
   MockPageActionsDirective,
   MockPageContentDirective,
+  MockPageStickyContentDirective,
   MockPageProgressComponent,
   MockPageTitleComponent,
   MockPageContentComponent,
   MockPageActionsComponent,
   MockPageComponent,
+  MockPageLocalNavigationComponent,
   MockPopoverComponent,
   MockProgressCircleComponent,
   MockRadioGroupComponent,

--- a/libs/designsystem/testing-base/testing-jasmine/src/lib/mock-providers.ts
+++ b/libs/designsystem/testing-base/testing-jasmine/src/lib/mock-providers.ts
@@ -25,6 +25,7 @@ export function chartJSServiceFactory() {
   return jasmine.createSpyObj<ChartJSService>('ChartJSService', [
     'renderChart',
     'redrawChart',
+    'destroyChart',
     'updateData',
     'updateLabels',
     'updateType',
@@ -52,6 +53,7 @@ export function modalControllerFactory() {
     'navigateWithinModal',
     'showActionSheet',
     'showAlert',
+    'registerPresentingElement',
     'hideTopmost',
     'scrollToTop',
     'scrollToBottom',
@@ -60,7 +62,9 @@ export function modalControllerFactory() {
 }
 
 export function tabsServiceFactory() {
-  return jasmine.createSpyObj<TabsService>('TabsService', ['setOutlet'], { outlet$: EMPTY });
+  return jasmine.createSpyObj<TabsService>('TabsService', ['setOutlet', 'resetOutlet'], {
+    outlet$: EMPTY,
+  });
 }
 
 export function toastControllerFactory() {

--- a/libs/designsystem/testing-jest/src/lib/mock-providers.ts
+++ b/libs/designsystem/testing-jest/src/lib/mock-providers.ts
@@ -25,6 +25,7 @@ export function chartJSServiceFactory() {
   return {
     renderChart: jest.fn(),
     redrawChart: jest.fn(),
+    destroyChart: jest.fn(),
     updateData: jest.fn(),
     updateLabels: jest.fn(),
     updateType: jest.fn(),
@@ -55,6 +56,7 @@ export function modalControllerFactory() {
     navigateWithinModal: jest.fn(),
     showActionSheet: jest.fn(),
     showAlert: jest.fn(),
+    registerPresentingElement: jest.fn(),
     hideTopmost: jest.fn(),
     scrollToTop: jest.fn(),
     scrollToBottom: jest.fn(),
@@ -65,6 +67,7 @@ export function modalControllerFactory() {
 export function tabsServiceFactory() {
   return {
     setOutlet: jest.fn(),
+    resetOutlet: jest.fn(),
     outlet$: EMPTY,
   };
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?

Added missing mocks for some of our new components. Apparently our generate-mocks script was not automatically run when the components were introduced.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
