### PR TITLE
Remove isDestructive button input

### DIFF
--- a/apps/cookbook/src/app/examples/alert-example/alert-example.component.html
+++ b/apps/cookbook/src/app/examples/alert-example/alert-example.component.html
@@ -1,7 +1,7 @@
 <button kirby-button (click)="showAlert()">Show alert</button>
 <button kirby-button (click)="showAlertWithIcon()">Show alert with icon</button>
 <button kirby-button (click)="showAlertWithoutCancel()">Show alert without cancel</button>
-<button kirby-button (click)="showDestructiveAlert()" isDestructive="true">
+<button kirby-button (click)="showDestructiveAlert()" class="destructive">
   Show destructive alert
 </button>
 <button kirby-button (click)="showAlertWithNewline()">Show alert with newline</button>

--- a/apps/cookbook/src/app/showcase/button-showcase/button-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/button-showcase/button-showcase.component.ts
@@ -34,13 +34,6 @@ export class ButtonShowcaseComponent {
       type: ['1', '2', '3'],
     },
     {
-      name: 'isDestructive',
-      description:
-        'If isDestructive is set, color of the button will be changed according to attention level.',
-      defaultValue: 'false',
-      type: ['true', 'false'],
-    },
-    {
       name: 'isFloating',
       description:
         '(Optional) Determine if the button is going to be a Floating Action Button (FAB). Please note: FABs have an elevation of z8 by default. FABs have only an icon and no text. FABs always have a size of 64x64.',

--- a/libs/designsystem/src/lib/components/button/button.component.scss
+++ b/libs/designsystem/src/lib/components/button/button.component.scss
@@ -65,16 +65,14 @@ $button-width: (
 
   @include interaction-state.apply-hover;
   @include interaction-state.apply-active('s');
-
-  &.destructive {
-    --kirby-button-color: #{utils.get-color('danger')};
-  }
 }
 
 @mixin button-attentionlevel1 {
   --kirby-button-background-color: #{utils.get-color('primary')};
   --kirby-button-color: #{utils.get-color('primary-contrast')};
 
+  // The destructive class is only ever applied by kirby-alert.
+  // Standalone destructive buttons are not a supported concept.
   &.destructive {
     --kirby-button-background-color: #{utils.get-color('danger')};
     --kirby-button-color: #{utils.get-color('danger-contrast')};
@@ -87,11 +85,6 @@ $button-width: (
 
   @include interaction-state.apply-hover('l', $make-lighter: true);
   @include interaction-state.apply-active('xxxl', $make-lighter: true);
-
-  &.destructive {
-    --kirby-button-background-color: #{utils.get-color('light')};
-    --kirby-button-color: #{utils.get-color('danger')};
-  }
 }
 
 @mixin button-attentionlevel3 {
@@ -102,10 +95,6 @@ $button-width: (
 
   @include interaction-state.apply-hover('xxxs');
   @include interaction-state.apply-active('xxs');
-
-  &.destructive {
-    --kirby-button-color: #{utils.get-color('danger')};
-  }
 }
 
 :host {

--- a/libs/designsystem/src/lib/components/button/button.component.spec.ts
+++ b/libs/designsystem/src/lib/components/button/button.component.spec.ts
@@ -128,33 +128,6 @@ describe('ButtonComponent', () => {
           'border-color': 'transparent',
         });
       });
-
-      describe('and is destructive', () => {
-        beforeEach(() => {
-          spectator.component.isDestructive = true;
-          spectator.detectChanges();
-        });
-
-        it('should render with correct background-color', () => {
-          expect(element).toHaveComputedStyle({
-            'background-color': getColor('danger'),
-          });
-        });
-
-        it('should render with correct color', () => {
-          expect(element).toHaveComputedStyle({
-            color: getColor('danger', 'contrast'),
-          });
-        });
-
-        it('should render with transparent border', () => {
-          expect(element).toHaveComputedStyle({
-            'border-width': '1px',
-            'border-style': 'solid',
-            'border-color': 'transparent',
-          });
-        });
-      });
     });
 
     describe('when configured with attentionlevel 2', () => {
@@ -182,33 +155,6 @@ describe('ButtonComponent', () => {
           'border-color': 'transparent',
         });
       });
-
-      describe('and is destructive', () => {
-        beforeEach(() => {
-          spectator.component.isDestructive = true;
-          spectator.detectChanges();
-        });
-
-        it('should render with correct background-color', () => {
-          expect(element).toHaveComputedStyle({
-            'background-color': getColor('light'),
-          });
-        });
-
-        it('should render with correct color', () => {
-          expect(element).toHaveComputedStyle({
-            color: getColor('danger'),
-          });
-        });
-
-        it('should render with transparent border', () => {
-          expect(element).toHaveComputedStyle({
-            'border-width': '1px',
-            'border-style': 'solid',
-            'border-color': 'transparent',
-          });
-        });
-      });
     });
 
     describe('when configured with attentionlevel 3', () => {
@@ -232,29 +178,6 @@ describe('ButtonComponent', () => {
       it('should render with correct color', () => {
         expect(element).toHaveComputedStyle({
           color: getColor('black'),
-        });
-      });
-
-      describe('and is destructive', () => {
-        beforeEach(() => {
-          spectator.component.isDestructive = true;
-          spectator.detectChanges();
-        });
-
-        it('should render with correct background-color', () => {
-          expect(element).toHaveComputedStyle({ 'background-color': 'transparent' });
-        });
-
-        it('should render with correct border-color', () => {
-          expect(element).toHaveComputedStyle({
-            'border-color': getColor('medium'),
-          });
-        });
-
-        it('should render with correct color', () => {
-          expect(element).toHaveComputedStyle({
-            color: getColor('danger'),
-          });
         });
       });
 
@@ -297,29 +220,6 @@ describe('ButtonComponent', () => {
         });
       });
 
-      describe('and is destructive', () => {
-        beforeEach(() => {
-          spectator.component.isDestructive = true;
-          spectator.detectChanges();
-        });
-
-        it('should render with correct background-color', () => {
-          expect(element).toHaveComputedStyle({ 'background-color': 'transparent' });
-        });
-
-        it('should render with correct border-color', () => {
-          expect(element).toHaveComputedStyle({
-            'border-color': getColor('medium'),
-          });
-        });
-
-        it('should render with correct color', () => {
-          expect(element).toHaveComputedStyle({
-            color: getColor('danger'),
-          });
-        });
-      });
-
       describe('and is disabled', () => {
         beforeEach(() => {
           element.disabled = true;
@@ -356,29 +256,6 @@ describe('ButtonComponent', () => {
       it('should render with correct color', () => {
         expect(element).toHaveComputedStyle({
           color: getColor('black'),
-        });
-      });
-
-      describe('and is destructive', () => {
-        beforeEach(() => {
-          spectator.component.isDestructive = true;
-          spectator.detectChanges();
-        });
-
-        it('should render with no background-color', () => {
-          expect(element).toHaveComputedStyle({ 'background-color': 'transparent' });
-        });
-
-        it('should render with transparent border', () => {
-          expect(element).toHaveComputedStyle({
-            'border-width': '1px',
-            'border-style': 'solid',
-            'border-color': 'transparent',
-          });
-        });
-
-        it('should render with correct color', () => {
-          expect(element).toHaveComputedStyle({ color: getColor('danger') });
         });
       });
     });

--- a/libs/designsystem/src/lib/components/button/button.component.ts
+++ b/libs/designsystem/src/lib/components/button/button.component.ts
@@ -55,9 +55,6 @@ export class ButtonComponent implements AfterContentInit {
     this.isAttentionLevel3 = false;
   }
 
-  @HostBinding('class.destructive')
-  destructive: boolean = false; // Default
-
   @HostBinding('class.floating')
   public get isButtonFloating(): boolean {
     return this.isFloating;
@@ -81,10 +78,6 @@ export class ButtonComponent implements AfterContentInit {
   @HostBinding('class')
   get _cssClass() {
     return [this.themeColor, this.size].filter((cssClass) => !!cssClass);
-  }
-
-  @Input() set isDestructive(state: boolean) {
-    this.destructive = state;
   }
 
   @Input()

--- a/libs/designsystem/src/lib/components/modal/alert/alert.component.html
+++ b/libs/designsystem/src/lib/components/modal/alert/alert.component.html
@@ -20,7 +20,7 @@
       [size]="cancelBtn ? null : 'lg'"
       attentionLevel="1"
       class="ok-btn"
-      [isDestructive]="okBtnIsDestructive"
+      [class.destructive]="okBtnIsDestructive"
       (click)="onOk()"
     >
       {{ okBtn }}

--- a/libs/designsystem/testing-base/src/lib/components/mock.button.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.button.component.ts
@@ -17,7 +17,6 @@ import { ButtonComponent, ButtonSize, NotificationColor } from '@kirbydesign/des
 export class MockButtonComponent {
   @Input() attentionLevel: '1' | '2' | '3' | '4';
   @Input() noDecoration: boolean;
-  @Input() isDestructive: boolean;
   @Input() themeColor: NotificationColor;
   @Input() expand: 'full' | 'block';
   @Input() isFloating: boolean;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2737

## What is the new behavior?
Destructive buttons are now only enabled as a class that can be applied on the attention-level 1 button and is not explicitly exposed to consumers via an input. This is because the destructive button should only be used inside an alert, as per the UX spec.

Alert applies the class now instead of setting the input. 

This paves the way for a simpler theme concept, as `isDestructive` will not have to be handled for each attention level. 

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

The `isDesctructive` behavior of button should only be used internally by Kirby in the alert, as destructive actions are always announced via an alert. Use the default button attention levels and combine with alerts when needed.

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

