### PR TITLE
Only add API table scrollbar when content overflows

### DIFF
--- a/apps/cookbook/src/app/shared/api-description/api-description.shared.scss
+++ b/apps/cookbook/src/app/shared/api-description/api-description.shared.scss
@@ -4,7 +4,7 @@
 :host {
   display: block;
   width: 100%;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 table.api-description {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?
During a review I noticed that our API tables always have a horizontal scrollbar even if content is not scrollable. 
I suggest to make it only appear when content is scrollable, e.g. on mobile, so the scroll track disappears on larger screens.
 
<img width="770" alt="image" src="https://user-images.githubusercontent.com/42470636/211751715-b3f781c8-6ccd-40d0-a6e7-4d849bf19af5.png">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

