### PR TITLE
Fix issue where iphone overscrolls and hides popout in cookbook

### DIFF
--- a/apps/cookbook/src/app/iphone/iphone.component.html
+++ b/apps/cookbook/src/app/iphone/iphone.component.html
@@ -21,5 +21,5 @@
       <iframe loading="lazy" importance="low" [src]="trustedSrc" #iframe></iframe>
     </figure>
   </div>
-  <a *ngIf="showExternalLink" class="pop-out" [href]="trustedSrc"> Pop out </a>
+  <a *ngIf="showExternalLink" class="kirby-external-icon" [href]="trustedSrc"> Pop out </a>
 </div>

--- a/apps/cookbook/src/app/iphone/iphone.component.scss
+++ b/apps/cookbook/src/app/iphone/iphone.component.scss
@@ -5,18 +5,11 @@
   text-align: center;
 }
 
-.pop-out {
-  color: utils.get-text-color('semi-dark');
-  padding-left: 24px;
-  background: no-repeat url('/assets/kirby/icons/svg/link.svg');
-}
-
 .docs-demo-device {
   --device-aspect-ratio: 2.125;
   --device-padding: 2rem;
 
   padding: var(--device-padding);
-  position: sticky;
   top: 0;
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?
The iPhone has position: sticky which causes an annoying issue with unclickable pop out links.

https://user-images.githubusercontent.com/42470636/211847208-46849eef-9332-4f6f-ba15-232e5c3de081.mov

This is fixed, and we now also use our own kirbified pop out link styling class instead of a homebrew solution.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
