### PR TITLE
Kirby card support kirby item in card header and footer

### DIFF
--- a/apps/cookbook/src/app/examples/card-example/card-example.module.ts
+++ b/apps/cookbook/src/app/examples/card-example/card-example.module.ts
@@ -9,6 +9,7 @@ import { CardClickableExampleComponent } from './examples/card-clickable-example
 import { CardCssBackgroundImageExampleComponent } from './examples/card-css-background-image-example/card-css-background-image-example.component';
 import { CardElevationsExampleComponent } from './examples/card-elevations-example/card-elevations-example.component';
 import { CardThemecolorExampleComponent } from './examples/card-themecolor-example/card-themecolor-example.component';
+import { CardWithItemHeaderExampleComponent } from './examples/card-with-item-header-example/card-with-item-header-example.component';
 
 const COMPONENT_DECLARATIONS = [
   CardExampleComponent,
@@ -17,6 +18,7 @@ const COMPONENT_DECLARATIONS = [
   CardThemecolorExampleComponent,
   CardBackgroundImageExampleComponent,
   CardCssBackgroundImageExampleComponent,
+  CardWithItemHeaderExampleComponent,
 ];
 
 @NgModule({

--- a/apps/cookbook/src/app/examples/card-example/examples/card-with-item-header-example/card-with-item-header-example.component.html
+++ b/apps/cookbook/src/app/examples/card-example/examples/card-with-item-header-example/card-with-item-header-example.component.html
@@ -1,6 +1,6 @@
-<kirby-card hasPadding="true">
+<kirby-card hasPadding="true" (click)="function()">
   <kirby-card-header *ngIf="true" [title]="title" [subtitle]="subtitle" [hasPadding]="false"
-    ><kirby-item [disclosure]="'arrow-down'" selectable="true">
+    ><kirby-item [disclosure]="'arrow-down'">
       <h3 class="kirby-text-bold">Item disclosure in header</h3>
     </kirby-item></kirby-card-header
   >

--- a/apps/cookbook/src/app/examples/card-example/examples/card-with-item-header-example/card-with-item-header-example.component.html
+++ b/apps/cookbook/src/app/examples/card-example/examples/card-with-item-header-example/card-with-item-header-example.component.html
@@ -1,0 +1,25 @@
+<kirby-card hasPadding="true">
+  <kirby-card-header *ngIf="true" [title]="title" [subtitle]="subtitle" [hasPadding]="false"
+    ><kirby-item [disclosure]="'arrow-down'" selectable="true">
+      <h3 class="kirby-text-bold">Item disclosure in header</h3>
+    </kirby-item></kirby-card-header
+  >
+
+  <!-- Card content example: -->
+  <div class="card-content">
+    <h2><b>Example content (with custom css properties)</b></h2>
+    <p>
+      Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae
+      necessitatibus ab veniam repellendus doloremque culpa quam libero, est quo accusamus cumque,
+      in quia itaque cupiditate ratione repellat!
+    </p>
+  </div>
+  <p style="margin-bottom: 8px">
+    Lorem, ipsum dolor sit amet consectetur adipisicing elit.
+    <kirby-flag slot="end" themeColor="danger" style="float: right"> Danger </kirby-flag>
+  </p>
+  <p>
+    Lorem, ipsum dolor sit amet consectetur adipisicing elit.
+    <kirby-flag slot="end" themeColor="success" style="float: right"> Success </kirby-flag>
+  </p>
+</kirby-card>

--- a/apps/cookbook/src/app/examples/card-example/examples/card-with-item-header-example/card-with-item-header-example.component.ts
+++ b/apps/cookbook/src/app/examples/card-example/examples/card-with-item-header-example/card-with-item-header-example.component.ts
@@ -1,0 +1,43 @@
+import { Component } from '@angular/core';
+
+const config = {
+  template: `<kirby-card hasPadding="true">
+  <kirby-card-header *ngIf="true" [title]="title" [subtitle]="subtitle" [hasPadding]="false"
+    ><kirby-item [disclosure]="'arrow-down'" selectable="true">
+      <h3 class="kirby-text-bold">Item disclosure in header</h3>
+    </kirby-item></kirby-card-header>
+
+  <!-- Card content example: -->
+  <div class="card-content">
+    <h2><b>Example content (with custom css properties)</b></h2>
+    <p>
+      Lorem, ipsum dolor sit amet consectetur adipisicing elit. Mollitia facere molestias recusandae
+      necessitatibus ab veniam repellendus doloremque culpa quam libero, est quo accusamus cumque,
+      in quia itaque cupiditate ratione repellat!
+    </p>
+  </div>
+  <p style="margin-bottom: 8px">
+    Lorem, ipsum dolor sit amet consectetur adipisicing elit.
+    <kirby-flag slot="end" themeColor="danger" style="float: right"> Danger </kirby-flag>
+  </p>
+  <p>
+    Lorem, ipsum dolor sit amet consectetur adipisicing elit.
+    <kirby-flag slot="end" themeColor="success" style="float: right"> Success </kirby-flag>
+  </p>
+</kirby-card>
+`,
+  selector: 'cookbook-card-with-item-header-example',
+  style: `kirby-card {
+ --kirby-card-padding-top: 0px;   
+}
+`,
+};
+@Component({
+  selector: config.selector,
+  templateUrl: './card-with-item-header-example.component.html',
+  styles: [config.style],
+})
+export class CardWithItemHeaderExampleComponent {
+  style: string = config.style;
+  template: string = config.template;
+}

--- a/apps/cookbook/src/app/examples/card-example/examples/card-with-item-header-example/card-with-item-header-example.component.ts
+++ b/apps/cookbook/src/app/examples/card-example/examples/card-with-item-header-example/card-with-item-header-example.component.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
 
 const config = {
-  template: `<kirby-card hasPadding="true">
+  template: `<kirby-card hasPadding="true" (click)="function()">
   <kirby-card-header *ngIf="true" [title]="title" [subtitle]="subtitle" [hasPadding]="false"
-    ><kirby-item [disclosure]="'arrow-down'" selectable="true">
+    ><kirby-item [disclosure]="'arrow-down'">
       <h3 class="kirby-text-bold">Item disclosure in header</h3>
     </kirby-item></kirby-card-header>
 

--- a/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.html
@@ -125,17 +125,41 @@
     </cookbook-example-viewer>
   </p>
 
+  <h2>Card with item disclosure in card header</h2>
+  <p>
+    This example uses the <code>--kirby-card-padding-top</code> custom css property to set the
+    padding top in card content area to <code>0px</code>. Thereafter a item with disclosure is
+    placed in the card header. The Card header input property <code>hasPadding</code> is set to
+    <code>false</code> to adjust to the use of item.
+  </p>
+  <p>
+    <em>Note:</em> Card footer support the use item disclosure as well and it is recommended to use
+    the custom css property
+    <code>--kirby-card-padding-bottom</code>
+  </p>
+  <cookbook-example-viewer
+    [html]="CardHeaderDisclosureExample.template"
+    [css]="CardHeaderDisclosureExample.style"
+    ><cookbook-card-with-item-header-example
+      #CardHeaderDisclosureExample
+    ></cookbook-card-with-item-header-example
+  ></cookbook-example-viewer>
+
   <kirby-divider [hasMargin]="true"></kirby-divider>
 
   <h2>API Description</h2>
-  <h3>Properties:</h3>
+  <h3>Card properties:</h3>
   <cookbook-api-description-properties
     [properties]="properties"
   ></cookbook-api-description-properties>
-  <h3>CSS Custom Properties</h3>
+  <h3>Card CSS Custom Properties</h3>
   <cookbook-api-description-properties
     [properties]="customCssProperties"
     [columns]="customCssPropertiesColumns"
   >
   </cookbook-api-description-properties>
+  <h3>Card header and footer properties:</h3>
+  <cookbook-api-description-properties
+    [properties]="propertiesHeaderAndFooter"
+  ></cookbook-api-description-properties>
 </div>

--- a/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.html
@@ -128,8 +128,8 @@
   <h2>Card with item disclosure in card header</h2>
   <p>
     This example uses the <code>--kirby-card-padding-top</code> custom css property to set the
-    padding top in card content area to <code>0px</code>. Thereafter a item with disclosure is
-    placed in the card header. The Card header input property <code>hasPadding</code> is set to
+    padding top in card content area to <code>0px</code>. Thereafter an item with disclosure is
+    placed in the card header. The card header input property <code>hasPadding</code> is set to
     <code>false</code> to adjust to the use of item.
   </p>
   <p>

--- a/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.html
@@ -133,7 +133,7 @@
     <code>false</code> to adjust to the use of item.
   </p>
   <p>
-    <em>Note:</em> Card footer support the use item disclosure as well and it is recommended to use
+    <em>Note: </em> Card footer support the use of item disclosure as well and often is used with
     the custom css property
     <code>--kirby-card-padding-bottom</code>
   </p>

--- a/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.ts
@@ -69,6 +69,15 @@ export class CardShowcaseComponent {
     },
   ];
 
+  propertiesHeaderAndFooter: ApiDescriptionProperty[] = [
+    {
+      name: 'hasPadding',
+      description: 'Sets the inner padding for card header and card footer',
+      defaultValue: 'true',
+      type: ['boolean'],
+    },
+  ];
+
   customCssPropertiesColumns: ApiDescriptionPropertyColumns = {
     name: 'Attribute',
     description: 'Description',
@@ -94,6 +103,16 @@ export class CardShowcaseComponent {
       name: '--kirby-card-background-size',
       description: "Sets the 'background-size' property of the card",
       defaultValue: 'cover',
+    },
+    {
+      name: '--kirby-card-padding-top',
+      description: 'Sets padding-top property of the card',
+      defaultValue: 'small',
+    },
+    {
+      name: '--kirby-card-padding-bottom',
+      description: 'Sets padding-bottom property of the card',
+      defaultValue: 'small',
     },
   ];
 }

--- a/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.ts
@@ -107,12 +107,12 @@ export class CardShowcaseComponent {
     {
       name: '--kirby-card-padding-top',
       description: "Sets the 'padding-top' property of the card",
-      defaultValue: 'small',
+      defaultValue: "size('s')",
     },
     {
       name: '--kirby-card-padding-bottom',
       description: "Sets the 'padding-bottom' property of the card",
-      defaultValue: 'small',
+      defaultValue: "size('s')",
     },
   ];
 }

--- a/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.ts
@@ -106,12 +106,12 @@ export class CardShowcaseComponent {
     },
     {
       name: '--kirby-card-padding-top',
-      description: 'Sets padding-top property of the card',
+      description: "Sets the 'padding-top' property of the card",
       defaultValue: 'small',
     },
     {
       name: '--kirby-card-padding-bottom',
-      description: 'Sets padding-bottom property of the card',
+      description: "Sets the 'padding-bottom' property of the card",
       defaultValue: 'small',
     },
   ];

--- a/libs/designsystem/card/src/card-footer/card-footer.component.scss
+++ b/libs/designsystem/card/src/card-footer/card-footer.component.scss
@@ -3,6 +3,7 @@
 :host {
   display: block;
   padding: utils.size('s');
+  padding: 0;
   border-bottom-left-radius: inherit;
   border-bottom-right-radius: inherit;
   overflow: hidden;
@@ -11,6 +12,10 @@
   // on Safari see https://stackoverflow.com/a/16681137
   backface-visibility: hidden;
   transform: translate3d(0, 0, 0);
+
+  &.has-padding {
+    padding: utils.size('s');
+  }
 }
 
 footer {

--- a/libs/designsystem/card/src/card-footer/card-footer.component.ts
+++ b/libs/designsystem/card/src/card-footer/card-footer.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular/core';
 
 @Component({
   selector: 'kirby-card-footer',
@@ -6,4 +6,8 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   styleUrls: ['./card-footer.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class CardFooterComponent {}
+export class CardFooterComponent {
+  @HostBinding('class.has-padding')
+  @Input()
+  hasPadding: boolean = true;
+}

--- a/libs/designsystem/card/src/card-header/card-header.component.scss
+++ b/libs/designsystem/card/src/card-header/card-header.component.scss
@@ -6,9 +6,13 @@
   border-top-left-radius: utils.$border-radius;
   border-top-right-radius: utils.$border-radius;
   text-align: center;
-  padding: var(--kirby-internal-card-header-padding, utils.size('s'));
+  padding: 0;
   color: var(--kirby-card-header-color);
   background-color: var(--kirby-card-header-background-color);
+
+  &.has-padding {
+    padding: var(--kirby-internal-card-header-padding, utils.size('s'));
+  }
 }
 
 h2 {

--- a/libs/designsystem/card/src/card-header/card-header.component.ts
+++ b/libs/designsystem/card/src/card-header/card-header.component.ts
@@ -15,4 +15,7 @@ export class CardHeaderComponent {
   @HostBinding('class')
   @Input()
   flagged: CardFlagLevel = null;
+  @HostBinding('class.has-padding')
+  @Input()
+  hasPadding: boolean = true;
 }

--- a/libs/designsystem/card/src/card.component.scss
+++ b/libs/designsystem/card/src/card.component.scss
@@ -31,7 +31,9 @@
 
   .content-wrapper {
     &.padding {
-      padding: utils.size('s');
+      padding-top: var(--kirby-card-padding-top, utils.size('s'));
+      padding-bottom: var(--kirby-card-padding-bottom, utils.size('s'));
+      padding-inline: utils.size('s');
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2683 

## What is the new behavior?

Card is now able to support the use of item disclosure in card header and card footer. Card now has two new custom CSS properties to set padding top and padding bottom. Card header and footer has a new input binding "hasPadding" to toggle padding on and off. Cookbook is updated with a showcase of item disclosure in card header. API properties is updated with the new features.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

