### PR TITLE
Add secondary modules exports

### DIFF
--- a/libs/designsystem/src/lib/index.ts
+++ b/libs/designsystem/src/lib/index.ts
@@ -1,16 +1,21 @@
 export * from './animation/kirby-animation';
 export * from './components';
 export * from './directives';
+
 export * from '@kirbydesign/designsystem/card';
-export * from '@kirbydesign/designsystem/icon';
 export * from '@kirbydesign/designsystem/flag';
 export * from '@kirbydesign/designsystem/helpers';
-export * from '@kirbydesign/designsystem/types';
-export * from '@kirbydesign/designsystem/shared';
+export * from '@kirbydesign/designsystem/icon';
+export * from '@kirbydesign/designsystem/item';
 export * from '@kirbydesign/designsystem/kirby-ionic-module';
+export * from '@kirbydesign/designsystem/section-header';
+export * from '@kirbydesign/designsystem/shared';
+export * from '@kirbydesign/designsystem/slide';
 export * from '@kirbydesign/designsystem/spinner';
-export * from '@kirbydesign/designsystem/toggle';
 export * from '@kirbydesign/designsystem/tabs';
+export * from '@kirbydesign/designsystem/toggle';
+export * from '@kirbydesign/designsystem/toggle-button';
+export * from '@kirbydesign/designsystem/types';
 
 export * from './scss/scss-helper';
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2768 
## What is the new behavior?
All secondary entries now export through the primary entry

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?
No
<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [-] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [-] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [-] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [-] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

