### PR TITLE
Now sets URL for example component immediately on page showcase initialization 

### DIFF
--- a/apps/cookbook/src/app/showcase/showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/showcase.component.ts
@@ -19,6 +19,7 @@ export class ShowcaseComponent implements OnDestroy {
   showCallToActionLinks = true;
 
   constructor(private router: Router, private elementRef: ElementRef<HTMLElement>) {
+    this.setExampleComponentFromUrl(this.router.url);
     this.onNavigationEnd();
   }
 
@@ -34,13 +35,11 @@ export class ShowcaseComponent implements OnDestroy {
   private onNavigationEnd() {
     this.routerEventsSubscription = this.router.events
       .pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd))
-      .subscribe((event) =>
-        setTimeout(() => this.setExampleComponentFromUrl(event.urlAfterRedirects))
-      );
+      .subscribe((event) => setTimeout(() => this.setExampleComponentFromUrl(this.router.url)));
   }
 
   private setExampleComponentFromUrl(url: string) {
-    let exampleComponentUrlSegment = this.getExampleComponentUrlSegment(url);
+    const exampleComponentUrlSegment = this.getExampleComponentUrlSegment(url);
     this.exampleComponentPopOutUrl = ['/', 'examples', exampleComponentUrlSegment];
     this.exampleComponentGitUrl = this.gitUrl + exampleComponentUrlSegment + '-example';
     this.exampleComponentName = this.replaceHyphens(exampleComponentUrlSegment);


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2730 

## What is the new behavior?

When opening a link in a new tab from the sidemenu in cookbook or refreshing the site. Pop out link and title for component on showcase is not set or working correctly. New behaviour now correctly sets URL for example component on initialisation, since the observable being subscribed to, does not emit an initial value. Title for component and pop out link is now working on refresh site and opening link in a new tab.

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

