### PR TITLE
Remove hasDarkBackgroundColor input from card

### DIFF
--- a/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.html
@@ -71,11 +71,10 @@
 </p>
 
 <p>
-  <em>Note:</em> this example uses
-  <a target="_blank" href="https://www.npmjs.com/package/include-media">include-media</a> for media
-  queries. This is re-exported from the <code>@kirbydesign/designsystem/scss/utils</code> Sass
-  module.
+  In this example, themeColor is explicitly set to dark to tell the card that the image content is
+  dark. This ensures that the hover and pressed state make the card lighter instead of darker.
 </p>
+
 <cookbook-example-viewer
   [html]="backgroundImageExample.template"
   [css]="backgroundImageExample.style"
@@ -84,6 +83,13 @@
     #backgroundImageExample
   ></cookbook-card-example-background-image>
 </cookbook-example-viewer>
+
+<p>
+  <em>Note:</em> this example uses
+  <a target="_blank" href="https://www.npmjs.com/package/include-media">include-media</a> for media
+  queries. This is re-exported from the <code>@kirbydesign/designsystem/scss/utils</code> Sass
+  module.
+</p>
 
 <h2>Flat</h2>
 <p>

--- a/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/card-showcase/card-showcase.component.ts
@@ -59,13 +59,6 @@ export class CardShowcaseComponent {
         'dark',
       ],
     },
-    {
-      name: 'hasDarkBackgroundColor',
-      description:
-        'Use this to make the hover and active interaction states be lighter instead of darker (which is the default)',
-      defaultValue: 'false',
-      type: ['boolean'],
-    },
   ];
 
   propertiesHeaderAndFooter: ApiDescriptionProperty[] = [

--- a/libs/designsystem/card/src/card.component.scss
+++ b/libs/designsystem/card/src/card.component.scss
@@ -63,11 +63,6 @@
     @include interaction-state.apply-active('xxs');
     @include interaction-state.apply-focus-visible($shadow: utils.get-elevation(2));
 
-    &.interaction-state-make-lighter-and-louder {
-      @include interaction-state.apply-hover('xxs', $make-lighter: true);
-      @include interaction-state.apply-active('s', $make-lighter: true);
-    }
-
     outline: none;
   }
 }

--- a/libs/designsystem/card/src/card.component.ts
+++ b/libs/designsystem/card/src/card.component.ts
@@ -49,10 +49,6 @@ export class CardComponent implements OnInit, OnDestroy {
   @Input()
   flat: boolean = false;
 
-  @HostBinding('class.interaction-state-make-lighter-and-louder')
-  @Input()
-  hasDarkBackgroundColor: boolean;
-
   constructor(
     private elementRef: ElementRef,
     private resizeObserverService: ResizeObserverService,

--- a/libs/designsystem/testing-base/src/lib/components/mock.card.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.card.component.ts
@@ -20,7 +20,6 @@ export class MockCardComponent {
   @Input() hasPadding: boolean;
   @Input() sizes: { [size: string]: number };
   @Input() mode: 'flat' | 'highlighted';
-  @Input() hasDarkBackgroundColor: boolean;
 }
 
 // #endregion


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2797 

## What is the new behavior?
In short: The `hasDarkBackgroundColor` input is made obsolete by the themeColor input. Setting themeColor to 'dark' will ensure similar functionality.  
See the issue ☝️ for more context.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

The `hasDarkBackgroundColor` input is made obsolete by the themeColor input. Setting themeColor to 'dark' will ensure similar functionality.  


## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- ~~[ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- ~~[ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be merged to `develop` by Team Kirby.

