### PR TITLE
Fix missing scss module namespace to color docs

### DIFF
--- a/apps/cookbook/src/app/showcase/colors-showcase/colors-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/colors-showcase/colors-showcase.component.html
@@ -12,15 +12,17 @@
       <div class="{{ selectedColor }}-shade">Shade</div>
     </div>
     <pre class="language-css">
+@use '@kirbydesign/designsystem/scss/utils';
+
 .color-sample-example {{ '{' }}
-  background-color: get-color('{{ selectedColor }}');
-  color: get-color('{{ selectedOnColor }}');
+  background-color: utils.get-color('{{ selectedColor }}');
+  color: utils.get-color('{{ selectedOnColor }}');
 {{ '}' }}
 .color-sample-tint {{ '{' }}
-  background-color: get-color('{{ selectedColor }}-tint');
+  background-color: utils.get-color('{{ selectedColor }}-tint');
 {{ '}' }}
 .color-sample-shade {{ '{' }}
-  background-color: get-color('{{ selectedColor }}-shade');
+  background-color: utils.get-color('{{ selectedColor }}-shade');
 {{ '}' }}</pre
     >
   </div>


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2800

## What is the new behavior?

Docs showcase use of get-color scss function correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

