### PR TITLE
Fix rare title intersection observer bug

### DIFF
--- a/libs/designsystem/src/lib/components/page/page.component.ts
+++ b/libs/designsystem/src/lib/components/page/page.component.ts
@@ -287,7 +287,6 @@ export class PageComponent
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    console.log('changes', changes);
     if (changes.titleMaxLines) {
       this.fitHeadingConfig = {
         ...this.fitHeadingConfig,

--- a/libs/designsystem/src/lib/components/page/page.component.ts
+++ b/libs/designsystem/src/lib/components/page/page.component.ts
@@ -287,6 +287,7 @@ export class PageComponent
   }
 
   ngOnChanges(changes: SimpleChanges): void {
+    console.log('changes', changes);
     if (changes.titleMaxLines) {
       this.fitHeadingConfig = {
         ...this.fitHeadingConfig,
@@ -424,13 +425,12 @@ export class PageComponent
   }
 
   private initializeTitle() {
-    // Ensures initializeTitle() won't run, if already initialized
-    if (this.hasPageTitle) return;
     this.hasPageTitle = this.title !== undefined || !!this.customTitleTemplate;
     this.toolbarTitleVisible = !this.hasPageTitle;
     this.hasPageSubtitle = this.subtitle !== undefined || !!this.customSubtitleTemplate;
 
     if (this.hasPageTitle) {
+      this.pageTitleIntersectionObserverRef.disconnect();
       setTimeout(() => {
         this.pageTitleIntersectionObserverRef.observe(this.pageTitle.nativeElement);
       });


### PR DESCRIPTION
## What is the new behavior?

There is a initializeTitle() function in Kirby-page which used to only run when the component enter or leave. However, in rare cases the reference to the title change without unmount the page component. In this case, the new title element won't be observed and there title will no be hidden and shown according to the scroll position.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

I made sure to test if running the initializeTitle() more often would cause performance issues. However, I found that assigning the same value to an existing angular propter won't cause and re-renders.

The issues couldn't be reproduced in the flows app. However, we could reproduce it in "relationsbanken". The bug was reported in kirby-guild(https://bankdata.slack.com/archives/CGKJ1RBM4/p1674640659682029)

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [ ] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] ~~Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be merged to `develop` by Team Kirby.

