### PR TITLE
Add theming for segmented control and form field

### DIFF
--- a/apps/cookbook/src/app/examples/form-field-example/examples/input/color.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/examples/input/color.ts
@@ -1,0 +1,32 @@
+import { Component } from '@angular/core';
+
+const config = {
+  selector: 'cookbook-form-field-input-color-example',
+  template: `<kirby-card hasPadding="true" [themeColor]="color">
+    <kirby-form-field>
+    <input kirby-input placeholder="Default input with placeholder text" />
+  </kirby-form-field>
+</kirby-card>
+
+<div class="card-option-button-group">
+    <button (click)="setThemeColor('light')" class="light"></button>
+    <button (click)="setThemeColor('white')" class="white"></button>
+    <button (click)="setThemeColor('secondary')" class="secondary"></button>
+    <button (click)="setThemeColor('dark')" class="dark"></button>
+</div>
+`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+  styleUrls: ['../../form-field-example.component.scss'],
+})
+export class FormFieldInputColorExampleComponent {
+  template: string = config.template;
+  color: string = 'white';
+
+  setThemeColor(color: string) {
+    this.color = color;
+  }
+}

--- a/apps/cookbook/src/app/examples/form-field-example/examples/input/color.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/examples/input/color.ts
@@ -7,7 +7,6 @@ const config = {
     <input kirby-input placeholder="Default input with placeholder text inside card" />
   </kirby-form-field>
 </kirby-card>
-
 <div class="card-option-button-group">
     <button (click)="setThemeColor('white')" class="white"></button>
     <button (click)="setThemeColor('light')" class="light"></button>
@@ -23,7 +22,9 @@ const config = {
   styleUrls: ['../../form-field-example.component.scss'],
 })
 export class FormFieldInputColorExampleComponent {
-  template: string = config.template;
+  get template(): string {
+    return config.template.split('<div class="card-option-button-group">')[0]; // Remove config part of the template
+  }
   color: string = 'white';
 
   setThemeColor(color: string) {

--- a/apps/cookbook/src/app/examples/form-field-example/examples/input/color.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/examples/input/color.ts
@@ -4,13 +4,13 @@ const config = {
   selector: 'cookbook-form-field-input-color-example',
   template: `<kirby-card hasPadding="true" [themeColor]="color">
     <kirby-form-field>
-    <input kirby-input placeholder="Default input with placeholder text" />
+    <input kirby-input placeholder="Default input with placeholder text inside card" />
   </kirby-form-field>
 </kirby-card>
 
 <div class="card-option-button-group">
-    <button (click)="setThemeColor('light')" class="light"></button>
     <button (click)="setThemeColor('white')" class="white"></button>
+    <button (click)="setThemeColor('light')" class="light"></button>
     <button (click)="setThemeColor('secondary')" class="secondary"></button>
     <button (click)="setThemeColor('dark')" class="dark"></button>
 </div>

--- a/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.html
+++ b/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.html
@@ -5,6 +5,7 @@
     ></cookbook-form-field-example-configuration>
     <h2>Input</h2>
     <cookbook-form-field-input-example [size]="size"></cookbook-form-field-input-example>
+    <cookbook-form-field-input-color-example></cookbook-form-field-input-color-example>
     <cookbook-form-field-input-label-example
       [size]="size"
     ></cookbook-form-field-input-label-example>

--- a/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.scss
+++ b/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.scss
@@ -7,3 +7,62 @@ kirby-page-content > * {
 kirby-page-content > * + * {
   margin-top: utils.size('m');
 }
+
+kirby-card {
+  min-width: 500px;
+}
+
+.card-option-button-group {
+  display: flex;
+  justify-content: center;
+  gap: utils.size('xxs');
+  padding: utils.size('xxs');
+}
+
+button {
+  height: utils.$fat-finger-size;
+  width: utils.$fat-finger-size;
+  border: none;
+  border-radius: 999px;
+  margin: 0;
+  color: #fff;
+  cursor: pointer;
+
+  &.white {
+    background-color: utils.get-color('white');
+
+    &:hover {
+      background-color: var(--kirby-white-shade);
+    }
+  }
+
+  &.light {
+    background-color: utils.get-color('light');
+    outline: #fff 2px solid;
+    border: #fff 2px solid;
+
+    &:hover {
+      background-color: var(--kirby-light-shade);
+    }
+  }
+
+  &.dark {
+    background-color: utils.get-color('dark');
+
+    &:hover {
+      background-color: var(--kirby-dark-shade);
+    }
+  }
+
+  &.secondary {
+    background-color: utils.get-color('secondary');
+
+    &:hover {
+      background-color: var(--kirby-secondary-shade);
+    }
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+}

--- a/apps/cookbook/src/app/examples/form-field-example/form-field-example.module.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/form-field-example.module.ts
@@ -5,6 +5,7 @@ import { KirbyModule } from '@kirbydesign/designsystem';
 
 import { FormFieldInputAffixExampleComponent } from './examples/input/affix';
 import { FormFieldInputBorderlessExampleComponent } from './examples/input/borderless';
+import { FormFieldInputColorExampleComponent } from './examples/input/color';
 import { FormFieldInputCounterExampleComponent } from './examples/input/counter';
 import { FormFieldInputDateExampleComponent } from './examples/input/date';
 import { FormFieldInputDecimalMaskExampleComponent } from './examples/input/decimal-mask';
@@ -33,6 +34,7 @@ const COMPONENT_DECLARATIONS = [
   FormFieldInputAffixExampleComponent,
   FormFieldInputErrorExampleComponent,
   FormFieldInputBorderlessExampleComponent,
+  FormFieldInputColorExampleComponent,
   FormFieldFocusExampleComponent,
   FormFieldTextareaDefaultExampleComponent,
   FormFieldTextareaLabelExampleComponent,

--- a/apps/cookbook/src/app/examples/segmented-control-example/color/color.scss
+++ b/apps/cookbook/src/app/examples/segmented-control-example/color/color.scss
@@ -1,6 +1,10 @@
 @use '@kirbydesign/core/src/scss/utils';
 
-kirby-card {
+:host {
+  display: block;
+}
+
+irby-card {
   margin-bottom: utils.size('s');
 }
 
@@ -13,10 +17,6 @@ kirby-card {
 
 fieldset {
   display: inline-block;
-
-  .disabled {
-    color: utils.get-text-color('semi-dark');
-  }
 }
 
 button {

--- a/apps/cookbook/src/app/examples/segmented-control-example/color/color.scss
+++ b/apps/cookbook/src/app/examples/segmented-control-example/color/color.scss
@@ -1,0 +1,68 @@
+@use '@kirbydesign/core/src/scss/utils';
+
+kirby-card {
+  margin-bottom: utils.size('s');
+}
+
+.card-option-button-group {
+  display: flex;
+  justify-content: center;
+  gap: utils.size('xxs');
+  padding: utils.size('xxs');
+}
+
+fieldset {
+  display: inline-block;
+
+  .disabled {
+    color: utils.get-text-color('semi-dark');
+  }
+}
+
+button {
+  height: utils.$fat-finger-size;
+  width: utils.$fat-finger-size;
+  border: none;
+  border-radius: 999px;
+  margin: 0;
+  color: #fff;
+  cursor: pointer;
+
+  &.white {
+    background-color: utils.get-color('white');
+
+    &:hover {
+      background-color: var(--kirby-white-shade);
+    }
+  }
+
+  &.light {
+    background-color: utils.get-color('light');
+    outline: #fff 2px solid;
+    border: #fff 2px solid;
+
+    &:hover {
+      background-color: var(--kirby-light-shade);
+    }
+  }
+
+  &.secondary {
+    background-color: utils.get-color('secondary');
+
+    &:hover {
+      background-color: var(--kirby-secondary-shade);
+    }
+  }
+
+  &.dark {
+    background-color: utils.get-color('dark');
+
+    &:hover {
+      background-color: var(--kirby-dark-shade);
+    }
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+}

--- a/apps/cookbook/src/app/examples/segmented-control-example/color/color.ts
+++ b/apps/cookbook/src/app/examples/segmented-control-example/color/color.ts
@@ -3,8 +3,7 @@ import { Component, OnInit } from '@angular/core';
 import { SegmentedControlMode, SegmentItem } from '@kirbydesign/designsystem';
 
 const config = {
-  template: `
-<kirby-card hasPadding="true" [themeColor]="color">  
+  template: `<kirby-card hasPadding="true" [themeColor]="color">  
   <kirby-segmented-control
   [items]="items"
   [value]="selectedSegment"
@@ -12,7 +11,6 @@ const config = {
   (segmentSelect)="onSegmentSelect($event)"
 ></kirby-segmented-control>
 </kirby-card>
-
 <div class="card-option-button-group">
     <button (click)="setThemeColor('white')" class="white"></button>
     <button (click)="setThemeColor('light')" class="light"></button>
@@ -55,8 +53,7 @@ const config = {
       Compact Chip
     </label>
   </p>
-</fieldset>
-`,
+</fieldset>`,
   codeSnippet: `onSegmentSelect(segment: SegmentItem) {
   this.selectedSegment = segment;
 }`,
@@ -69,7 +66,7 @@ const config = {
 export class SegmentedControlExampleColorComponent implements OnInit {
   get template(): string {
     return config.template
-      .split('<fieldset>')[0] // Remove config part of the template
+      .split('<div class="card-option-button-group">')[0] // Remove config part of the template
       .replace('[mode]="mode"', `mode="${this.mode}"`);
   }
   codeSnippet = config.codeSnippet;

--- a/apps/cookbook/src/app/examples/segmented-control-example/color/color.ts
+++ b/apps/cookbook/src/app/examples/segmented-control-example/color/color.ts
@@ -54,9 +54,6 @@ const config = {
     </label>
   </p>
 </fieldset>`,
-  codeSnippet: `onSegmentSelect(segment: SegmentItem) {
-  this.selectedSegment = segment;
-}`,
 };
 @Component({
   selector: 'cookbook-segmented-control-example-color',
@@ -69,7 +66,6 @@ export class SegmentedControlExampleColorComponent implements OnInit {
       .split('<div class="card-option-button-group">')[0] // Remove config part of the template
       .replace('[mode]="mode"', `mode="${this.mode}"`);
   }
-  codeSnippet = config.codeSnippet;
 
   mode: SegmentedControlMode = SegmentedControlMode.default;
 
@@ -106,11 +102,6 @@ export class SegmentedControlExampleColorComponent implements OnInit {
 
   ngOnInit() {
     this.selectedSegment = this.items[0];
-  }
-
-  onSegmentSelect(segment: SegmentItem) {
-    console.log('selectedSegment', segment);
-    this.selectedSegment = segment;
   }
 
   setMode(mode: SegmentedControlMode) {

--- a/apps/cookbook/src/app/examples/segmented-control-example/color/color.ts
+++ b/apps/cookbook/src/app/examples/segmented-control-example/color/color.ts
@@ -1,0 +1,127 @@
+import { Component, OnInit } from '@angular/core';
+
+import { SegmentedControlMode, SegmentItem } from '@kirbydesign/designsystem';
+
+const config = {
+  template: `
+<kirby-card hasPadding="true" [themeColor]="color">  
+  <kirby-segmented-control
+  [items]="items"
+  [value]="selectedSegment"
+  [mode]="mode"
+  (segmentSelect)="onSegmentSelect($event)"
+></kirby-segmented-control>
+</kirby-card>
+
+<div class="card-option-button-group">
+    <button (click)="setThemeColor('light')" class="light"></button>
+    <button (click)="setThemeColor('white')" class="white"></button>
+    <button (click)="setThemeColor('secondary')" class="secondary"></button>
+    <button (click)="setThemeColor('dark')" class="dark"></button>
+</div>
+
+<fieldset>
+  <legend>Configuration</legend>
+  <p>
+    <strong>Mode:</strong><br/>
+    <label>
+      <input
+        type="radio"
+        name="mode"
+        value="default"
+        [checked]="mode === 'default'"
+        (change)="setMode($event.target.value)"
+      />
+      Default
+    </label>
+    <label>
+      <input
+        type="radio"
+        name="mode"
+        value="chip"
+        [checked]="mode === 'chip'"
+        (change)="setMode($event.target.value)"
+      />
+      Chip
+    </label>
+    <label> 
+      <input
+        type="radio"
+        name="mode"
+        value="compactChip"
+        [checked]="mode === 'compactChip'"
+        (change)="setMode($event.target.value)"
+      />
+      Compact Chip
+    </label>
+  </p>
+</fieldset>
+`,
+  codeSnippet: `onSegmentSelect(segment: SegmentItem) {
+  this.selectedSegment = segment;
+}`,
+};
+@Component({
+  selector: 'cookbook-segmented-control-example-color',
+  template: config.template,
+  styleUrls: ['./color.scss'],
+})
+export class SegmentedControlExampleColorComponent implements OnInit {
+  get template(): string {
+    return config.template
+      .split('<fieldset>')[0] // Remove config part of the template
+      .replace('[mode]="mode"', `mode="${this.mode}"`);
+  }
+  codeSnippet = config.codeSnippet;
+
+  mode: SegmentedControlMode = SegmentedControlMode.default;
+
+  color: string = 'white';
+
+  selectedSegment: SegmentItem;
+
+  private defaultItems: SegmentItem[] = [
+    {
+      text: 'Item 1',
+      id: '1',
+    },
+    {
+      text: 'Item 2',
+      id: '2',
+    },
+  ];
+
+  private chipItems = [...'123456'].map((i) => ({ text: `Chip-${i}`, id: i }));
+
+  // Showcase compact chips with less chararcters but more chips
+  private compactChipItems = [...'12345678'].map((i) => ({ text: `c${i}`, id: i }));
+
+  get items(): SegmentItem[] {
+    switch (this.mode) {
+      case SegmentedControlMode.default:
+        return this.defaultItems;
+      case SegmentedControlMode.chip:
+        return this.chipItems;
+      case SegmentedControlMode.compactChip:
+        return this.compactChipItems;
+    }
+  }
+
+  ngOnInit() {
+    this.selectedSegment = this.items[0];
+  }
+
+  onSegmentSelect(segment: SegmentItem) {
+    console.log('selectedSegment', segment);
+    this.selectedSegment = segment;
+  }
+
+  setMode(mode: SegmentedControlMode) {
+    this.mode = mode;
+    this.selectedSegment = this.items[0];
+  }
+
+  setThemeColor(color: string) {
+    this.color = color;
+  }
+}

--- a/apps/cookbook/src/app/examples/segmented-control-example/color/color.ts
+++ b/apps/cookbook/src/app/examples/segmented-control-example/color/color.ts
@@ -14,8 +14,8 @@ const config = {
 </kirby-card>
 
 <div class="card-option-button-group">
-    <button (click)="setThemeColor('light')" class="light"></button>
     <button (click)="setThemeColor('white')" class="white"></button>
+    <button (click)="setThemeColor('light')" class="light"></button>
     <button (click)="setThemeColor('secondary')" class="secondary"></button>
     <button (click)="setThemeColor('dark')" class="dark"></button>
 </div>
@@ -82,11 +82,11 @@ export class SegmentedControlExampleColorComponent implements OnInit {
 
   private defaultItems: SegmentItem[] = [
     {
-      text: 'Item 1',
+      text: 'First Item',
       id: '1',
     },
     {
-      text: 'Item 2',
+      text: 'Second Item',
       id: '2',
     },
   ];

--- a/apps/cookbook/src/app/examples/segmented-control-example/color/color.ts
+++ b/apps/cookbook/src/app/examples/segmented-control-example/color/color.ts
@@ -8,7 +8,6 @@ const config = {
   [items]="items"
   [value]="selectedSegment"
   [mode]="mode"
-  (segmentSelect)="onSegmentSelect($event)"
 ></kirby-segmented-control>
 </kirby-card>
 <div class="card-option-button-group">

--- a/apps/cookbook/src/app/examples/segmented-control-example/segmented-control-example.component.html
+++ b/apps/cookbook/src/app/examples/segmented-control-example/segmented-control-example.component.html
@@ -12,3 +12,8 @@
 <cookbook-segmented-control-example-with-badge
   class="example"
 ></cookbook-segmented-control-example-with-badge>
+
+<h3>Segmented Control on different theme colors</h3>
+<cookbook-segmented-control-example-color
+  class="example"
+></cookbook-segmented-control-example-color>

--- a/apps/cookbook/src/app/examples/segmented-control-example/segmented-control-example.module.ts
+++ b/apps/cookbook/src/app/examples/segmented-control-example/segmented-control-example.module.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { KirbyModule } from '@kirbydesign/designsystem';
+import { SegmentedControlExampleColorComponent } from './color/color';
 
 import { SegmentedControlExampleDefaultComponent } from './default/default';
 import { SegmentedControlExampleGroupedComponent } from './grouped/grouped';
@@ -11,6 +12,7 @@ const COMPONENT_DECLARATIONS = [
   SegmentedControlExampleDefaultComponent,
   SegmentedControlExampleGroupedComponent,
   SegmentedControlExampleWithBadgeComponent,
+  SegmentedControlExampleColorComponent,
 ];
 
 @NgModule({

--- a/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
@@ -10,6 +10,13 @@
   ></cookbook-form-field-input-example>
 </cookbook-example-viewer>
 
+<h3>Color</h3>
+<cookbook-example-viewer [html]="inputColorExample.template">
+  <cookbook-form-field-input-color-example
+    #inputColorExample
+  ></cookbook-form-field-input-color-example>
+</cookbook-example-viewer>
+
 <h3>Label</h3>
 <cookbook-example-viewer [html]="inputLabelExample.template">
   <cookbook-form-field-input-label-example

--- a/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
@@ -43,6 +43,9 @@
     ></cookbook-segmented-control-example-with-badge>
   </cookbook-example-viewer>
 
+  <h3>Color</h3>
+  <cookbook-segmented-control-example-color></cookbook-segmented-control-example-color>
+
   <h2>Properties:</h2>
   <cookbook-api-description-properties
     [properties]="properties"

--- a/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
@@ -44,7 +44,11 @@
   </cookbook-example-viewer>
 
   <h3>Color</h3>
-  <cookbook-segmented-control-example-color></cookbook-segmented-control-example-color>
+  <cookbook-example-viewer [html]="colorExample.template" [ts]="colorExample.codeSnippet">
+    <cookbook-segmented-control-example-color
+      #colorExample
+    ></cookbook-segmented-control-example-color>
+  </cookbook-example-viewer>
 
   <h2>Properties:</h2>
   <cookbook-api-description-properties

--- a/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
@@ -44,7 +44,7 @@
   </cookbook-example-viewer>
 
   <h3>Color</h3>
-  <cookbook-example-viewer [html]="colorExample.template" [ts]="colorExample.codeSnippet">
+  <cookbook-example-viewer [html]="colorExample.template">
     <cookbook-segmented-control-example-color
       #colorExample
     ></cookbook-segmented-control-example-color>

--- a/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.ts
@@ -60,4 +60,15 @@ export class SegmentedControlShowcaseComponent {
       type: ['boolean'],
     },
   ];
+
+  items = [
+    {
+      text: 'Item 1',
+      id: '1',
+    },
+    {
+      text: 'Item 2',
+      id: '2',
+    },
+  ];
 }

--- a/libs/core/src/scss/_global-styles.scss
+++ b/libs/core/src/scss/_global-styles.scss
@@ -8,9 +8,12 @@
 @use 'base/html-list';
 
 @use 'components/grid';
+@use 'themes/component-themes';
 
 :root,
 :host {
+  @include component-themes.apply-light-theme;
+
   --kirby-font-family: 'Roboto';
 
   font-family: var(--kirby-font-family);

--- a/libs/core/src/scss/themes/_component-themes.scss
+++ b/libs/core/src/scss/themes/_component-themes.scss
@@ -3,34 +3,36 @@
 @use '../interaction-state';
 
 @mixin apply-dark-theme {
-  --kirby-interactable-background-color: var(--kirby-white-overlay);
-  --kirby-interactable-background-color-hover: var(--kirby-white-overlay-20);
-  --kirby-interactable-background-color-active: var(--kirby-white-overlay-30);
-  --kirby-interactable-color: var(--kirby-white);
-  --kirby-interactable-indicator-background-color: var(--kirby-white);
-  --kirby-interactable-indicator-color: var(--kirby-black);
-  --kirby-interactable-placeholder-color: var(--kirby-white-overlay-50);
+  --kirby-inputs-background-color: var(--kirby-white-overlay);
+  --kirby-inputs-background-color-hover: var(--kirby-white-overlay-20);
+  --kirby-inputs-background-color-active: var(--kirby-white-overlay-30);
+  --kirby-inputs-color: var(--kirby-white);
+  --kirby-inputs-indicator-background-color: var(--kirby-white);
+  --kirby-inputs-indicator-color: var(--kirby-black);
+  --kirby-inputs-placeholder-color: var(--kirby-white-overlay-50);
 }
 
 @mixin apply-white-theme {
-  --kirby-interactable-background-color: var(--kirby-dark-overlay);
-  --kirby-interactable-background-color-hover: var(--kirby-dark-overlay-10);
-  --kirby-interactable-background-color-active: var(--kirby-dark-overlay-20);
-  --kirby-interactable-color: var(--kirby-black);
-  --kirby-interactable-indicator-background-color: var(--kirby-black);
-  --kirby-interactable-indicator-color: var(--kirby-white);
-  --kirby-interactable-placeholder-color: var(--kirby-semi-dark);
+  --kirby-inputs-background-color: var(--kirby-dark-overlay);
+  --kirby-inputs-background-color-hover: var(--kirby-dark-overlay-10);
+  --kirby-inputs-background-color-active: var(--kirby-dark-overlay-20);
+  --kirby-inputs-color: var(--kirby-black);
+  --kirby-inputs-indicator-background-color: var(--kirby-black);
+  --kirby-inputs-indicator-color: var(--kirby-white);
+  --kirby-inputs-placeholder-color: var(--kirby-semi-dark);
 }
 
 @mixin apply-light-theme {
-  --kirby-interactable-background-color: var(--kirby-white);
-  --kirby-interactable-background-color-hover: var(--kirby-dark-overlay-10);
-  --kirby-interactable-background-color-active: var(--kirby-dark-overlay-20);
-  --kirby-interactable-color: var(--kirby-black);
-  --kirby-interactable-indicator-background-color: var(--kirby-black);
-  --kirby-interactable-indicator-color: var(--kirby-white);
-  --kirby-interactable-placeholder-color: var(--kirby-semi-dark);
-  --kirby-interactive-elevation: #{utils.get-elevation(2)};
+  --kirby-inputs-background-color: var(--kirby-white);
+  --kirby-inputs-background-color-hover: var(--kirby-dark-overlay-10);
+  --kirby-inputs-background-color-active: var(--kirby-dark-overlay-20);
+  --kirby-inputs-color: var(--kirby-black);
+  --kirby-inputs-indicator-background-color: var(--kirby-black);
+  --kirby-inputs-indicator-color: var(--kirby-white);
+  --kirby-inputs-placeholder-color: var(--kirby-semi-dark);
+
+  // Only set elevation on input components for light theme
+  --kirby-inputs-elevation: var(--kirby-elevation-2);
 }
 
 :host,
@@ -51,4 +53,6 @@
   --kirby-white: hsl(0deg 0% 100%);
   --kirby-black: hsl(0deg 0% 11%);
   --kirby-semi-dark: hsl(0deg 0% 56%);
+  --kirby-elevation-2: 0 1px 24px 0 rgb(28 28 28 / 4%);
+  --kirby-elevation-4: 0 20px 30px -15px hsla(0deg 0% 11% 30%), 0 0 5px 0 hsla(0deg 0% 11% 8%);
 }

--- a/libs/core/src/scss/themes/_component-themes.scss
+++ b/libs/core/src/scss/themes/_component-themes.scss
@@ -3,15 +3,21 @@
 @mixin apply-dark-theme {
   --kirby-interactive-element-background-color: #{utils.get-color('white-overlay')};
   --kirby-interactive-element-color: #{utils.get-color('white')};
+  --kirby-interactive-element-indicator-background-color: #{utils.get-color('white')};
+  --kirby-interactive-element-indicator-color: #{utils.get-color('white-contrast')};
 }
 
 @mixin apply-white-theme {
   --kirby-interactive-element-background-color: #{utils.get-color('dark-overlay')};
   --kirby-interactive-element-color: #{utils.get-color('black')};
+  --kirby-interactive-element-indicator-background-color: #{utils.get-color('black')};
+  --kirby-interactive-element-indicator-color: #{utils.get-color('black-contrast')};
 }
 
 @mixin apply-light-theme {
   --kirby-interactive-element-background-color: #{utils.get-color('white')};
   --kirby-interactive-element-color: #{utils.get-color('white-contrast')};
+  --kirby-interactive-element-indicator-background-color: #{utils.get-color('black')};
+  --kirby-interactive-element-indicator-color: #{utils.get-color('black-contrast')};
   --kirby-interactive-elevation: #{utils.get-elevation(2)};
 }

--- a/libs/core/src/scss/themes/_component-themes.scss
+++ b/libs/core/src/scss/themes/_component-themes.scss
@@ -1,23 +1,54 @@
+@use 'sass:color';
 @use '../utils';
+@use '../interaction-state';
 
 @mixin apply-dark-theme {
-  --kirby-interactive-element-background-color: #{utils.get-color('white-overlay')};
-  --kirby-interactive-element-color: #{utils.get-color('white')};
-  --kirby-interactive-element-indicator-background-color: #{utils.get-color('white')};
-  --kirby-interactive-element-indicator-color: #{utils.get-color('white-contrast')};
+  --kirby-interactable-background-color: var(--kirby-white-overlay);
+  --kirby-interactable-background-color-hover: var(--kirby-white-overlay-20);
+  --kirby-interactable-background-color-active: var(--kirby-white-overlay-30);
+  --kirby-interactable-color: var(--kirby-white);
+  --kirby-interactable-indicator-background-color: var(--kirby-white);
+  --kirby-interactable-indicator-color: var(--kirby-black);
+  --kirby-interactable-placeholder-color: var(--kirby-white-overlay-50);
 }
 
 @mixin apply-white-theme {
-  --kirby-interactive-element-background-color: #{utils.get-color('dark-overlay')};
-  --kirby-interactive-element-color: #{utils.get-color('black')};
-  --kirby-interactive-element-indicator-background-color: #{utils.get-color('black')};
-  --kirby-interactive-element-indicator-color: #{utils.get-color('black-contrast')};
+  --kirby-interactable-background-color: var(--kirby-dark-overlay);
+  --kirby-interactable-background-color-hover: var(--kirby-dark-overlay-10);
+  --kirby-interactable-background-color-active: var(--kirby-dark-overlay-20);
+  --kirby-interactable-color: var(--kirby-black);
+  --kirby-interactable-indicator-background-color: var(--kirby-black);
+  --kirby-interactable-indicator-color: var(--kirby-white);
+  --kirby-interactable-placeholder-color: var(--kirby-semi-dark);
 }
 
 @mixin apply-light-theme {
-  --kirby-interactive-element-background-color: #{utils.get-color('white')};
-  --kirby-interactive-element-color: #{utils.get-color('white-contrast')};
-  --kirby-interactive-element-indicator-background-color: #{utils.get-color('black')};
-  --kirby-interactive-element-indicator-color: #{utils.get-color('black-contrast')};
+  --kirby-interactable-background-color: var(--kirby-white);
+  --kirby-interactable-background-color-hover: var(--kirby-dark-overlay-10);
+  --kirby-interactable-background-color-active: var(--kirby-dark-overlay-20);
+  --kirby-interactable-color: var(--kirby-black);
+  --kirby-interactable-indicator-background-color: var(--kirby-black);
+  --kirby-interactable-indicator-color: var(--kirby-white);
+  --kirby-interactable-placeholder-color: var(--kirby-semi-dark);
   --kirby-interactive-elevation: #{utils.get-elevation(2)};
+}
+
+:host,
+:root {
+  --kirby-white-overlay: hsl(0deg 0% 100% / 15%);
+  --kirby-white-overlay-10: hsl(0deg 0% 100% / 10%);
+  --kirby-white-overlay-20: hsl(0deg 0% 100% / 20%);
+  --kirby-white-overlay-30: hsl(0deg 0% 100% / 30%);
+  --kirby-white-overlay-40: hsl(0deg 0% 100% / 40%);
+  --kirby-white-overlay-50: hsl(0deg 0% 100% / 50%);
+  --kirby-dark-overlay: hsl(0deg 0% 11% / 6%);
+  --kirby-dark-overlay-10: hsl(0deg 0% 11% / 10%);
+  --kirby-dark-overlay-20: hsl(0deg 0% 11% / 20%);
+  --kirby-dark-overlay-30: hsl(0deg 0% 11% / 30%);
+  --kirby-dark-overlay-40: hsl(0deg 0% 11% / 40%);
+  --kirby-dark-overlay-50: hsl(0deg 0% 11% / 50%);
+  --kirby-white-overlay-6: hsl(0deg 0% 100% / 6%);
+  --kirby-white: hsl(0deg 0% 100%);
+  --kirby-black: hsl(0deg 0% 11%);
+  --kirby-semi-dark: hsl(0deg 0% 56%);
 }

--- a/libs/core/src/scss/themes/_component-themes.scss
+++ b/libs/core/src/scss/themes/_component-themes.scss
@@ -4,8 +4,8 @@
 
 @mixin apply-dark-theme {
   --kirby-inputs-background-color: var(--kirby-white-overlay);
-  --kirby-inputs-background-color-hover: var(--kirby-white-overlay-20);
-  --kirby-inputs-background-color-active: var(--kirby-white-overlay-30);
+  --kirby-inputs-background-color-hover: var(--kirby-white-overlay-30);
+  --kirby-inputs-background-color-active: var(--kirby-white-overlay-40);
   --kirby-inputs-color: var(--kirby-white);
   --kirby-inputs-indicator-background-color: var(--kirby-white);
   --kirby-inputs-indicator-color: var(--kirby-black);
@@ -49,7 +49,6 @@
   --kirby-dark-overlay-30: hsl(0deg 0% 11% / 30%);
   --kirby-dark-overlay-40: hsl(0deg 0% 11% / 40%);
   --kirby-dark-overlay-50: hsl(0deg 0% 11% / 50%);
-  --kirby-white-overlay-6: hsl(0deg 0% 100% / 6%);
   --kirby-white: hsl(0deg 0% 100%);
   --kirby-black: hsl(0deg 0% 11%);
   --kirby-semi-dark: hsl(0deg 0% 56%);

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -92,9 +92,6 @@ $button-width: (
 
   @include interaction-state.apply-hover('xs');
   @include interaction-state.apply-active('s');
-
-  // only apply box shadow for att. lvl. 3 (if set by theme)
-  box-shadow: var(--kirby-inputs-elevation);
 }
 
 :host {
@@ -113,6 +110,10 @@ $button-width: (
     align-items: inherit;
     justify-content: inherit;
     padding-inline: var(--kirby-button-padding-left) var(--kirby-button-padding-right);
+
+    &.attention-level3 {
+      box-shadow: var(--kirby-inputs-elevation);
+    }
   }
 
   font-family: var(--kirby-font-family);

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -94,6 +94,9 @@ $button-width: (
 
   @include interaction-state.apply-hover('xs');
   @include interaction-state.apply-active('s');
+
+  // only apply box shadow for att. lvl. 3 (if set by theme)
+  box-shadow: var(--kirby-inputs-elevation);
 }
 
 :host {
@@ -117,7 +120,6 @@ $button-width: (
   font-family: var(--kirby-font-family);
   background-color: var(--kirby-button-background-color, initial);
   color: var(--kirby-button-color, inherit);
-  box-shadow: var(--kirby-inputs-elevation);
   border-radius: utils.$border-radius-round;
   box-sizing: border-box; // Ensure border is not added to button height
   display: inline-flex;

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -90,10 +90,10 @@ $button-width: (
 
 @mixin button-attentionlevel3 {
   --kirby-button-background-color: var(
-    --kirby-interactive-element-background-color,
+    --kirby-interactable-background-color,
     #{utils.get-color('white')}
   );
-  --kirby-button-color: var(--kirby-interactive-element-color, #{utils.get-color('black')});
+  --kirby-button-color: var(--kirby-interactable-color, #{utils.get-color('black')});
 
   @include interaction-state.apply-hover('xs');
   @include interaction-state.apply-active('s');

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -90,10 +90,10 @@ $button-width: (
 
 @mixin button-attentionlevel3 {
   --kirby-button-background-color: var(
-    --kirby-interactable-background-color,
+    --kirby-inputs-background-color,
     #{utils.get-color('white')}
   );
-  --kirby-button-color: var(--kirby-interactable-color, #{utils.get-color('black')});
+  --kirby-button-color: var(--kirby-inputs-color, #{utils.get-color('black')});
 
   @include interaction-state.apply-hover('xs');
   @include interaction-state.apply-active('s');
@@ -120,7 +120,7 @@ $button-width: (
   font-family: var(--kirby-font-family);
   background-color: var(--kirby-button-background-color, initial);
   color: var(--kirby-button-color, inherit);
-  box-shadow: var(--kirby-interactive-elevation);
+  box-shadow: var(--kirby-inputs-elevation);
   border-radius: utils.$border-radius-round;
   box-sizing: border-box; // Ensure border is not added to button height
   display: inline-flex;

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -62,8 +62,6 @@ $button-width: (
   --kirby-button-background-color: transparent;
   --kirby-button-color: #{utils.get-color('black')};
 
-  box-shadow: none;
-
   @include interaction-state.apply-hover;
   @include interaction-state.apply-active('s');
 }

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -89,11 +89,8 @@ $button-width: (
 }
 
 @mixin button-attentionlevel3 {
-  --kirby-button-background-color: var(
-    --kirby-inputs-background-color,
-    #{utils.get-color('white')}
-  );
-  --kirby-button-color: var(--kirby-inputs-color, #{utils.get-color('black')});
+  --kirby-button-background-color: var(--kirby-inputs-background-color);
+  --kirby-button-color: var(--kirby-inputs-color);
 
   @include interaction-state.apply-hover('xs');
   @include interaction-state.apply-active('s');

--- a/libs/designsystem/form-field/src/_form-field-inputs.shared.scss
+++ b/libs/designsystem/form-field/src/_form-field-inputs.shared.scss
@@ -31,8 +31,8 @@ $form-field-label-height: 24px;
 :host {
   @include interaction-state.apply-focus-visible($shadow: utils.get-elevation(2));
 
-  background-color: var(--kirby-interactable-background-color, #{utils.get-color('white')});
-  color: var(--kirby-interactable-color, #{utils.get-color('black')});
+  background-color: var(--kirby-inputs-background-color, #{utils.get-color('white')});
+  color: var(--kirby-inputs-color, #{utils.get-color('black')});
   border: none;
   box-sizing: border-box;
   display: block;
@@ -47,7 +47,7 @@ $form-field-label-height: 24px;
   margin: 0;
   appearance: none;
   border-radius: utils.size('s');
-  box-shadow: var(--kirby-interactive-elevation);
+  box-shadow: var(--kirby-inputs-elevation);
   padding: $form-field-input-padding;
   width: 100%;
 
@@ -66,6 +66,6 @@ $form-field-label-height: 24px;
   }
 
   &::placeholder {
-    color: var(--kirby-interactable-placeholder-color, #{utils.get-text-color('semi-dark')});
+    color: var(--kirby-inputs-placeholder-color, #{utils.get-text-color('semi-dark')});
   }
 }

--- a/libs/designsystem/form-field/src/_form-field-inputs.shared.scss
+++ b/libs/designsystem/form-field/src/_form-field-inputs.shared.scss
@@ -31,8 +31,8 @@ $form-field-label-height: 24px;
 :host {
   @include interaction-state.apply-focus-visible($shadow: utils.get-elevation(2));
 
-  background-color: utils.get-color('white');
-  color: utils.get-color('white-contrast');
+  background-color: var(--kirby-interactable-background-color, #{utils.get-color('white')});
+  color: var(--kirby-interactable-color, #{utils.get-color('black')});
   border: none;
   box-sizing: border-box;
   display: block;
@@ -47,7 +47,7 @@ $form-field-label-height: 24px;
   margin: 0;
   appearance: none;
   border-radius: utils.size('s');
-  box-shadow: utils.get-elevation(2);
+  box-shadow: var(--kirby-interactive-elevation);
   padding: $form-field-input-padding;
   width: 100%;
 
@@ -66,6 +66,6 @@ $form-field-label-height: 24px;
   }
 
   &::placeholder {
-    color: utils.get-text-color('semi-dark');
+    color: var(--kirby-interactable-placeholder-color, #{utils.get-text-color('semi-dark')});
   }
 }

--- a/libs/designsystem/form-field/src/_form-field-inputs.shared.scss
+++ b/libs/designsystem/form-field/src/_form-field-inputs.shared.scss
@@ -31,8 +31,8 @@ $form-field-label-height: 24px;
 :host {
   @include interaction-state.apply-focus-visible($shadow: utils.get-elevation(2));
 
-  background-color: var(--kirby-inputs-background-color, #{utils.get-color('white')});
-  color: var(--kirby-inputs-color, #{utils.get-color('black')});
+  background-color: var(--kirby-inputs-background-color);
+  color: var(--kirby-inputs-color);
   border: none;
   box-sizing: border-box;
   display: block;
@@ -66,6 +66,6 @@ $form-field-label-height: 24px;
   }
 
   &::placeholder {
-    color: var(--kirby-inputs-placeholder-color, #{utils.get-text-color('semi-dark')});
+    color: var(--kirby-inputs-placeholder-color);
   }
 }

--- a/libs/designsystem/form-field/src/input/input.component.scss
+++ b/libs/designsystem/form-field/src/input/input.component.scss
@@ -6,11 +6,11 @@ $padding-block-size-md: shared.$form-field-input-padding * 0.5;
 
 :host {
   @include interaction-state.apply-hover {
-    background-color: interaction-state.get-state-color('white', 'xxxs');
+    background-color: var(--kirby-interactable-background-color-hover);
     cursor: text;
   }
   @include interaction-state.apply-active {
-    background-color: interaction-state.get-state-color('white');
+    background-color: var(--kirby-interactable-background-color-active);
   }
 
   transition: interaction-state.transition();

--- a/libs/designsystem/form-field/src/input/input.component.scss
+++ b/libs/designsystem/form-field/src/input/input.component.scss
@@ -6,11 +6,11 @@ $padding-block-size-md: shared.$form-field-input-padding * 0.5;
 
 :host {
   @include interaction-state.apply-hover {
-    background-color: var(--kirby-interactable-background-color-hover);
+    background-color: var(--kirby-inputs-background-color-hover);
     cursor: text;
   }
   @include interaction-state.apply-active {
-    background-color: var(--kirby-interactable-background-color-active);
+    background-color: var(--kirby-inputs-background-color-active);
   }
 
   transition: interaction-state.transition();

--- a/libs/designsystem/shared/src/theme-color/theme-color.directive.integration.spec.ts
+++ b/libs/designsystem/shared/src/theme-color/theme-color.directive.integration.spec.ts
@@ -22,14 +22,14 @@ describe('ThemeColorDirective', () => {
     it('should add CSS Custom Property for theming background-color', () => {
       expect(
         getComputedStyle(spectator.element).getPropertyValue(
-          '--kirby-interactive-element-background-color'
+          '--kirby-interactable-background-color'
         )
       ).not.toBe('');
     });
 
     it('should add CSS Custom Property for theming color', () => {
       expect(
-        getComputedStyle(spectator.element).getPropertyValue('--kirby-interactive-element-color')
+        getComputedStyle(spectator.element).getPropertyValue('--kirby-interactable-color')
       ).not.toBe('');
     });
   });

--- a/libs/designsystem/shared/src/theme-color/theme-color.directive.integration.spec.ts
+++ b/libs/designsystem/shared/src/theme-color/theme-color.directive.integration.spec.ts
@@ -21,16 +21,14 @@ describe('ThemeColorDirective', () => {
 
     it('should add CSS Custom Property for theming background-color', () => {
       expect(
-        getComputedStyle(spectator.element).getPropertyValue(
-          '--kirby-interactable-background-color'
-        )
+        getComputedStyle(spectator.element).getPropertyValue('--kirby-inputs-background-color')
       ).not.toBe('');
     });
 
     it('should add CSS Custom Property for theming color', () => {
-      expect(
-        getComputedStyle(spectator.element).getPropertyValue('--kirby-interactable-color')
-      ).not.toBe('');
+      expect(getComputedStyle(spectator.element).getPropertyValue('--kirby-inputs-color')).not.toBe(
+        ''
+      );
     });
   });
 

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -28,7 +28,7 @@
 
   &.default-mode {
     ion-segment {
-      --background: var(--kirby-interactive-element-background-color, #{utils.get-color('white')});
+      --background: var(--kirby-interactable-background-color, #{utils.get-color('white')});
 
       box-shadow: var(--kirby-interactive-elevation);
       width: fit-content; // The segmented control itself is block-level, but we don't want it to stretch
@@ -54,7 +54,7 @@
     }
 
     ion-segment-button {
-      --background: var(--kirby-interactive-element-background-color, #{utils.get-color('white')});
+      --background: var(--kirby-interactable-background-color, #{utils.get-color('white')});
       --indicator-transition: none;
 
       flex: initial;
@@ -100,12 +100,12 @@ ion-segment-button {
   --border-radius: #{utils.$border-radius-round};
   --border-style: none;
   --background: none;
-  --color: var(--kirby-interactive-element-color);
+  --color: var(--kirby-interactable-color, #{utils.get-color('black')});
   --indicator-color: var(
-    --kirby-interactive-element-indicator-background-color,
+    --kirby-interactable-indicator-background-color,
     #{utils.get-color('black')}
   );
-  --color-checked: var(--kirby-interactive-element-indicator-color, #{utils.get-color('white')});
+  --color-checked: var(--kirby-interactable-indicator-color, #{utils.get-color('white')});
   --indicator-box-shadow: none;
   --indicator-transform: none;
   --padding-start: #{utils.size('m')};

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -28,9 +28,9 @@
 
   &.default-mode {
     ion-segment {
-      --background: var(--kirby-interactable-background-color, #{utils.get-color('white')});
+      --background: var(--kirby-inputs-background-color, #{utils.get-color('white')});
 
-      box-shadow: var(--kirby-interactive-elevation);
+      box-shadow: var(--kirby-inputs-elevation);
       width: fit-content; // The segmented control itself is block-level, but we don't want it to stretch
       overflow: visible; // Ensures the badge is not cut off
       contain: none; // Ensures the badge is not cut off
@@ -54,7 +54,7 @@
     }
 
     ion-segment-button {
-      --background: var(--kirby-interactable-background-color, #{utils.get-color('white')});
+      --background: var(--kirby-inputs-background-color, #{utils.get-color('white')});
       --indicator-transition: none;
 
       flex: initial;
@@ -88,24 +88,16 @@ ion-segment-button {
     outline: none;
     border-radius: utils.$border-radius-round;
   }
-  @include interaction-state.apply-hover-ionic;
-  @include interaction-state.apply-active-ionic('s');
   @include utils.accessible-target-size;
 
-  &.segment-button-checked {
-    @include interaction-state.apply-hover-ionic('l', $make-lighter: true);
-    @include interaction-state.apply-active-ionic('xxxl', $make-lighter: true);
-  }
-
+  --background-hover: var(--kirby-inputs-background-color-hover);
+  --background-hover-opacity: 1;
   --border-radius: #{utils.$border-radius-round};
   --border-style: none;
   --background: none;
-  --color: var(--kirby-interactable-color, #{utils.get-color('black')});
-  --indicator-color: var(
-    --kirby-interactable-indicator-background-color,
-    #{utils.get-color('black')}
-  );
-  --color-checked: var(--kirby-interactable-indicator-color, #{utils.get-color('white')});
+  --color: var(--kirby-inputs-color);
+  --indicator-color: var(--kirby-inputs-indicator-background-color);
+  --color-checked: var(--kirby-inputs-indicator-color);
   --indicator-box-shadow: none;
   --indicator-transform: none;
   --padding-start: #{utils.size('m')};

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -28,7 +28,7 @@
 
   &.default-mode {
     ion-segment {
-      --background: var(--kirby-inputs-background-color, #{utils.get-color('white')});
+      --background: var(--kirby-inputs-background-color);
 
       box-shadow: var(--kirby-inputs-elevation);
       width: fit-content; // The segmented control itself is block-level, but we don't want it to stretch
@@ -54,7 +54,7 @@
     }
 
     ion-segment-button {
-      --background: var(--kirby-inputs-background-color, #{utils.get-color('white')});
+      --background: var(--kirby-inputs-background-color);
       --indicator-transition: none;
 
       flex: initial;

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -87,8 +87,6 @@ ion-segment-button {
   @include interaction-state.apply-focus-part($part: 'native');
   @include utils.accessible-target-size;
 
-  --background-hover: var(--kirby-inputs-background-color-hover);
-  --background-hover-opacity: 1;
   --border-radius: #{utils.$border-radius-round};
   --border-style: none;
   --background: none;
@@ -113,10 +111,8 @@ ion-segment-button {
 
   // NOTE: This is a custom implementation of the hover interaction state;
   // identical to FabSheet's ion-fab-button & PageComponent's ion-back-button.
-  opacity: 1; // not strictly required but declared to be consistent
 
   &::part(native) {
-    opacity: 1; // required for interaction states to work
     border-radius: #{utils.$border-radius-round};
     overflow: hidden; // not strictly required but declared to be consistent
   }

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -84,10 +84,7 @@ ion-segment {
 }
 
 ion-segment-button {
-  @include interaction-state.apply-focus-visible {
-    outline: none;
-    border-radius: utils.$border-radius-round;
-  }
+  @include interaction-state.apply-focus-part($part: 'native');
   @include utils.accessible-target-size;
 
   --background-hover: var(--kirby-inputs-background-color-hover);

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -28,8 +28,9 @@
 
   &.default-mode {
     ion-segment {
-      --background: #{utils.get-color('white')};
+      --background: var(--kirby-interactive-element-background-color, #{utils.get-color('white')});
 
+      box-shadow: var(--kirby-interactive-elevation);
       width: fit-content; // The segmented control itself is block-level, but we don't want it to stretch
       overflow: visible; // Ensures the badge is not cut off
       contain: none; // Ensures the badge is not cut off
@@ -53,7 +54,7 @@
     }
 
     ion-segment-button {
-      --background: #{utils.get-color('white')};
+      --background: var(--kirby-interactive-element-background-color, #{utils.get-color('white')});
       --indicator-transition: none;
 
       flex: initial;
@@ -99,10 +100,12 @@ ion-segment-button {
   --border-radius: #{utils.$border-radius-round};
   --border-style: none;
   --background: none;
-  --color: #{utils.get-color('white-contrast')};
-  --indicator-color: #{utils.get-color('black')};
-  --color-checked: #{utils.get-color('black-contrast')};
-  --color-hover: #{utils.get-color('black-tint')};
+  --color: var(--kirby-interactive-element-color);
+  --indicator-color: var(
+    --kirby-interactive-element-indicator-background-color,
+    #{utils.get-color('black')}
+  );
+  --color-checked: var(--kirby-interactive-element-indicator-color, #{utils.get-color('white')});
   --indicator-box-shadow: none;
   --indicator-transform: none;
   --padding-start: #{utils.size('m')};


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2620

## What is the new behavior?
Segmented Control and Form Field now implement the CSS Custom Properties required to react to themeColor changes on e.g. card. 

This PR also includes: 
- A rename of the (otherwise very very long) CSS props to `--kirby-inputs-*` to indicate that they are relevant for interactive input components.
- Applying the default (light) theme via global styles so button, dropdown, form-field and segmented control show up correctly when no theme is set. No theme is assumed to be a light-gray (#efefef) background.  

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- ~~[ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

