### PR TITLE
Fix kirby-button attentionLevel 3 in kirby-list & kirby-modal footer

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -70,7 +70,7 @@ Additionally, multiple components and directives are now standalone components, 
 <h3 id="components-v8">Components</h3>
 
 <h4 id="button-v8">Button</h4>
-The isDesctructive behavior of button should only be used internally by Kirby in the alert, as destructive actions are always announced via an alert. Use the default button attention levels and combine with alerts when needed.
+The isDestructive behavior of button should only be used internally by Kirby in the alert, as destructive actions are always announced via an alert. Use the default button attention levels and combine with alerts when needed.
 
 ---
 

--- a/libs/designsystem/list/src/list.component.scss
+++ b/libs/designsystem/list/src/list.component.scss
@@ -95,6 +95,8 @@ ion-item-divider {
 }
 
 .footer {
+  @include themes.apply-white-theme;
+
   background-color: utils.get-color('white');
   border-top: 1px solid $divider-color;
   display: flex;

--- a/libs/designsystem/modal/experimental/src/footer/footer.component.scss
+++ b/libs/designsystem/modal/experimental/src/footer/footer.component.scss
@@ -1,9 +1,12 @@
 @use '@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/themes';
 
 $padding-horizontal: utils.size('s');
 $padding-vertical: utils.size('xxs');
 
 ion-footer {
+  @include themes.apply-white-theme;
+
   box-shadow: utils.get-elevation(8);
   display: flex;
   justify-content: var(--kirby-modal-footer-justify-content, center);

--- a/libs/designsystem/modal/src/modal/footer/modal-footer.component.scss
+++ b/libs/designsystem/modal/src/modal/footer/modal-footer.component.scss
@@ -1,9 +1,12 @@
 @use '@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/themes';
 
 $padding-horizontal: utils.size('s');
 $padding-vertical: utils.size('xxs');
 
 ion-footer {
+  @include themes.apply-white-theme;
+
   box-shadow: utils.get-elevation(4);
   display: flex;
   justify-content: var(--kirby-modal-footer-justify-content, center);


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2864

## What is the new behavior?
A kirby-button with attentionLevel 3 will change the background color to grey in `kirby-list-footer` and `kirby-modal-footer`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

