### PR TITLE
Fix kirby-button attentionLevel 3 in kirby-page-footer

### DIFF
--- a/libs/designsystem/page/src/page-footer/page-footer.component.scss
+++ b/libs/designsystem/page/src/page-footer/page-footer.component.scss
@@ -1,4 +1,5 @@
 @use '@kirbydesign/core/src/scss/utils';
+@use '@kirbydesign/core/src/scss/themes';
 
 $padding-horizontal: utils.size('s');
 $padding-vertical: utils.size('xxs');
@@ -6,6 +7,7 @@ $padding-vertical: utils.size('xxs');
 :host {
   display: block;
   background-color: utils.get-color('white');
+  @include themes.apply-white-theme;
 
   .wrapper {
     position: relative;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue.

## What is the new behavior?
A kirby-button with attentionLevel 3 will change the background color to grey in kirby-page-footer

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

