### PR TITLE
Fix date mask directive in form field

### DIFF
--- a/libs/designsystem/form-field/src/form-field.module.ts
+++ b/libs/designsystem/form-field/src/form-field.module.ts
@@ -3,12 +3,13 @@ import { NgModule } from '@angular/core';
 import { FormFieldMessageComponent } from './form-field-message/form-field-message.component';
 import { FormFieldComponent } from './form-field.component';
 import { InputCounterComponent } from './input-counter/input-counter.component';
+import { DecimalMaskDirective } from './directives/decimal-mask/decimal-mask.directive';
 
 const declarations = [FormFieldComponent, FormFieldMessageComponent, InputCounterComponent];
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, DecimalMaskDirective],
   declarations: [...declarations],
-  exports: [...declarations],
+  exports: [...declarations, DecimalMaskDirective],
 })
 export class FormFieldModule {}

--- a/libs/designsystem/form-field/src/public_api.ts
+++ b/libs/designsystem/form-field/src/public_api.ts
@@ -4,6 +4,5 @@ export { InputComponent, InputSize } from './input/input.component';
 export { InputCounterComponent } from './input-counter/input-counter.component';
 export { TextareaComponent } from './textarea/textarea.component';
 export * from './directives/date/date-input.directive';
-export { DecimalMaskDirective } from './directives/decimal-mask/decimal-mask.directive';
 export { AffixDirective } from './directives/affix/affix.directive';
 export * from './form-field.module';

--- a/libs/designsystem/form-field/src/public_api.ts
+++ b/libs/designsystem/form-field/src/public_api.ts
@@ -4,5 +4,6 @@ export { InputComponent, InputSize } from './input/input.component';
 export { InputCounterComponent } from './input-counter/input-counter.component';
 export { TextareaComponent } from './textarea/textarea.component';
 export * from './directives/date/date-input.directive';
+export { DecimalMaskDirective } from './directives/decimal-mask/decimal-mask.directive';
 export { AffixDirective } from './directives/affix/affix.directive';
 export * from './form-field.module';


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2875

## What is the new behavior?
The date mask directive is now enabled again by exporting it from within the module - otherwise the decimal-mask directive will not be initialized when used on a form field. 

I suspect this change might be relevant for all the tightly coupled directives for form field, that are currently exported via the public api instead of through the module, but will have to investigate further.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

