### PR TITLE
Hotfix Release v8.1.1: Add CommonModule in standalone comps

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kirbydesign/core",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "description": "Core web-components for the Kirby Design System.",
   "module": "dist/index.js",
   "main": "dist/index.cjs.js",

--- a/libs/designsystem/button/src/button.component.ts
+++ b/libs/designsystem/button/src/button.component.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import {
   AfterContentInit,
   ChangeDetectionStrategy,
@@ -23,6 +24,7 @@ const ATTENTION_LEVEL_4_DEPRECATION_WARNING =
 
 @Component({
   standalone: true,
+  imports: [CommonModule],
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'button[kirby-button],Button[kirby-button]',
   templateUrl: './button.component.html',

--- a/libs/designsystem/divider/src/divider.component.ts
+++ b/libs/designsystem/divider/src/divider.component.ts
@@ -1,7 +1,9 @@
+import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
 @Component({
   standalone: true,
+  imports: [CommonModule],
   selector: 'kirby-divider',
   templateUrl: './divider.component.html',
   styleUrls: ['./divider.component.scss'],

--- a/libs/designsystem/flag/src/flag.component.ts
+++ b/libs/designsystem/flag/src/flag.component.ts
@@ -1,7 +1,9 @@
+import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular/core';
 
 @Component({
   standalone: true,
+  imports: [CommonModule],
   selector: 'kirby-flag',
   template: `
     <ng-content></ng-content>

--- a/libs/designsystem/form-field/src/input/input.component.ts
+++ b/libs/designsystem/form-field/src/input/input.component.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -16,6 +17,7 @@ export enum InputSize {
 
 @Component({
   standalone: true,
+  imports: [CommonModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'input[kirby-input]',

--- a/libs/designsystem/grid/src/grid.component.ts
+++ b/libs/designsystem/grid/src/grid.component.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import { Component, HostBinding, Input, OnDestroy } from '@angular/core';
 import { ScssHelper } from '@kirbydesign/designsystem/helpers/scss';
 import { Subscription } from 'rxjs';
@@ -24,6 +25,7 @@ class GridCard {
 
 @Component({
   standalone: true,
+  imports: [CommonModule],
   selector: 'kirby-grid',
   templateUrl: './grid.component.html',
   styleUrls: ['./grid.component.scss'],

--- a/libs/designsystem/item-group/src/item-group.component.ts
+++ b/libs/designsystem/item-group/src/item-group.component.ts
@@ -1,7 +1,9 @@
+import { CommonModule } from '@angular/common';
 import { Component, HostBinding } from '@angular/core';
 
 @Component({
   standalone: true,
+  imports: [CommonModule],
   selector: 'kirby-item-group',
   templateUrl: './item-group.component.html',
   styleUrls: ['./item-group.component.scss'],

--- a/libs/designsystem/modal/src/modal/footer/modal-footer.component.ts
+++ b/libs/designsystem/modal/src/modal/footer/modal-footer.component.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -17,7 +18,7 @@ import {
 
 @Component({
   standalone: true,
-  imports: [IonicModule, ThemeColorDirective],
+  imports: [IonicModule, ThemeColorDirective, CommonModule],
   selector: 'kirby-modal-footer',
   templateUrl: './modal-footer.component.html',
   styleUrls: ['./modal-footer.component.scss'],

--- a/libs/designsystem/package.json
+++ b/libs/designsystem/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@fontsource/roboto": "4.2.1",
     "@ionic/angular": "6.2.1",
-    "@kirbydesign/core": "0.0.40",
+    "@kirbydesign/core": "0.0.41",
     "inputmask": "5.0.5"
   },
   "peerDependencies": {

--- a/libs/designsystem/popover/src/popover.component.ts
+++ b/libs/designsystem/popover/src/popover.component.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import {
   AfterViewInit,
   Component,
@@ -19,6 +20,7 @@ export enum HorizontalDirection {
 
 @Component({
   standalone: true,
+  imports: [CommonModule],
   selector: 'kirby-popover',
   template: `
     <div #wrapper class="wrapper"><ng-content></ng-content></div>

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.ts
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.ts
@@ -1,9 +1,10 @@
+import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular/core';
 import { ThemeColorDirective } from '@kirbydesign/designsystem/shared';
 
 @Component({
   standalone: true,
-  imports: [ThemeColorDirective],
+  imports: [ThemeColorDirective, CommonModule],
   selector: 'kirby-progress-circle-ring',
   templateUrl: './progress-circle-ring.component.svg',
   styleUrls: ['./progress-circle-ring.component.scss'],

--- a/libs/designsystem/progress-circle/src/progress-circle.component.ts
+++ b/libs/designsystem/progress-circle/src/progress-circle.component.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
@@ -12,7 +13,7 @@ import { ProgressCircleRingComponent } from './progress-circle-ring.component';
 
 @Component({
   standalone: true,
-  imports: [ProgressCircleRingComponent],
+  imports: [ProgressCircleRingComponent, CommonModule],
   selector: 'kirby-progress-circle',
   templateUrl: './progress-circle.component.html',
   styleUrls: ['./progress-circle.component.scss'],

--- a/libs/designsystem/section-header/src/section-header.component.ts
+++ b/libs/designsystem/section-header/src/section-header.component.ts
@@ -1,9 +1,10 @@
+import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { IonicModule } from '@ionic/angular';
 
 @Component({
   standalone: true,
-  imports: [IonicModule],
+  imports: [IonicModule, CommonModule],
   selector: 'kirby-section-header',
   templateUrl: './section-header.component.html',
   styleUrls: ['./section-header.component.scss'],

--- a/libs/designsystem/toggle/src/toggle.component.ts
+++ b/libs/designsystem/toggle/src/toggle.component.ts
@@ -1,9 +1,10 @@
+import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { KirbyIonicModule } from '@kirbydesign/designsystem/kirby-ionic-module';
 
 @Component({
   standalone: true,
-  imports: [KirbyIonicModule],
+  imports: [KirbyIonicModule, CommonModule],
   selector: 'kirby-toggle',
   templateUrl: './toggle.component.html',
   styleUrls: ['./toggle.component.scss'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "designsystem",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "designsystem",
-      "version": "8.1.0",
+      "version": "8.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -117,13 +117,13 @@
         "webpack-cli": "^4.9.0"
       },
       "engines": {
-        "node": ">=16.0.0",
+        "node": ">=16.0.0 <=18.13.0",
         "npm": ">=8.5.0"
       }
     },
     "libs/core": {
       "name": "@kirbydesign/core",
-      "version": "0.0.40",
+      "version": "0.0.41",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "designsystem",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "Kirby Design Angular Components. This library provides Angular wrappers for the @kirbydesign/core package, for smoother integration into Angular projects.",
   "engines": {
     "node": ">=16.0.0 <=18.13.0",


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue, it is a hotfix.

## What is the new behavior?
In Kirby v8.1.0 the Grid component gives the following error: 
`Can't bind to 'ngForOf' since it isn't a known property of 'ng-container' (used in the 'GridComponent' component template).` when used in projects. 

From a place of caution I have updated both GridComponent and all other standalone components to include `CommonModule` so we wont accidentally get this error if we start using the built in directives in the standalone components that would not have CommonModule installed down the line. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
