### PR TITLE
Hotfix Release v8.1.2: Import ComponentLoader in Grid

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kirbydesign/core",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "description": "Core web-components for the Kirby Design System.",
   "module": "dist/index.js",
   "main": "dist/index.cjs.js",

--- a/libs/designsystem/grid/src/grid.component.ts
+++ b/libs/designsystem/grid/src/grid.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, HostBinding, Input, OnDestroy } from '@angular/core';
 import { ScssHelper } from '@kirbydesign/designsystem/helpers/scss';
+import { ComponentLoaderDirective } from '@kirbydesign/designsystem/shared';
 import { Subscription } from 'rxjs';
 
 import { BreakpointHelperService } from './breakpoint-helper.service';
@@ -25,7 +26,7 @@ class GridCard {
 
 @Component({
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ComponentLoaderDirective],
   selector: 'kirby-grid',
   templateUrl: './grid.component.html',
   styleUrls: ['./grid.component.scss'],

--- a/libs/designsystem/package.json
+++ b/libs/designsystem/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "@fontsource/roboto": "4.2.1",
     "@ionic/angular": "6.2.1",
-    "@kirbydesign/core": "0.0.41",
+    "@kirbydesign/core": "0.0.42",
     "inputmask": "5.0.5"
   },
   "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "designsystem",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "designsystem",
-      "version": "8.1.1",
+      "version": "8.1.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -123,7 +123,7 @@
     },
     "libs/core": {
       "name": "@kirbydesign/core",
-      "version": "0.0.41",
+      "version": "0.0.42",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "designsystem",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "description": "Kirby Design Angular Components. This library provides Angular wrappers for the @kirbydesign/core package, for smoother integration into Angular projects.",
   "engines": {
     "node": ">=16.0.0 <=18.13.0",


### PR DESCRIPTION
## Which issue does this PR close?

This PR is a hotfix for errors where the GridComponent cant recognize the component loader directive because it was not imported when the component was made standalone. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No