### PR TITLE
Disable prettier rules for linting in HTML files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,7 +65,9 @@
     },
     {
       "files": ["*.html"],
-      "rules": {}
+      "rules": {
+        "prettier/prettier": "off"
+      }
     }
   ],
   "rules": {


### PR DESCRIPTION
## What is the new behavior?

This prevents issues where linting will throw an error due to html files being linted according to JSX rules.  This change will still define the correct rules for prettier so that prettier will format html files correctly. However, the prettier specific linting-rules won't throw errors when linting.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [ ] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] ~~Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be merged to `develop` by Team Kirby.

