### PR TITLE
Fix ion-backdrop scroll block on navigation return

### DIFF
--- a/libs/designsystem/fab-sheet/src/fab-sheet.component.ts
+++ b/libs/designsystem/fab-sheet/src/fab-sheet.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule, DOCUMENT } from '@angular/common';
 import {
   AfterContentInit,
+  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -23,7 +24,7 @@ import { ActionSheetComponent } from '@kirbydesign/designsystem/modal';
   styleUrls: ['./fab-sheet.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FabSheetComponent implements AfterContentInit {
+export class FabSheetComponent implements AfterContentInit, AfterViewInit {
   @Input() disabled: boolean = false;
   @Input() horizontalAlignment: 'left' | 'center' | 'right' = 'right';
 
@@ -51,6 +52,10 @@ export class FabSheetComponent implements AfterContentInit {
     if (this.actionSheet) {
       this.actionSheet.hideCancel = true;
     }
+  }
+
+  ngAfterViewInit(): void {
+    this.renderer.removeClass(this.document.body, 'backdrop-no-scroll');
   }
 
   hideActions() {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2879 

## What is the new behavior?

Fix ion-backdrop scroll block when navigation away from page with fab-sheet and and giong back...

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

