### PR TITLE
Enhancement/2935 implement roving tabindex and accessibility patterns

### DIFF
--- a/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.html
+++ b/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.html
@@ -1,4 +1,4 @@
-<button #tabButton>
-  <span attr.data-text="{{ label }}" text>{{ label }}</span>
+<button role="tab" #tabButton>
+  <span attr.data-text="{{ label }}">{{ label }}</span>
   <ng-content></ng-content>
 </button>

--- a/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.scss
+++ b/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.scss
@@ -10,8 +10,8 @@ $divider-max-width-breakpoint: utils.$page-content-max-width + (utils.size('s') 
   position: relative;
   padding-bottom: $bottom-border-height * 2;
 
-  button {
-    font-family: var(--kirby-font-family);
+  button[role='tab'] {
+    font-family: inherit;
     background-color: utils.get-color('background-color');
     color: utils.get-color('black');
     padding: utils.size('s');
@@ -37,28 +37,26 @@ $divider-max-width-breakpoint: utils.$page-content-max-width + (utils.size('s') 
     &:hover {
       font-weight: utils.font-weight('bold');
     }
-  }
 
-  &.selected {
-    // Selected divider
-    &::before {
-      content: '';
-      width: 100%;
-      background-color: $border-color-selected;
-      position: absolute;
-      border-radius: 1px;
-      height: $bottom-border-height * 2;
-      bottom: 0;
-      z-index: 2;
-    }
-
-    button {
+    &[aria-selected='true'] {
       font-weight: utils.font-weight('bold');
+
+      // Selected divider
+      &::before {
+        content: '';
+        width: 100%;
+        background-color: $border-color-selected;
+        position: absolute;
+        border-radius: 1px;
+        height: $bottom-border-height * 2;
+        bottom: 0;
+        z-index: 2;
+      }
     }
   }
 }
 
-span[text] {
+span[data-text] {
   max-width: $tab-item-text-max-width;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.spec.ts
+++ b/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.spec.ts
@@ -35,13 +35,13 @@ describe('TabNavigationItemComponent', () => {
   });
 
   it('should render the correct text', () => {
-    const textElement = spectator.query('span[text]');
+    const textElement = spectator.query('span[data-text]');
 
     expect(textElement).toHaveExactText('Tab1');
   });
 
   it('should set the data attribute with the correct text', () => {
-    const textElement = spectator.query('span[text]');
+    const textElement = spectator.query('span[data-text]');
 
     expect(textElement).toHaveAttribute('data-text', 'Tab1');
   });

--- a/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.ts
+++ b/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.ts
@@ -1,13 +1,4 @@
-import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
-  ElementRef,
-  HostBinding,
-  HostListener,
-  Input,
-  ViewChild,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input } from '@angular/core';
 
 @Component({
   selector: 'kirby-tab-navigation-item',
@@ -15,30 +6,11 @@ import {
   styleUrls: ['./tab-navigation-item.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TabNavigationItemComponent implements AfterViewInit {
-  @ViewChild('tabButton')
-  private tabButton: ElementRef<HTMLElement>;
-
-  @HostBinding('attr.tabindex')
-  tabindex: number = -1;
-
-  @HostListener('focus')
-  onFocus() {
-    if (this.tabButtonElement) {
-      this.tabButtonElement.focus();
-    }
-  }
-
+export class TabNavigationItemComponent {
   @Input()
   label = '';
 
-  private tabButtonElement: HTMLElement;
-
   constructor(private elementRef: ElementRef<HTMLElement>) {
     /* */
-  }
-
-  ngAfterViewInit(): void {
-    this.tabButtonElement = this.tabButton.nativeElement;
   }
 }

--- a/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.html
+++ b/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.html
@@ -1,3 +1,3 @@
-<div class="tab-bar" #tabBar>
+<div role="tablist" #tabBar>
   <ng-content></ng-content>
 </div>

--- a/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.scss
+++ b/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.scss
@@ -6,8 +6,10 @@ $border-color-standard: utils.get-color('medium');
 $border-color-selected: utils.get-color('dark');
 $divider-max-width-breakpoint: utils.$page-content-max-width + (utils.size('s') * 2);
 
-.tab-bar {
+div[role='tablist'] {
   position: relative;
+  background-color: utils.get-color('background-color');
+  max-width: var(--page-content-max-width, utils.$page-content-max-width);
   margin: 0 auto;
   display: flex;
   gap: utils.size('xs');
@@ -28,12 +30,6 @@ $divider-max-width-breakpoint: utils.$page-content-max-width + (utils.size('s') 
   &::-webkit-scrollbar {
     display: none;
   }
-}
-
-.container {
-  position: relative;
-  background-color: utils.get-color('background-color');
-  max-width: var(--page-content-max-width, utils.$page-content-max-width);
 
   // Divider
   &::before {

--- a/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.spec.ts
+++ b/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.spec.ts
@@ -11,7 +11,7 @@ import { TabNavigationComponent } from './tab-navigation.component';
 describe('TabNavigationComponent', () => {
   let component: TabNavigationComponent;
   let spectator: SpectatorHost<TabNavigationComponent>;
-  let items: Element[];
+  let tabButtons: Element[];
 
   const createHost = createHostFactory({
     component: TabNavigationComponent,
@@ -23,20 +23,17 @@ describe('TabNavigationComponent', () => {
     spectator = createHost(
       `
       <kirby-tab-navigation [(selectedIndex)]="selectedIndex">
-        <kirby-tab-navigation-item>
-          <span text>Tab1</span>
+        <kirby-tab-navigation-item label="Tab1">
           <kirby-badge themeColor="warning">
             <kirby-icon name="attach"></kirby-icon>
           </kirby-badge>
         </kirby-tab-navigation-item> 
-        <kirby-tab-navigation-item>
-          <span text>Tab2</span>
+        <kirby-tab-navigation-item label="Tab2">
           <kirby-badge themeColor="success">
             3
           </kirby-badge>
         </kirby-tab-navigation-item> 
-        <kirby-tab-navigation-item>
-          <span text>Tab3</span>
+        <kirby-tab-navigation-item label="Tab3">
         </kirby-tab-navigation-item> 
       </kirby-tab-navigation>
       `,
@@ -50,17 +47,11 @@ describe('TabNavigationComponent', () => {
     component = spectator.component;
     tick(component.DEBOUNCE_TIME_MS);
 
-    items = spectator.queryAll('kirby-tab-navigation-item');
+    tabButtons = spectator.queryAll('kirby-tab-navigation-item button');
   }));
 
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('should have initial selected class', () => {
-    const initialSelected = items[component.selectedIndex];
-
-    expect(initialSelected).toHaveClass('selected');
   });
 
   it('should render correct number of item badges', () => {
@@ -69,18 +60,9 @@ describe('TabNavigationComponent', () => {
     expect(badges.length).toBe(2);
   });
 
-  it('should select tab on click', fakeAsync(() => {
-    const selectElement = items[1];
-
-    spectator.click(selectElement);
-    tick();
-
-    expect(selectElement).toHaveClass('selected');
-  }));
-
-  it('should update selectedIndex corretly on click', fakeAsync(() => {
+  it('should update selectedIndex corretly on tab selection', fakeAsync(() => {
     const selectIndex = 1;
-    const selectElement = items[selectIndex];
+    const selectElement = tabButtons[selectIndex];
 
     spectator.click(selectElement);
     tick();
@@ -90,22 +72,73 @@ describe('TabNavigationComponent', () => {
 
   it('should select tab on setting selectedIndex', fakeAsync(() => {
     const selectIndex = 2;
-    const selectElement = items[selectIndex];
+    const selectElement = tabButtons[selectIndex];
 
     component.selectedIndex = selectIndex;
     tick();
 
-    expect(selectElement).toHaveClass('selected');
+    expect(selectElement).toHaveAttribute('aria-selected', 'true');
   }));
 
-  it('should emit selectedIndex on tab change', fakeAsync(() => {
+  it('should emit selectedIndex on tab selection', fakeAsync(() => {
     const selectIndex = 1;
-    const selectElement = items[selectIndex];
+    const selectElement = tabButtons[selectIndex];
     spyOn(component.selectedIndexChange, 'emit');
 
     spectator.click(selectElement);
     tick();
 
     expect(component.selectedIndexChange.emit).toHaveBeenCalledWith(selectIndex);
+  }));
+
+  it('should set tabindex correctly on pressing arrow-right', fakeAsync(() => {
+    const selectIndex = 1;
+    const selectElement = tabButtons[selectIndex];
+
+    spectator.click(selectElement);
+    tick();
+    spectator.dispatchKeyboardEvent(selectElement, 'keydown', 'ArrowRight');
+
+    tabButtons.forEach((tabButton, index) =>
+      expect(tabButton).toHaveAttribute('tabindex', index === selectIndex + 1 ? '0' : '-1')
+    );
+  }));
+
+  it('should set tabindex correctly on pressing arrow-left', fakeAsync(() => {
+    const selectIndex = 1;
+    const selectElement = tabButtons[selectIndex];
+
+    spectator.click(selectElement);
+    tick();
+    spectator.dispatchKeyboardEvent(selectElement, 'keydown', 'ArrowLeft');
+
+    tabButtons.forEach((tabButton, index) =>
+      expect(tabButton).toHaveAttribute('tabindex', index === selectIndex - 1 ? '0' : '-1')
+    );
+  }));
+
+  it('should set tabindex and aria-selected correctly on setting selectedIndex', fakeAsync(() => {
+    const selectIndex = 1;
+
+    component.selectedIndex = selectIndex;
+    tick();
+
+    tabButtons.forEach((tabButton, index) => {
+      expect(tabButton).toHaveAttribute('tabindex', index === selectIndex ? '0' : '-1');
+      expect(tabButton).toHaveAttribute('aria-selected', index === selectIndex ? 'true' : 'false');
+    });
+  }));
+
+  it('should set tabindex and aria-selected correctly on tab selection', fakeAsync(() => {
+    const selectIndex = 1;
+    const selectElement = tabButtons[selectIndex];
+
+    spectator.click(selectElement);
+    tick();
+
+    tabButtons.forEach((tabButton, index) => {
+      expect(tabButton).toHaveAttribute('tabindex', index === selectIndex ? '0' : '-1');
+      expect(tabButton).toHaveAttribute('aria-selected', index === selectIndex ? 'true' : 'false');
+    });
   }));
 });


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2935 

## What is the new behavior?

This enhancement add roving tabindex for preserving tab selection and implements the w3c recommended accessibility patterns related to tabs. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

