### PR TITLE
Add new breakpoints and reuse in Grid & Page

### DIFF
--- a/libs/core/src/scss/base/_variables.scss
+++ b/libs/core/src/scss/base/_variables.scss
@@ -93,6 +93,13 @@ $breakpoints: (
   xlarge: 60em,
   xxlarge: 80em,
 ) !default;
+$breakpoint-map: (
+  'xs': 0,
+  'sm': 632px,
+  'md': 768px,
+  'lg': 992px,
+  'xl': 1200px,
+);
 
 /* Elevation
 ****************************************************************************/

--- a/libs/core/src/scss/components/_grid.scss
+++ b/libs/core/src/scss/components/_grid.scss
@@ -2,13 +2,6 @@
 @use '../utils';
 
 /* stylelint-disable custom-property-pattern */
-$breakpoint-map: (
-  'xs': 0,
-  'sm': 632px,
-  'md': 768px,
-  'lg': 992px,
-  'xl': 1200px,
-);
 
 .kirby-grid {
   --kirby-grid-columns: 12;
@@ -132,7 +125,7 @@ $breakpoint-map: (
 }
 
 @mixin breakpoint-style($breakpoint) {
-  @media (min-width: map.get($breakpoint-map, $breakpoint)) {
+  @media (min-width: map.get(utils.$breakpoint-map, $breakpoint)) {
     @include column-style($breakpoint, 1);
     @include column-style($breakpoint, 2);
     @include column-style($breakpoint, 3);

--- a/libs/designsystem/page/src/page.component.scss
+++ b/libs/designsystem/page/src/page.component.scss
@@ -3,13 +3,6 @@
 @use '@kirbydesign/core/src/scss/utils';
 
 $ion-content-padding-top: utils.size('xs');
-$breakpoint-map: (
-  'xs': 0,
-  'sm': 632px,
-  'md': 768px,
-  'lg': 992px,
-  'xl': 1200px,
-);
 
 /*
  * Page Header
@@ -224,7 +217,7 @@ ion-content {
   --background: #{utils.get-color('background-color')};
   --color: #{utils.get-color('black')};
 
-  @media (min-width: map.get($breakpoint-map, 'sm')) {
+  @media (min-width: map.get(utils.$breakpoint-map, 'sm')) {
     --padding-start: var(--page-content-padding-start, #{utils.size('xxl')});
     --padding-end: var(--page-content-padding-end, #{utils.size('xxl')});
   }


### PR DESCRIPTION
## What is the new behavior?

This doesn't change the behaviour in any way but just moves the breakpoint to a shared location and then reuses it across components.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?
Not to sure if there is a better way of having an old and new sets of breakpoints, if the naming should have been different or something. Feel free to come with suggestions :-) 

With this change we would have an old set of breakpoints named "$breakpoints" and a new set called "$breakpoint-map".

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [ ] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] ~~Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be merged to `develop` by Team Kirby.

