### PR TITLE
Add box shadow to buttons with attention level 3

### DIFF
--- a/libs/designsystem/button/src/button.component.integration.spec.ts
+++ b/libs/designsystem/button/src/button.component.integration.spec.ts
@@ -25,6 +25,7 @@ import { ButtonComponent } from './button.component';
 const getColor = DesignTokenHelper.getColor;
 const size = DesignTokenHelper.size;
 const fontSize = DesignTokenHelper.fontSize;
+const getElevation = DesignTokenHelper.getElevation;
 
 describe('ButtonComponent in Kirby Page', () => {
   let spectator: SpectatorHost<PageComponent>;
@@ -562,5 +563,71 @@ describe('ButtonComponent configured with text and icon using an ngIf directive'
     element = spectator.element as HTMLButtonElement;
 
     expect(element).not.toHaveClass('icon-only');
+  });
+});
+
+describe('ButtonComponent with attention-level 3 in a parent with the "kirby-color-brightness-light" class', () => {
+  let spectator: SpectatorHost<ButtonComponent>;
+  const createHost = createHostFactory({
+    component: ButtonComponent,
+  });
+
+  beforeEach(() => {
+    spectator = createHost(
+      `<div class="kirby-color-brightness-light">
+        <button kirby-button attentionLevel="3">
+          <span>Text</span>
+        </button>
+      </div>`
+    );
+  });
+
+  it('should have a box-shadow', () => {
+    const button = spectator.queryHost('button[kirby-button]');
+    expect(button).toHaveComputedStyle({ 'box-shadow': getElevation(2) });
+  });
+});
+
+describe('ButtonComponent with attention-level 3 in a parent with the "kirby-color-brightness-white" class', () => {
+  let spectator: SpectatorHost<ButtonComponent>;
+  const createHost = createHostFactory({
+    component: ButtonComponent,
+  });
+
+  beforeEach(() => {
+    spectator = createHost(
+      `<div class="kirby-color-brightness-white">
+      <button kirby-button attentionLevel="3">
+          <span>Text</span>
+        </button>
+      </div>`
+    );
+  });
+
+  it('should not have a box-shadow', () => {
+    const button = spectator.queryHost('button[kirby-button]');
+    expect(button).toHaveComputedStyle({ 'box-shadow': 'none' });
+  });
+});
+
+describe('ButtonComponent with attention-level 3 in a parent with the "kirby-color-brightness-dark" class', () => {
+  let spectator: SpectatorHost<ButtonComponent>;
+  const createHost = createHostFactory({
+    component: ButtonComponent,
+  });
+
+  beforeEach(() => {
+    spectator = createHost(
+      `<div class="kirby-color-brightness-dark">
+        <button kirby-button attentionLevel="3">
+          <span>Text</span>
+        </button>
+      </div>`
+    );
+  });
+
+  it('should not have a box-shadow', () => {
+    const button = spectator.queryHost('button[kirby-button]');
+    expect(button).toHaveComputedStyle({ 'box-shadow': 'none' });
   });
 });

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -264,6 +264,12 @@ $button-width: (
   }
 }
 
+:host-context(.kirby-color-brightness-white) {
+  &.attention-level3 {
+    box-shadow: none;
+  }
+}
+
 :host-context(.kirby-color-brightness-dark) {
   &.no-decoration {
     --kirby-button-color: #{utils.get-color('white')};
@@ -283,6 +289,8 @@ $button-width: (
   &.attention-level3 {
     @include interaction-state.apply-hover('xxxs', $make-lighter: true);
     @include interaction-state.apply-active('xxs', $make-lighter: true);
+
+    box-shadow: none;
   }
 }
 

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -128,6 +128,8 @@ $button-width: (
 
   @include interaction-state.apply-hover('xs');
   @include interaction-state.apply-active('s');
+
+  box-shadow: utils.get-elevation(2);
 }
 
 :host {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2938

## What is the new behavior?
Buttons with attention level 3 now have a box shadow

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

