### PR TITLE
Revert "Add box shadow to buttons with attention level 3"

### DIFF
--- a/libs/designsystem/button/src/button.component.integration.spec.ts
+++ b/libs/designsystem/button/src/button.component.integration.spec.ts
@@ -25,7 +25,6 @@ import { ButtonComponent } from './button.component';
 const getColor = DesignTokenHelper.getColor;
 const size = DesignTokenHelper.size;
 const fontSize = DesignTokenHelper.fontSize;
-const getElevation = DesignTokenHelper.getElevation;
 
 describe('ButtonComponent in Kirby Page', () => {
   let spectator: SpectatorHost<PageComponent>;
@@ -563,71 +562,5 @@ describe('ButtonComponent configured with text and icon using an ngIf directive'
     element = spectator.element as HTMLButtonElement;
 
     expect(element).not.toHaveClass('icon-only');
-  });
-});
-
-describe('ButtonComponent with attention-level 3 in a parent with the "kirby-color-brightness-light" class', () => {
-  let spectator: SpectatorHost<ButtonComponent>;
-  const createHost = createHostFactory({
-    component: ButtonComponent,
-  });
-
-  beforeEach(() => {
-    spectator = createHost(
-      `<div class="kirby-color-brightness-light">
-        <button kirby-button attentionLevel="3">
-          <span>Text</span>
-        </button>
-      </div>`
-    );
-  });
-
-  it('should have a box-shadow', () => {
-    const button = spectator.queryHost('button[kirby-button]');
-    expect(button).toHaveComputedStyle({ 'box-shadow': getElevation(2) });
-  });
-});
-
-describe('ButtonComponent with attention-level 3 in a parent with the "kirby-color-brightness-white" class', () => {
-  let spectator: SpectatorHost<ButtonComponent>;
-  const createHost = createHostFactory({
-    component: ButtonComponent,
-  });
-
-  beforeEach(() => {
-    spectator = createHost(
-      `<div class="kirby-color-brightness-white">
-      <button kirby-button attentionLevel="3">
-          <span>Text</span>
-        </button>
-      </div>`
-    );
-  });
-
-  it('should not have a box-shadow', () => {
-    const button = spectator.queryHost('button[kirby-button]');
-    expect(button).toHaveComputedStyle({ 'box-shadow': 'none' });
-  });
-});
-
-describe('ButtonComponent with attention-level 3 in a parent with the "kirby-color-brightness-dark" class', () => {
-  let spectator: SpectatorHost<ButtonComponent>;
-  const createHost = createHostFactory({
-    component: ButtonComponent,
-  });
-
-  beforeEach(() => {
-    spectator = createHost(
-      `<div class="kirby-color-brightness-dark">
-        <button kirby-button attentionLevel="3">
-          <span>Text</span>
-        </button>
-      </div>`
-    );
-  });
-
-  it('should not have a box-shadow', () => {
-    const button = spectator.queryHost('button[kirby-button]');
-    expect(button).toHaveComputedStyle({ 'box-shadow': 'none' });
   });
 });

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -128,8 +128,6 @@ $button-width: (
 
   @include interaction-state.apply-hover('xs');
   @include interaction-state.apply-active('s');
-
-  box-shadow: utils.get-elevation(2);
 }
 
 :host {
@@ -264,12 +262,6 @@ $button-width: (
   }
 }
 
-:host-context(.kirby-color-brightness-white) {
-  &.attention-level3 {
-    box-shadow: none;
-  }
-}
-
 :host-context(.kirby-color-brightness-dark) {
   &.no-decoration {
     --kirby-button-color: #{utils.get-color('white')};
@@ -289,8 +281,6 @@ $button-width: (
   &.attention-level3 {
     @include interaction-state.apply-hover('xxxs', $make-lighter: true);
     @include interaction-state.apply-active('xxs', $make-lighter: true);
-
-    box-shadow: none;
   }
 }
 


### PR DESCRIPTION
Reverts kirbydesign/designsystem#2943 as the solution prevents focus rings on buttons with attention level 3. Additionally, the solution should be changed to utilize the `--kirby-inputs-elevation` css variable, which is made for this exact use-case.