### PR TITLE
Enhancement/2955 tab navigation final review findings

### DIFF
--- a/libs/designsystem/dropdown/src/dropdown.component.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.ts
@@ -588,8 +588,8 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
 
     const newFocusedIndex = this.keyboardHandlerService.handle(
       event,
-      this.items,
-      this.focusedIndex
+      this.focusedIndex,
+      this.items.length - 1
     );
 
     if (newFocusedIndex > -1) {
@@ -607,8 +607,8 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
 
     const newFocusedIndex = this.keyboardHandlerService.handle(
       event,
-      this.items,
-      this.focusedIndex
+      this.focusedIndex,
+      this.items.length - 1
     );
     if (newFocusedIndex > -1) {
       this.focusedIndex = newFocusedIndex;

--- a/libs/designsystem/dropdown/src/keyboard-handler.service.ts
+++ b/libs/designsystem/dropdown/src/keyboard-handler.service.ts
@@ -4,17 +4,26 @@ import { Injectable } from '@angular/core';
   providedIn: 'root',
 })
 export class KeyboardHandlerService {
-  handle(event: KeyboardEvent, items: any[] | string[], selectedIndex: number) {
+  handle(
+    event: KeyboardEvent,
+    items: any[] | string[],
+    selectedIndex: number,
+    cyclicIndex?: boolean
+  ) {
     let newIndex = -1;
     switch (event.key) {
       case 'ArrowUp':
       case 'ArrowLeft':
-        // Select previous item:
-        newIndex = selectedIndex - 1;
+        if (selectedIndex === 0 && cyclicIndex) {
+          newIndex = items.length - 1;
+        } else {
+          // Select previous item:
+          newIndex = selectedIndex - 1;
+        }
         break;
       case 'ArrowDown':
       case 'ArrowRight':
-        if (selectedIndex === undefined) {
+        if (selectedIndex === undefined || (selectedIndex === items.length - 1 && cyclicIndex)) {
           // None selected, select first item:
           newIndex = 0;
         } else if (selectedIndex < items.length - 1) {

--- a/libs/designsystem/dropdown/src/keyboard-handler.service.ts
+++ b/libs/designsystem/dropdown/src/keyboard-handler.service.ts
@@ -4,18 +4,13 @@ import { Injectable } from '@angular/core';
   providedIn: 'root',
 })
 export class KeyboardHandlerService {
-  handle(
-    event: KeyboardEvent,
-    items: any[] | string[],
-    selectedIndex: number,
-    cyclicIndex?: boolean
-  ) {
+  handle(event: KeyboardEvent, selectedIndex: number, maxIndex: number, cyclicIndex = false) {
     let newIndex = -1;
     switch (event.key) {
       case 'ArrowUp':
       case 'ArrowLeft':
         if (selectedIndex === 0 && cyclicIndex) {
-          newIndex = items.length - 1;
+          newIndex = maxIndex;
         } else {
           // Select previous item:
           newIndex = selectedIndex - 1;
@@ -23,10 +18,10 @@ export class KeyboardHandlerService {
         break;
       case 'ArrowDown':
       case 'ArrowRight':
-        if (selectedIndex === undefined || (selectedIndex === items.length - 1 && cyclicIndex)) {
+        if (selectedIndex === undefined || (selectedIndex === maxIndex && cyclicIndex)) {
           // None selected, select first item:
           newIndex = 0;
-        } else if (selectedIndex < items.length - 1) {
+        } else if (selectedIndex < maxIndex) {
           // Select next item:
           newIndex = selectedIndex + 1;
         }
@@ -37,7 +32,7 @@ export class KeyboardHandlerService {
         break;
       case 'End':
         // Select last item:
-        newIndex = items.length - 1;
+        newIndex = maxIndex;
         break;
       default:
         break;

--- a/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.scss
+++ b/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.scss
@@ -6,32 +6,40 @@ $border-color-standard: utils.get-color('medium');
 $border-color-selected: utils.get-color('dark');
 $divider-max-width-breakpoint: utils.$page-content-max-width + (utils.size('s') * 2);
 
+@mixin button-reset {
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  white-space: nowrap;
+  user-select: none;
+  text-decoration: none;
+  margin: 0;
+  padding: 0;
+  width: auto;
+  border: none;
+  outline: none;
+}
+
 :host {
   position: relative;
   padding-bottom: $bottom-border-height * 2;
 
   button[role='tab'] {
-    font-family: inherit;
+    @include button-reset;
+
     background-color: utils.get-color('background-color');
     color: utils.get-color('black');
-    padding: utils.size('s');
-    margin: 0;
-    font-size: utils.font-size('n');
-    font-weight: inherit;
-    line-height: utils.line-height('m');
-    cursor: pointer;
     box-sizing: border-box; // Ensure border is not added to button height
-    display: inline-flex;
+    padding: utils.size('s');
+    font-size: utils.font-size('n');
+    line-height: utils.line-height('m');
     gap: utils.size('xxxs');
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
-    vertical-align: middle;
-    white-space: nowrap;
-    user-select: none;
-    text-decoration: none;
-    border: none;
-    outline: none;
 
     &:focus,
     &:hover {

--- a/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.ts
+++ b/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.ts
@@ -10,7 +10,7 @@ export class TabNavigationItemComponent {
   @Input()
   label = '';
 
-  constructor(private elementRef: ElementRef<HTMLElement>) {
+  constructor() {
     /* */
   }
 }

--- a/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.scss
+++ b/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.scss
@@ -14,7 +14,6 @@ div[role='tablist'] {
   align-items: center;
   justify-content: left;
   flex-wrap: nowrap;
-  overflow-y: hidden;
   overflow-x: scroll;
 
   @include utils.media('<medium') {

--- a/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.ts
+++ b/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.ts
@@ -7,18 +7,13 @@ import {
   EventEmitter,
   HostListener,
   Input,
-  OnDestroy,
   Output,
   QueryList,
   ViewChild,
 } from '@angular/core';
-import { filter, fromEvent, map, Subject, takeUntil, tap } from 'rxjs';
 import { WindowRef } from '@kirbydesign/designsystem/types';
 import { KeyboardHandlerService } from '@kirbydesign/designsystem/dropdown';
 import { TabNavigationItemComponent } from '../tab-navigation-item/tab-navigation-item.component';
-
-const ARROW_LEFT = 'ArrowLeft';
-const ARROW_RIGHT = 'ArrowRight';
 
 @Component({
   selector: 'kirby-tab-navigation',
@@ -26,7 +21,7 @@ const ARROW_RIGHT = 'ArrowRight';
   styleUrls: ['./tab-navigation.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TabNavigationComponent implements AfterViewInit, OnDestroy {
+export class TabNavigationComponent implements AfterViewInit {
   public readonly DEBOUNCE_TIME_MS = 250;
 
   @ViewChild('tabBar')
@@ -38,7 +33,6 @@ export class TabNavigationComponent implements AfterViewInit, OnDestroy {
   private tabBarElement: HTMLElement;
   private tabElements = new Array<HTMLElement>();
   private tabButtonElements = new Array<HTMLElement>();
-  private destroyed$ = new Subject<void>();
 
   @Input()
   get selectedIndex(): number {
@@ -96,17 +90,12 @@ export class TabNavigationComponent implements AfterViewInit, OnDestroy {
     event.preventDefault();
     const newFocusIndex = this.keyboardHandlerService.handle(
       event,
-      this.tabElements,
       this._focusIndex,
+      this.tabElements.length - 1,
       true
     );
 
     this.focusTab(newFocusIndex);
-  }
-
-  ngOnDestroy(): void {
-    this.destroyed$.next();
-    this.destroyed$.complete();
   }
 
   private selectTab(tabIndex: number): void {

--- a/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.ts
+++ b/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.ts
@@ -43,15 +43,25 @@ export class TabNavigationComponent implements AfterViewInit {
     if (index !== this._selectedIndex) {
       this._selectedIndex = index;
 
-      setTimeout(() => {
-        this.scrollToTab(this.selectedIndex);
-        this.focusTab(this.selectedIndex);
-        this.selectTab(this.selectedIndex);
-        this.selectedIndexChange.emit(this.selectedIndex);
-      });
+      this.focusIndex = index;
+      this.selectTab(this.selectedIndex);
+      this.selectedIndexChange.emit(this.selectedIndex);
     }
   }
   private _selectedIndex = -1;
+
+  get focusIndex(): number {
+    return this._focusIndex;
+  }
+
+  set focusIndex(index: number) {
+    if (index !== this._focusIndex) {
+      this._focusIndex = index;
+
+      this.scrollToTab(this.focusIndex);
+      this.focusTab(this.focusIndex);
+    }
+  }
   private _focusIndex = -1;
 
   @Output()
@@ -70,8 +80,8 @@ export class TabNavigationComponent implements AfterViewInit {
 
     setTimeout(() => {
       this.selectTab(this.selectedIndex);
-      this.scrollToTab(this.selectedIndex);
-      this.focusTab(this.selectedIndex);
+      this.scrollToTab(this.focusIndex);
+      this.focusTab(this.focusIndex);
     }, this.DEBOUNCE_TIME_MS);
   }
 
@@ -88,14 +98,12 @@ export class TabNavigationComponent implements AfterViewInit {
   @HostListener('keydown.arrowleft', ['$event'])
   onKeydown(event: KeyboardEvent) {
     event.preventDefault();
-    const newFocusIndex = this.keyboardHandlerService.handle(
+    this.focusIndex = this.keyboardHandlerService.handle(
       event,
-      this._focusIndex,
+      this.focusIndex,
       this.tabElements.length - 1,
       true
     );
-
-    this.focusTab(newFocusIndex);
   }
 
   private selectTab(tabIndex: number): void {
@@ -105,13 +113,13 @@ export class TabNavigationComponent implements AfterViewInit {
   }
 
   private focusTab(focusIndex: number): void {
-    this._focusIndex = focusIndex;
-
     this.tabButtonElements.forEach((tabButtonElement, index) => {
       tabButtonElement.setAttribute('tabindex', index === focusIndex ? '0' : '-1');
     });
 
-    this.tabButtonElements[focusIndex].focus();
+    if (0 <= focusIndex && focusIndex < this.tabButtonElements.length) {
+      this.tabButtonElements[focusIndex].focus();
+    }
   }
 
   private scrollToTab(tabIndex: number): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "coveralls": "3.0.2",
         "eslint": "8.15.0",
         "eslint-config-prettier": "8.1.0",
-        "eslint-plugin-import": "*",
+        "eslint-plugin-import": "latest",
         "eslint-plugin-jasmine": "^4.1.3",
         "eslint-plugin-prettier": "^4.2.1",
         "fs-extra": "^8.1.0",


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2955 

## What is the new behavior?

This corrects the findings from the last code-review of the component.

Describe the solution you'd like
- Extend KeyboardHandlerService and use Angular hostlisteners for event listening on tabs .
- Avoid setTimeout in setSelectedIndex, remove no longer needed element-ref and overflow-y .
- Move button-reset styling to mixin.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

