### PR TITLE
Add box shadow to buttons with attention level 3

### DIFF
--- a/libs/core/src/scss/themes/_component-themes.scss
+++ b/libs/core/src/scss/themes/_component-themes.scss
@@ -10,6 +10,7 @@
   --kirby-inputs-indicator-background-color: var(--kirby-white);
   --kirby-inputs-indicator-color: var(--kirby-black);
   --kirby-inputs-placeholder-color: var(--kirby-white-overlay-50);
+  --kirby-inputs-elevation: none;
 }
 
 @mixin apply-white-theme {
@@ -20,6 +21,7 @@
   --kirby-inputs-indicator-background-color: var(--kirby-black);
   --kirby-inputs-indicator-color: var(--kirby-white);
   --kirby-inputs-placeholder-color: var(--kirby-semi-dark);
+  --kirby-inputs-elevation: none;
 }
 
 @mixin apply-light-theme {

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -146,10 +146,6 @@ $button-width: (
     align-items: inherit;
     justify-content: inherit;
     padding-inline: var(--kirby-button-padding-left) var(--kirby-button-padding-right);
-
-    &.attention-level3 {
-      box-shadow: var(--kirby-inputs-elevation);
-    }
   }
 
   font-family: var(--kirby-font-family);
@@ -236,6 +232,10 @@ $button-width: (
 
   &.attention-level3 {
     @include button-attentionlevel3;
+
+    .state-layer {
+      box-shadow: var(--kirby-inputs-elevation);
+    }
   }
 
   &[expand='block'] {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2938

## What is the new behavior?
Buttons with attention level 3 now have a box shadow

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

