### PR TITLE
Add Modal V2 to KirbyModule

### DIFF
--- a/libs/designsystem/src/lib/index.ts
+++ b/libs/designsystem/src/lib/index.ts
@@ -26,6 +26,7 @@ export * from '@kirbydesign/designsystem/kirby-ionic-module';
 export * from '@kirbydesign/designsystem/list';
 export * from '@kirbydesign/designsystem/loading-overlay';
 export * from '@kirbydesign/designsystem/modal';
+export * from '@kirbydesign/designsystem/modal/v2';
 export * from '@kirbydesign/designsystem/page';
 export * from '@kirbydesign/designsystem/popover';
 export * from '@kirbydesign/designsystem/progress-circle';

--- a/libs/designsystem/src/lib/kirby.module.ts
+++ b/libs/designsystem/src/lib/kirby.module.ts
@@ -60,6 +60,7 @@ import {
   ModalHelper,
   ModalWrapperComponent,
 } from '@kirbydesign/designsystem/modal';
+import { KirbyModalModule } from '@kirbydesign/designsystem/modal/v2';
 import { PageModule } from '@kirbydesign/designsystem/page';
 import { HeaderModule } from '@kirbydesign/designsystem/header';
 import { EmptyStateModule } from '@kirbydesign/designsystem/empty-state';
@@ -144,6 +145,7 @@ const exportedModules = [
   SlideModule,
   AccordionModule,
   HeaderModule,
+  KirbyModalModule,
   ...standaloneComponents,
 ];
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?
Modal V2 is now exported through KirbyModule

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

