### PR TITLE
Fix modal routing cookbook examples

### DIFF
--- a/apps/cookbook/src/app/examples/modal-v2-example/modal-routing/modal-routing-v2-example-page1.component.ts
+++ b/apps/cookbook/src/app/examples/modal-v2-example/modal-routing/modal-routing-v2-example-page1.component.ts
@@ -18,8 +18,7 @@ import { ActivatedRoute } from '@angular/router';
       </p>
 
       <kirby-modal-v2-footer themeColor="white" class="footer" footer>
-        <button kirby-button class="nav" routerLink="../page2">
-          Next
+        <button kirby-button class="nav" routerLink="../page2" nav-next>
           <kirby-icon name="arrow-more"></kirby-icon>
         </button>
       </kirby-modal-v2-footer>

--- a/apps/cookbook/src/app/examples/modal-v2-example/modal-routing/modal-routing-v2-example-page2.component.ts
+++ b/apps/cookbook/src/app/examples/modal-v2-example/modal-routing/modal-routing-v2-example-page2.component.ts
@@ -16,7 +16,7 @@ import { ActivatedRoute, Router } from '@angular/router';
       </p>
 
       <kirby-modal-v2-footer themeColor="white" class="footer" footer>
-        <button kirby-button attentionLevel="3" routerLink="../page1">
+        <button kirby-button attentionLevel="3" routerLink="../page1" nav-prev>
           <kirby-icon name="arrow-back"></kirby-icon>
         </button>
         <button kirby-button (click)="closeModal()">Finish</button>

--- a/libs/designsystem/modal/v2/src/modal-routing/modal-routing.component.html
+++ b/libs/designsystem/modal/v2/src/modal-routing/modal-routing.component.html
@@ -1,4 +1,4 @@
-<ion-modal [isOpen]="isOpen" (willDismiss)="closeModal()">
+<ion-modal [isOpen]="isOpen" (willDismiss)="closeModal()" class="kirby-modal-v2">
   <ng-template>
     <div fxFlex class="outlet-container">
       <router-outlet></router-outlet>


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?
The correct border-radius is applied to the routing modal, and it correctly utilizes the `nav-next` and `nav-prev` slots for the navigation buttons

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

