### PR TITLE
Add PageBackButtonOverride as Interface

### DIFF
--- a/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.html
@@ -155,11 +155,11 @@
 
   <p>
     In rare use cases where it might be necessary to take complete control over the back button
-    behavior Kirby Page exposes an injection token for just this.
+    behavior Kirby Page exposes an injection token for exactly this.
   </p>
   <p>
     When the token is provided the supplied
-    <code>PageBackButtonOverride</code>
+    <code>PageBackButtonOverride.navigateBack()</code>
     callback is executed whenever the back button is pressed. Within the method, you will have
     access to the specific
     <code>NavController</code>

--- a/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.ts
@@ -187,7 +187,9 @@ export class PageShowcaseComponent {
     },
   ];
 
-  public injectionTokenExample = `@Injectable({
+  public injectionTokenExample = `import { PAGE_BACK_BUTTON_OVERRIDE, PageBackButtonOverride } from '@kirbydesign/designsystem';
+  
+@Injectable({
   providedIn: 'root',
 })
 export class MyBackButtonOverrideService implements PageBackButtonOverride {

--- a/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.ts
@@ -187,7 +187,7 @@ export class PageShowcaseComponent {
     },
   ];
 
-  public injectionTokenExample = `import { PAGE_BACK_BUTTON_OVERRIDE, PageBackButtonOverride } from '@kirbydesign/designsystem';
+  public injectionTokenExample = `import { PAGE_BACK_BUTTON_OVERRIDE, PageBackButtonOverride } from '@kirbydesign/designsystem/page';
   
 @Injectable({
   providedIn: 'root',

--- a/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.ts
@@ -187,20 +187,31 @@ export class PageShowcaseComponent {
     },
   ];
 
-  public injectionTokenExample = `export const MY_BACK_BUTTON_OVERRIDE: PageBackButtonOverride = (routerOutlet, navCtrl, defaultHref) => {
+  public injectionTokenExample = `@Injectable({
+  providedIn: 'root',
+})
+export class MyBackButtonOverrideService implements PageBackButtonOverride {
+  constructor(private someDependency: SomeDependency) {}
+
+  navigateBack(routerOutlet: IonRouterOutlet, navCtrl: NavController, defaultBackHref: string) {
     if (routerOutlet?.canGoBack()) {
-      // custom logic could go here
-      routerOutlet.pop()
+      // custom use of some dependency could go here:
+      this.someDependency.doSomething();
+
+      // and we might still want to use the provided router outlet for something:
+      routerOutlet.pop();
+    } else {
+      // custom use of some dependency could also go here:
+      this.someDependency.doSomethingElse();
+
+      // and we might still want to use the provided nav controller for something:
+      navCtrl.navigateBack(defaultBackHref);
     }
-    else {
-      // or here
-      navCtrl.navigateBack(defaultHref);
   }
 }
 
-// then supplied like this in providers array 
-
-{ provide: PAGE_BACK_BUTTON_OVERRIDE, useValue: MY_BACK_BUTTON_OVERRIDE },
+// then provided like this in the providers array (e.g. in app.module.ts)
+{ provide: PAGE_BACK_BUTTON_OVERRIDE, useClass: MyBackButtonOverrideService },
 `;
 
   public pageHtml = `<kirby-page\n (enter)="startSubscription()"\n (leave)="stopSubscription()"\n></kirby-page>`;

--- a/libs/designsystem/page/src/page.component.ts
+++ b/libs/designsystem/page/src/page.component.ts
@@ -67,11 +67,13 @@ export const PAGE_BACK_BUTTON_OVERRIDE = new InjectionToken<PageBackButtonOverri
   'page-back-button-override'
 );
 
-export type PageBackButtonOverride = (
-  routerOutlet: IonRouterOutlet,
-  navCtrl: NavController,
-  defaultBackHref: string
-) => void;
+export interface PageBackButtonOverride {
+  navigateBack: (
+    routerOutlet: IonRouterOutlet,
+    navCtrl: NavController,
+    defaultBackHref: string
+  ) => void;
+}
 
 /**
  * Event emitted when "pull-to-refresh" begins.
@@ -473,7 +475,7 @@ export class PageComponent
     if (this.backButtonOverride) {
       this.backButtonDelegate.onClick = (event: Event) => {
         event.preventDefault();
-        this.backButtonOverride(this.routerOutlet, this.navCtrl, this.defaultBackHref);
+        this.backButtonOverride.navigateBack(this.routerOutlet, this.navCtrl, this.defaultBackHref);
       };
     }
 


### PR DESCRIPTION
## What is the new behavior?
In #2963 we created a type for the PageBackButtonOverride callback on page's back button click when the appropriate InjectionToken is provided in projects. This is now an interface instead for ease of use as consumers can more easily provide a class (e.g. a service) where they can use standard dependency injection to get a hold of their own dependencies and call them in our provided callback: 

```
@Injectable({
  providedIn: 'root',
})
export class MyBackButtonOverride implements PageBackButtonOverride {
  constructor(private someDependency: SomeDependency) {}

  navigateBack(routerOutlet: IonRouterOutlet, navCtrl: NavController, defaultBackHref: string) {
    if (routerOutlet?.canGoBack()) {
      // custom use of some dependency could go here
      this.someDependency.doSomething();

      // and we might still want to use the provided router outlet for something:
      routerOutlet.pop();
    } else {
      // custom use of some dependency could also go here
      this.someDependency.doSomethingElse();

      // and we might still want to use the provided nav controller for something:
      navCtrl.navigateBack(defaultBackHref);
    }
  }
}
``` 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No - #2963 is not released yet, so not an actual breaking change.


## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

