### PR TITLE
Fix missing dependency for portal directive and  mismatch in reference getter/setter types

### DIFF
--- a/libs/designsystem/ng-package.json
+++ b/libs/designsystem/ng-package.json
@@ -10,6 +10,7 @@
     "@ionic/angular",
     "@kirbydesign/core",
     "@floating-ui/dom",
+    "@angular/cdk",
     "inputmask"
   ]
 }

--- a/libs/designsystem/package.json
+++ b/libs/designsystem/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "dependencies": {
     "@floating-ui/dom": "^1.1.0",
+    "@angular/cdk": "^15.0.3",
     "@fontsource/roboto": "4.2.1",
     "@ionic/angular": "6.2.1",
     "@kirbydesign/core": "0.0.46",

--- a/libs/designsystem/shared/floating/src/floating.directive.ts
+++ b/libs/designsystem/shared/floating/src/floating.directive.ts
@@ -67,14 +67,14 @@ export class FloatingDirective implements OnInit, OnDestroy {
   /**
    * Reference to the element for which the host should anchor to
    * */
-  @Input() public set reference(ref: ElementRef) {
+  @Input() public set reference(ref: ElementRef<HTMLElement> | undefined) {
     this.tearDownReferenceElementEventHandling();
     this._reference = ref;
     this.setupEventHandling();
     this.autoUpdatePosition();
   }
 
-  public get reference(): ElementRef | undefined {
+  public get reference(): ElementRef<HTMLElement> | undefined {
     return this._reference;
   }
 
@@ -198,7 +198,7 @@ export class FloatingDirective implements OnInit, OnDestroy {
 
   private _triggers: Array<TriggerEvent> = ['click'];
 
-  private _reference: ElementRef | undefined;
+  private _reference: ElementRef<HTMLElement> | undefined;
 
   private autoUpdaterRef: () => void;
   private isShown: boolean = false;
@@ -402,6 +402,7 @@ export class FloatingDirective implements OnInit, OnDestroy {
   }
 
   private handleClickOutsideHostElement(event: Event): void {
+    if (!(event.target instanceof HTMLElement)) return;
     const clickedOnReferenceWithClickTriggerEnabled: boolean =
       this.reference?.nativeElement.contains(event.target) && this.triggers.includes('click');
 

--- a/libs/designsystem/shared/floating/src/floating.directive.ts
+++ b/libs/designsystem/shared/floating/src/floating.directive.ts
@@ -402,12 +402,13 @@ export class FloatingDirective implements OnInit, OnDestroy {
   }
 
   private handleClickOutsideHostElement(event: Event): void {
-    if (!(event.target instanceof HTMLElement)) return;
-    const clickedOnReferenceWithClickTriggerEnabled: boolean =
-      this.reference?.nativeElement.contains(event.target) && this.triggers.includes('click');
+    if (event.target instanceof Node) {
+      const clickedOnReferenceWithClickTriggerEnabled: boolean =
+        this.reference?.nativeElement.contains(event.target) && this.triggers.includes('click');
 
-    if (this.closeOnBackdrop && !clickedOnReferenceWithClickTriggerEnabled) {
-      this.hide();
+      if (this.closeOnBackdrop && !clickedOnReferenceWithClickTriggerEnabled) {
+        this.hide();
+      }
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "designsystem",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "designsystem",
-      "version": "8.3.0",
+      "version": "8.3.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "designsystem",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "Kirby Design Angular Components. This library provides Angular wrappers for the @kirbydesign/core package, for smoother integration into Angular projects.",
   "engines": {
     "node": ">=16.0.0 <=18.13.0",


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue but fixes two compile-time problems that occur when installing Kirby v8.3.0:
![image](https://user-images.githubusercontent.com/42470636/228536198-e56f01d2-e698-476e-b529-67b0a4b9eeb4.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

