### PR TITLE
Fix wrong padding in Modal V2 header and content area

### DIFF
--- a/libs/designsystem/modal/v2/src/modal/modal.component.html
+++ b/libs/designsystem/modal/v2/src/modal/modal.component.html
@@ -33,7 +33,7 @@
     <ion-content [scrollEvents]="true" [scrollY]="!scrollDisabled">
       <ion-header *ngIf="hasCollapsibleTitle" collapse="condense">
         <ion-toolbar>
-          <span class="kirby-text-large">{{ title }}</span>
+          <span class="kirby-text-xlarge">{{ title }}</span>
         </ion-toolbar>
       </ion-header>
       <ng-container>

--- a/libs/designsystem/modal/v2/src/modal/modal.component.scss
+++ b/libs/designsystem/modal/v2/src/modal/modal.component.scss
@@ -24,6 +24,7 @@ ion-header {
 
     button {
       background-color: utils.get-color('white');
+      margin-block: 0;
     }
   }
 

--- a/libs/designsystem/modal/v2/src/modal/modal.component.scss
+++ b/libs/designsystem/modal/v2/src/modal/modal.component.scss
@@ -71,10 +71,15 @@ ion-content {
   }
 
   @include utils.media('>=medium') {
-    --padding-top: #{utils.size('xl')};
-    --padding-bottom: #{utils.size('xl')};
     --padding-start: #{utils.size('xxl')};
     --padding-end: #{utils.size('xxl')};
+  }
+
+  ion-toolbar {
+    --padding-start: #{utils.size('s')};
+    --padding-end: #{utils.size('s')};
+    --padding-top: #{utils.size('m')};
+    --padding-bottom: #{utils.size('m')};
   }
 }
 

--- a/libs/designsystem/modal/v2/src/wrapper/wrapper.component.html
+++ b/libs/designsystem/modal/v2/src/wrapper/wrapper.component.html
@@ -17,7 +17,7 @@
 <ion-content [scrollEvents]="true" [scrollY]="!scrollDisabled">
   <ion-header *ngIf="hasCollapsibleTitle" collapse="condense">
     <ion-toolbar>
-      <span class="kirby-text-large">{{ title }}</span>
+      <span class="kirby-text-xlarge">{{ title }}</span>
     </ion-toolbar>
   </ion-header>
   <ng-container>

--- a/libs/designsystem/modal/v2/src/wrapper/wrapper.component.html
+++ b/libs/designsystem/modal/v2/src/wrapper/wrapper.component.html
@@ -1,4 +1,4 @@
-<ion-header>
+<ion-header class="modal-header">
   <ion-toolbar>
     <ng-content select="[header-start]"></ng-content>
     <ion-buttons slot="start" *ngIf="flavor === 'drawer'">

--- a/libs/designsystem/modal/v2/src/wrapper/wrapper.component.scss
+++ b/libs/designsystem/modal/v2/src/wrapper/wrapper.component.scss
@@ -75,10 +75,15 @@ ion-content {
   }
 
   @include utils.media('>=medium') {
-    --padding-top: #{utils.size('xl')};
-    --padding-bottom: #{utils.size('xl')};
     --padding-start: #{utils.size('xxl')};
     --padding-end: #{utils.size('xxl')};
+  }
+
+  ion-toolbar {
+    --padding-start: #{utils.size('s')};
+    --padding-end: #{utils.size('s')};
+    --padding-top: #{utils.size('m')};
+    --padding-bottom: #{utils.size('m')};
   }
 }
 

--- a/libs/designsystem/modal/v2/src/wrapper/wrapper.component.scss
+++ b/libs/designsystem/modal/v2/src/wrapper/wrapper.component.scss
@@ -24,6 +24,7 @@ ion-header {
 
     button {
       background-color: utils.get-color('white');
+      margin-block: 0;
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?
Adjusts paddings in the modal header and content area to reduce excessive whitespace

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

