### PR TITLE
cookbook: indicate when kirby-item receive focus

### DIFF
--- a/apps/cookbook/src/app/app.component.html
+++ b/apps/cookbook/src/app/app.component.html
@@ -1,2 +1,5 @@
-<!-- <cookbook-kirby-christmas></cookbook-kirby-christmas> -->
-<router-outlet></router-outlet>
+<kirby-app>
+  <div class="kirby-app-content">
+    <router-outlet></router-outlet>
+  </div>
+</kirby-app>

--- a/apps/cookbook/src/styles.scss
+++ b/apps/cookbook/src/styles.scss
@@ -53,3 +53,8 @@ code:not([class*='language-']) {
     color: utils.get-color('dark-contrast');
   }
 }
+
+.kirby-app-content {
+  height: 100%;
+  overflow: auto;
+}


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2942

## What is the new behavior?
`kirby-item` will now indicate when tabbed to. Additionally, this update to the cookbook also fixes the issue with modals scrolling to the top of the page, when opened.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?
It might seem random that the fix to the issue is that the cookbook has been wrapped in `kirby-app`, but it is because `ion-item` is dependent on some logic that is executed in one of `ion-app` lifecycle hooks. `kirby-app` wraps `ion-app`, which makes sure that the lifecycle hook is executed. `ion-item` will now get the `ion-focused` class when the element is navigated to by using the tab key.

According to the [ion-app](https://ionicframework.com/docs/api/app) documentation, then the component enables a multiple different behaviours, including: 

> Other tap and focus utilities which make the experience of using an Ionic app feel more native


## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

