### PR TITLE
Remove space between tabs of tab-nav

### DIFF
--- a/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.scss
+++ b/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.scss
@@ -36,7 +36,7 @@ $divider-max-width-breakpoint: utils.$page-content-max-width + (utils.size('s') 
     background-color: utils.get-color('background-color');
     color: utils.get-color('black');
     box-sizing: border-box; // Ensure border is not added to button height
-    padding: utils.size('s');
+    padding: utils.size('s') utils.size('m');
     font-size: utils.font-size('n');
     line-height: utils.line-height('m');
     gap: utils.size('xxxs');

--- a/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.scss
+++ b/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.scss
@@ -10,7 +10,6 @@ div[role='tablist'] {
   position: relative;
   margin: 0 auto;
   display: flex;
-  gap: utils.size('xs');
   align-items: center;
   justify-content: left;
   flex-wrap: nowrap;

--- a/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.ts
+++ b/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.ts
@@ -88,8 +88,10 @@ export class TabNavigationComponent implements AfterViewInit {
   @HostListener('click', ['$event'])
   @HostListener('keydown.enter', ['$event'])
   onItemSelect(event: PointerEvent) {
-    const targetTabNavItem: HTMLElement = (event.target as HTMLElement).closest('button');
-    this.selectedIndex = this.tabButtonElements.indexOf(targetTabNavItem);
+    if (event.target !== this.tabBarElement) {
+      const targetTabNavItem = (event.target as HTMLElement).closest('button');
+      this.selectedIndex = this.tabButtonElements.indexOf(targetTabNavItem);
+    }
   }
 
   @HostListener('keydown.home', ['$event'])


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3004

## What is the new behavior?
Remove space between tab-items of tab-navigation avoiding in-between no-click and no-focus areas.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

