### PR TITLE
added warning about missing directive declaration

### DIFF
--- a/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
@@ -18,7 +18,7 @@
   <code>FormFieldModule</code>
   &nbsp;
   <a href="https://github.com/kirbydesign/designsystem/issues/3007">(See issue here)</a>
-  . A fix will be released in the next major verision of Kirby.
+  . A fix will be released in the next major version of Kirby.
 </p>
 <kirby-divider></kirby-divider>
 <h2>Input</h2>

--- a/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
@@ -1,3 +1,26 @@
+<h2>NB!</h2>
+<p>
+  If you are importing
+  <code>FormFieldModule</code>
+  rather than
+  <code>KirbyModule</code>
+  , you'll also need to import
+  <code>DateInputDirective</code>
+  .
+</p>
+<p>
+  In your module:
+  <code>imports: [ FormFieldModule, DateInputDirective ]</code>
+</p>
+
+<p>
+  This is due to a bug in the
+  <code>FormFieldModule</code>
+  &nbsp;
+  <a href="https://github.com/kirbydesign/designsystem/issues/3007">(See issue here)</a>
+  . A fix will be released in the next major verision of Kirby.
+</p>
+<kirby-divider></kirby-divider>
 <h2>Input</h2>
 <cookbook-form-field-example-configuration
   [(size)]="size"


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3007 

## What is the new behavior?
A cookbook description of how to circumvent the missing Directive.
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?
The fix PR is here: https://github.com/kirbydesign/designsystem/pull/3008
## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [-] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [-] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [-] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

