### PR TITLE
Make the cookbook side-nav scrollable on smaller viewports

### DIFF
--- a/apps/cookbook/src/app/page/side-nav/side-nav.component.scss
+++ b/apps/cookbook/src/app/page/side-nav/side-nav.component.scss
@@ -29,6 +29,11 @@ section {
   padding: 0 $menu-padding-mobile;
   box-shadow: utils.get-elevation(4);
 
+  @include utils.media('<large') {
+    height: 100vh;
+    overflow: auto;
+  }
+
   @include utils.media('>=large') {
     box-shadow: none;
     display: block;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?
The side-nav is now scrollable when it is opened on smaller viewports. PR #2981 introduced a regression that prevents the user from scrolling down and accessing all options in the side-nav.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

