### PR TITLE
bug: setting button nodecoration false resets attentionlevel

### DIFF
--- a/libs/designsystem/button/src/button.component.spec.ts
+++ b/libs/designsystem/button/src/button.component.spec.ts
@@ -183,6 +183,20 @@ describe('ButtonComponent', () => {
           color: getColor('black'),
         });
       });
+
+      describe('and attentionLevel', () => {
+        it('should render with no background-color', () => {
+          spectator.component.attentionLevel = '1';
+          spectator.detectChanges();
+          expect(element).toHaveComputedStyle({ 'background-color': 'transparent' });
+        });
+
+        it('should not reset attentionLevel', () => {
+          spectator.component.attentionLevel = '3';
+          spectator.component.noDecoration = false;
+          expect(spectator.component.attentionLevel).toEqual('3');
+        });
+      });
     });
   });
 

--- a/libs/designsystem/button/src/button.component.spec.ts
+++ b/libs/designsystem/button/src/button.component.spec.ts
@@ -85,15 +85,6 @@ describe('ButtonComponent', () => {
           color: getColor('semi-dark', 'shade'),
         });
       });
-
-      it('should not have a background-color when disabled', () => {
-        expect(element).toHaveComputedStyle({ 'background-color': getColor('semi-light') });
-
-        spectator.component.noDecoration = true;
-        spectator.detectChanges();
-
-        expect(element).toHaveComputedStyle({ 'background-color': 'transparent' });
-      });
     });
 
     describe('when configured with attentionlevel 1', () => {
@@ -181,6 +172,15 @@ describe('ButtonComponent', () => {
       it('should render with correct color', () => {
         expect(element).toHaveComputedStyle({
           color: getColor('black'),
+        });
+      });
+
+      describe('and is disabled', () => {
+        it('should not have a background-color', () => {
+          spectator.component.noDecoration = true;
+          spectator.detectChanges();
+
+          expect(element).toHaveComputedStyle({ 'background-color': 'transparent' });
         });
       });
 

--- a/libs/designsystem/button/src/button.component.ts
+++ b/libs/designsystem/button/src/button.component.ts
@@ -36,30 +36,22 @@ const ATTENTION_LEVEL_4_DEPRECATION_WARNING =
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ButtonComponent implements AfterContentInit {
-  @HostBinding('class.attention-level1')
-  isAttentionLevel1: boolean = true; // Default
-  @HostBinding('class.attention-level2')
-  isAttentionLevel2: boolean;
-  @HostBinding('class.attention-level3')
-  isAttentionLevel3: boolean;
+  private _attentionLevel?: AttentionLevel;
+  get attentionLevel(): AttentionLevel | undefined {
+    return this._attentionLevel;
+  }
+
   @Input() set attentionLevel(level: AttentionLevel) {
-    this.isAttentionLevel1 = level === '1';
-    this.isAttentionLevel2 = level === '2';
-    this.isAttentionLevel3 = level === '3' || level === '4';
+    this._attentionLevel = level;
     if (level === '4') {
+      this._attentionLevel = '3';
       console.warn(ATTENTION_LEVEL_4_DEPRECATION_WARNING);
     }
   }
 
   @HostBinding('class.no-decoration')
-  hasNoDecoration = false;
   @Input()
-  set noDecoration(enable: boolean) {
-    this.hasNoDecoration = enable;
-    this.isAttentionLevel1 = !enable;
-    this.isAttentionLevel2 = false;
-    this.isAttentionLevel3 = false;
-  }
+  noDecoration = false;
 
   @HostBinding('class.floating')
   public get isButtonFloating(): boolean {
@@ -83,7 +75,14 @@ export class ButtonComponent implements AfterContentInit {
 
   @HostBinding('class')
   get _cssClass() {
-    return [this.themeColor, this.size].filter((cssClass) => !!cssClass);
+    const attentionLevel = this.getAttentionLevelCssClass();
+    return [this.themeColor, this.size, attentionLevel].filter((cssClass) => !!cssClass);
+  }
+
+  private getAttentionLevelCssClass() {
+    if (this.noDecoration) return;
+    const attentionLevelDefault: AttentionLevel = '1';
+    return `attention-level${this._attentionLevel || attentionLevelDefault}`;
   }
 
   @Input()

--- a/libs/designsystem/empty-state/src/empty-state.component.integration.spec.ts
+++ b/libs/designsystem/empty-state/src/empty-state.component.integration.spec.ts
@@ -32,12 +32,13 @@ describe('EmptyStateComponent with slotted buttons', () => {
   });
 
   it('should not change the attention level of the first button', () => {
-    expect(buttons[0].isAttentionLevel1).toBeTrue();
+    expect(buttons[0].attentionLevel).toBeUndefined();
+    expect(buttons[0]._cssClass).toContain('attention-level1');
   });
 
   it('should set the attention level of all buttons to 3 except the first one', () => {
     const allButtonsButTheFirst = buttons.splice(1, buttons.length);
-    expect(allButtonsButTheFirst.every((button) => button.isAttentionLevel3)).toBeTrue();
+    expect(allButtonsButTheFirst.every((button) => button.attentionLevel === '3')).toBeTrue();
   });
 });
 
@@ -67,7 +68,7 @@ describe('EmptyStateComponent with slotted buttons configured with attention lev
   });
 
   it('should set the attention level of all buttons to 3', () => {
-    expect(buttons.every((button) => button.isAttentionLevel3)).toBeTrue();
+    expect(buttons.every((button) => button.attentionLevel === '3')).toBeTrue();
   });
 });
 
@@ -97,11 +98,11 @@ describe('EmptyStateComponent with slotted buttons configured with attention lev
   });
 
   it('should not change the attention level of the first button', () => {
-    expect(buttons[0].isAttentionLevel1).toBeTrue();
+    expect(buttons[0].attentionLevel).toEqual('1');
   });
 
   it('should set the attention level of all buttons to 3 except the first one', () => {
     const allButtonsButTheFirst = buttons.splice(1, buttons.length);
-    expect(allButtonsButTheFirst.every((button) => button.isAttentionLevel3)).toBeTrue();
+    expect(allButtonsButTheFirst.every((button) => button.attentionLevel === '3')).toBeTrue();
   });
 });

--- a/libs/designsystem/empty-state/src/empty-state.component.ts
+++ b/libs/designsystem/empty-state/src/empty-state.component.ts
@@ -39,9 +39,11 @@ export class EmptyStateComponent implements AfterContentInit {
    */
   private enforceAttentionLevelRules() {
     this.slottedButtons.forEach((button, index) => {
-      if (index === 0 && button.isAttentionLevel1) return;
+      if (index === 0 && (button.attentionLevel === undefined || button.attentionLevel === '1')) {
+        return;
+      }
 
-      if (!button.isAttentionLevel3) {
+      if (button.attentionLevel !== '3') {
         button.attentionLevel = '3';
       }
     });


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3021 

## What is the new behavior?

Refactor and simplifies css classes + fixes the issue mentioned. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

