### PR TITLE
enhancement: add support for progress circle in header

### DIFF
--- a/apps/cookbook/src/app/examples/header-example/examples/progress-circle-with-avatar.ts
+++ b/apps/cookbook/src/app/examples/header-example/examples/progress-circle-with-avatar.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+
+const config = {
+  selector: 'cookbook-header-example-progress-circle-with-avatar',
+  template: `<kirby-header [title]="'Title'" subtitle1="Subtitle one" subtitle2="Subtitle two">
+  <kirby-progress-circle value="75" themeColor="success" size="lg">
+    <kirby-avatar themeColor="white">
+      <kirby-icon name="kirby"></kirby-icon>
+    </kirby-avatar>
+  </kirby-progress-circle>
+</kirby-header>`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+})
+export class HeaderExampleProgressCircleWithAvatarComponent {
+  template: string = config.template;
+}

--- a/apps/cookbook/src/app/examples/header-example/header-example.component.html
+++ b/apps/cookbook/src/app/examples/header-example/header-example.component.html
@@ -24,6 +24,9 @@
   <div class="header-example">
     <cookbook-header-example-avatar></cookbook-header-example-avatar>
   </div>
+  <div class="header-example">
+    <cookbook-header-example-progress-circle-with-avatar></cookbook-header-example-progress-circle-with-avatar>
+  </div>
 </div>
 
 <div class="header-example-container">

--- a/apps/cookbook/src/app/examples/header-example/header-example.module.ts
+++ b/apps/cookbook/src/app/examples/header-example/header-example.module.ts
@@ -7,6 +7,7 @@ import { HeaderExampleComponent } from './header-example.component';
 
 import { HeaderExampleDefaultComponent } from './examples/default';
 import { HeaderExampleAvatarComponent } from './examples/avatar';
+import { HeaderExampleProgressCircleWithAvatarComponent } from './examples/progress-circle-with-avatar';
 import { HeaderExampleFlagComponent } from './examples/flag';
 import { HeaderExampleValueComponent } from './examples/value';
 import { HeaderExampleCombinedComponent } from './examples/combined';
@@ -17,6 +18,7 @@ const COMPONENT_DECLARATIONS = [
   HeaderExampleComponent,
   HeaderExampleDefaultComponent,
   HeaderExampleAvatarComponent,
+  HeaderExampleProgressCircleWithAvatarComponent,
   HeaderExampleFlagComponent,
   HeaderExampleValueComponent,
   HeaderExampleCombinedComponent,

--- a/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
@@ -69,6 +69,21 @@
       </div>
     </cookbook-example-viewer>
   </div>
+  <div class="header-example-container">
+    <h3>Progress Circle with Avatar</h3>
+    <p>
+      The avatar can also be nested within a
+      <code>kirby-progress-circle</code>
+      to show progress:
+    </p>
+    <cookbook-example-viewer [html]="progressCircleExample.template">
+      <div class="header-example">
+        <cookbook-header-example-progress-circle-with-avatar
+          #progressCircleExample
+        ></cookbook-header-example-progress-circle-with-avatar>
+      </div>
+    </cookbook-example-viewer>
+  </div>
 
   <div class="header-example-container">
     <h2>Scaling of title</h2>

--- a/libs/designsystem/header/src/header.component.html
+++ b/libs/designsystem/header/src/header.component.html
@@ -1,5 +1,5 @@
-<div *ngIf="!!avatar" class="avatar">
-  <ng-content select="kirby-avatar"></ng-content>
+<div *ngIf="!!avatar || !!progressCircle" class="avatar">
+  <ng-content select="kirby-avatar,kirby-progress-circle"></ng-content>
 </div>
 
 <div *ngIf="!!flag" class="flag">

--- a/libs/designsystem/header/src/header.component.spec.ts
+++ b/libs/designsystem/header/src/header.component.spec.ts
@@ -102,20 +102,41 @@ describe('HeaderComponent', () => {
   });
 
   describe('with avatar', () => {
-    const title = 'title';
-    const subtitle1 = 'Subtitle one';
-    const subtitle2 = 'Subtitle two';
-
     let spectator: Spectator<HeaderComponent>;
     beforeEach(() => {
       spectator = createHost(`
-      <kirby-header title="${title}" subtitle1="${subtitle1}" subtitle2="${subtitle2}">
+      <kirby-header title="title" subtitle1="subtitle one" subtitle2="subtitle two">
         <kirby-avatar size="lg" text="A" title="lg"></kirby-avatar>
       </kirby-header>
       `);
     });
 
-    it(`should have correct avatar`, () => {
+    it(`should render the avatar`, () => {
+      const avatarElement = spectator.query('kirby-avatar');
+
+      expect(avatarElement).toBeTruthy();
+    });
+  });
+
+  describe('with progress circle', () => {
+    let spectator: Spectator<HeaderComponent>;
+    beforeEach(() => {
+      spectator = createHost(`
+      <kirby-header title="title" subtitle1="subtitle one" subtitle2="subtitle two">
+        <kirby-progress-circle value="75" themeColor="success" size="lg">  
+          <kirby-avatar size="lg" text="A" title="lg"></kirby-avatar>
+        </kirby-progress-circle>
+      </kirby-header>
+      `);
+    });
+
+    it(`should render the progress circle`, () => {
+      const progressCircleElement = spectator.query('kirby-progress-circle');
+
+      expect(progressCircleElement).toBeTruthy();
+    });
+
+    it(`should render the avatar`, () => {
       const avatarElement = spectator.query('kirby-avatar');
 
       expect(avatarElement).toBeTruthy();
@@ -123,20 +144,16 @@ describe('HeaderComponent', () => {
   });
 
   describe('with flag', () => {
-    const title = 'title';
-    const subtitle1 = 'Subtitle one';
-    const subtitle2 = 'Subtitle two';
-
     let spectator: Spectator<HeaderComponent>;
     beforeEach(() => {
       spectator = createHost(`
-      <kirby-header title="${title}" subtitle1="${subtitle1}" subtitle2="${subtitle2}">
+      <kirby-header title="title" subtitle1="subtitle one" subtitle2="subtitle two">
         <kirby-flag themeColor="warning">Warning</kirby-flag>
       </kirby-header>
       `);
     });
 
-    it(`should have correct flag`, () => {
+    it(`should render the flag`, () => {
       const avatarElement = spectator.query('kirby-flag');
 
       expect(avatarElement).toBeTruthy();

--- a/libs/designsystem/header/src/header.component.ts
+++ b/libs/designsystem/header/src/header.component.ts
@@ -12,9 +12,11 @@ import {
   TemplateRef,
   ViewChild,
 } from '@angular/core';
+
 import { ACTIONGROUP_CONFIG, ActionGroupConfig } from '@kirbydesign/designsystem/action-group';
 import { AvatarComponent } from '@kirbydesign/designsystem/avatar';
 import { FlagComponent } from '@kirbydesign/designsystem/flag';
+import { ProgressCircleComponent } from '@kirbydesign/designsystem/progress-circle';
 import type { FitHeadingConfig } from '@kirbydesign/designsystem/shared';
 
 @Directive({
@@ -45,6 +47,9 @@ export class HeaderComponent implements AfterContentInit, OnInit {
 
   @ContentChild(AvatarComponent)
   avatar: AvatarComponent;
+
+  @ContentChild(ProgressCircleComponent)
+  progressCircle: ProgressCircleComponent;
 
   @ContentChild(FlagComponent)
   flag: FlagComponent;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3016 

## What is the new behavior?

Support for wrapping an avatar in a progress circle within the header.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

