### PR TITLE
Extend mock base chart for mock charts to work

### DIFF
--- a/libs/designsystem/testing-base/src/lib/components/mock.chart.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.chart.component.ts
@@ -2,6 +2,10 @@ import { Component, forwardRef, Input } from '@angular/core';
 
 import { ChartComponent, ChartType } from '@kirbydesign/designsystem';
 
+// IMPORTANT: MockChartComponent class needs to extend MockBaseChartComponent
+// see https://github.com/kirbydesign/designsystem/issues/3029
+import { MockBaseChartComponent } from './mock.base-chart.component';
+
 // #region AUTO-GENERATED - PLEASE DON'T EDIT CONTENT WITHIN!
 @Component({
   selector: 'kirby-chart',
@@ -13,7 +17,7 @@ import { ChartComponent, ChartType } from '@kirbydesign/designsystem';
     },
   ],
 })
-export class MockChartComponent {
+export class MockChartComponent extends MockBaseChartComponent {
   @Input() type: Exclude<ChartType, 'stock'>;
 }
 

--- a/libs/designsystem/testing-base/src/lib/components/mock.stock-chart.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.stock-chart.component.ts
@@ -3,6 +3,10 @@ import { Component, forwardRef, Input } from '@angular/core';
 import { StockChartComponent } from '@kirbydesign/designsystem';
 import { ChartDataLabelOptions } from '@kirbydesign/designsystem/chart';
 
+// IMPORTANT: MockStockChartComponent class needs to extend MockBaseChartComponent
+// see https://github.com/kirbydesign/designsystem/issues/3029
+import { MockBaseChartComponent } from './mock.base-chart.component';
+
 // #region AUTO-GENERATED - PLEASE DON'T EDIT CONTENT WITHIN!
 @Component({
   selector: 'kirby-stock-chart',
@@ -14,7 +18,7 @@ import { ChartDataLabelOptions } from '@kirbydesign/designsystem/chart';
     },
   ],
 })
-export class MockStockChartComponent {
+export class MockStockChartComponent extends MockBaseChartComponent {
   @Input() dataLabelOptions?: ChartDataLabelOptions;
 }
 


### PR DESCRIPTION
## What is the new behavior?
Chart Mocks need to extend the `BaseChartComponent` for the API to match the real implementation. 
For now this is a quickfix where I manually extend the already generated `MockBaseChartComponent`, until https://github.com/kirbydesign/designsystem/issues/3029 is implemented. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

