### PR TITLE
fix: align attentionLevel getter and setter type

### DIFF
--- a/libs/designsystem/button/src/button.component.ts
+++ b/libs/designsystem/button/src/button.component.ts
@@ -41,7 +41,7 @@ export class ButtonComponent implements AfterContentInit {
     return this._attentionLevel;
   }
 
-  @Input() set attentionLevel(level: AttentionLevel) {
+  @Input() set attentionLevel(level: AttentionLevel | undefined) {
     this._attentionLevel = level;
     if (level === '4') {
       this._attentionLevel = '3';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "designsystem",
-  "version": "8.4.1",
+  "version": "8.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "designsystem",
-  "version": "8.4.1",
+  "version": "8.4.2",
   "description": "Kirby Design Angular Components. This library provides Angular wrappers for the @kirbydesign/core package, for smoother integration into Angular projects.",
   "engines": {
     "node": ">=16.0.0 <=18.13.0",


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3033

## What is the new behavior?

Doesn't break strict compilation in consuming projects.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

