### PR TITLE
Enhancement: interactive header title

### DIFF
--- a/apps/cookbook/src/app/examples/examples.common.ts
+++ b/apps/cookbook/src/app/examples/examples.common.ts
@@ -53,6 +53,7 @@ import { DataTableExampleComponent } from './data-table-example/data-table-examp
 import { LoadingOverlayServiceExampleComponent } from './loading-overlay-example/service/loading-overlay-service-example.component';
 import { HeaderWithActionGroupExampleComponent } from './header-example/examples/action-group';
 import { HeaderWithCustomActionsExampleComponent } from './header-example/examples/custom-actions';
+import { HeaderWithInteractiveTitleExampleComponent } from './header-example/examples/interactive-title';
 import { MenuExampleComponent } from './menu-example/menu-example.component';
 
 export const COMPONENT_DECLARATIONS: any[] = [
@@ -91,6 +92,7 @@ export const COMPONENT_DECLARATIONS: any[] = [
   PageFixedTitleAndActionsExampleComponent,
   HeaderWithActionGroupExampleComponent,
   HeaderWithCustomActionsExampleComponent,
+  HeaderWithInteractiveTitleExampleComponent,
   PageTabNavExampleComponent,
   TabExampleComponent,
   PageFixedFooterTabsExampleComponent,

--- a/apps/cookbook/src/app/examples/examples.routes.ts
+++ b/apps/cookbook/src/app/examples/examples.routes.ts
@@ -81,6 +81,7 @@ import { HeaderExampleComponent } from './header-example/header-example.componen
 import { NestedModalsV2ExampleComponent } from './modal-v2-example/nested-modals/nested-modals-v2-example.component';
 import { HeaderWithActionGroupExampleComponent } from './header-example/examples/action-group';
 import { HeaderWithCustomActionsExampleComponent } from './header-example/examples/custom-actions';
+import { HeaderWithInteractiveTitleExampleComponent } from './header-example/examples/interactive-title';
 import { MenuExampleComponent } from './menu-example/menu-example.component';
 
 export const routes: Routes = [
@@ -183,6 +184,10 @@ export const routes: Routes = [
           {
             path: 'header-and-custom-actions',
             component: HeaderWithCustomActionsExampleComponent,
+          },
+          {
+            path: 'header-and-interactive-title',
+            component: HeaderWithInteractiveTitleExampleComponent,
           },
         ],
       },

--- a/apps/cookbook/src/app/examples/header-example/examples/interactive-title.ts
+++ b/apps/cookbook/src/app/examples/header-example/examples/interactive-title.ts
@@ -1,0 +1,45 @@
+import { Component } from '@angular/core';
+import { ToastConfig, ToastController } from '@kirbydesign/designsystem';
+
+import { BasePageExampleComponent } from '../../page-example/base-page-example.component';
+
+export const config = {
+  template: `<kirby-page defaultBackHref="/">
+  <kirby-header (titleClick)="onTitleClick($event)" [title]="'Interactive Title'" value="12345,67" valueUnit="USD" subtitle1="Subtitle one" subtitle2="Subtitle two">
+    <kirby-icon name="arrow-down" *kirbyHeaderTitleActionIcon></kirby-icon>
+  </kirby-header>
+
+  <kirby-page-content>
+    <div [innerHTML]="content"></div>
+  </kirby-page-content>
+</kirby-page>`,
+};
+@Component({
+  template: config.template,
+})
+export class HeaderWithInteractiveTitleExampleComponent extends BasePageExampleComponent {
+  static readonly template = config.template
+    .replace(' defaultBackHref="/"', '')
+    .replace(' [innerHTML]="content">', '>...');
+  static readonly codeSnippet = `onTitleClick(event: PointerEvent) {
+  // Maybe do something based on the event target:
+  const eventTarget = event.currentTarget as HTMLElement;
+  const targetLocation = eventTarget.closest('kirby-header') ? 'Title in header clicked' : 'Title in toolbar clicked';
+  // Do something...
+}`;
+
+  constructor(private toastController: ToastController) {
+    super();
+  }
+
+  onTitleClick(event: PointerEvent) {
+    const eventTarget = event.currentTarget as HTMLElement;
+    const targetLocation = eventTarget.closest('kirby-header') ? 'in header' : 'in toolbar';
+    const config: ToastConfig = {
+      message: `Title ${targetLocation} clicked...`,
+      messageType: 'success',
+      durationInMs: 1500,
+    };
+    this.toastController.showToast(config);
+  }
+}

--- a/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
@@ -259,7 +259,7 @@
   <div class="header-example-container">
     <h2 #interactiveTitle>Interactive Title (in key value scenarios)</h2>
     <p>
-      If you need the user to interact with the title (when a having
+      If you need the user to interact with the title (when having a
       <code>value</code>
       prop
       <em>in addition to</em>

--- a/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
@@ -313,7 +313,7 @@
     [properties]="properties"
   ></cookbook-api-description-properties>
 
-  <h2>Directives:</h2>
+  <h3>Directives:</h3>
   <cookbook-api-description-properties
     [columns]="directiveColumns"
     [properties]="directives"

--- a/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
@@ -48,6 +48,12 @@
         <cookbook-header-example-value #valueExample></cookbook-header-example-value>
       </div>
     </cookbook-example-viewer>
+    <p>
+      <em>
+        See also:
+        <a href="#" (click)="scrollTo(interactiveTitle)">Interactive Title</a>
+      </em>
+    </p>
   </div>
 
   <div class="header-example-container">
@@ -249,6 +255,37 @@
   </div>
 
   <div class="header-example-container">
+    <h2 #interactiveTitle>Interactive Title</h2>
+    <p>
+      If you need the user to interact with the title you can register a handler for the header's
+      <code>titleClick</code>
+      event. Within your event handler you can access the DOM event object with the
+      <code>event</code>
+      argument passed to the output event handler - e.g. to access the event's
+      <code>currentTarget</code>
+      as shown in the example below.
+    </p>
+    <p>
+      You should also add affordance to your interactive title by slotting a
+      <code>kirby-icon</code>
+      into the header and decorate it with the
+      <code>*kirbyHeaderTitleActionIcon</code>
+      directive as shown in the example below:
+    </p>
+    <cookbook-iphone
+      viewMode="full-size"
+      [showViewModeToggle]="true"
+      src="/examples/page/header-and-interactive-title"
+      showExternalLink="true"
+    ></cookbook-iphone>
+
+    <cookbook-example-viewer
+      [html]="interactiveTitleTemplate"
+      [ts]="interactiveTitleSnippet"
+    ></cookbook-example-viewer>
+  </div>
+
+  <div class="header-example-container">
     <h2>Combined</h2>
     <p>This example shows all the above options combined:</p>
     <cookbook-example-viewer [html]="combinedExample.template" [css]="combinedExample.styles">
@@ -258,9 +295,18 @@
     </cookbook-example-viewer>
   </div>
 
-  <h1>API</h1>
-  <h2>Header Properties:</h2>
+  <h2>API</h2>
+  <h3>Properties</h3>
   <cookbook-api-description-properties
     [properties]="properties"
   ></cookbook-api-description-properties>
+
+  <h2>Directives:</h2>
+  <cookbook-api-description-properties
+    [columns]="directiveColumns"
+    [properties]="directives"
+  ></cookbook-api-description-properties>
+
+  <h3>Events</h3>
+  <cookbook-api-description-events [events]="events"></cookbook-api-description-events>
 </div>

--- a/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
@@ -51,7 +51,9 @@
     <p>
       <em>
         See also:
-        <a href="#" (click)="scrollTo(interactiveTitle)">Interactive Title</a>
+        <a href="#" (click)="scrollTo(interactiveTitle)">
+          Interactive Title (in key value scenarios)
+        </a>
       </em>
     </p>
   </div>
@@ -255,18 +257,28 @@
   </div>
 
   <div class="header-example-container">
-    <h2 #interactiveTitle>Interactive Title</h2>
+    <h2 #interactiveTitle>Interactive Title (in key value scenarios)</h2>
     <p>
-      If you need the user to interact with the title you can register a handler for the header's
+      If you need the user to interact with the title (when a having
+      <code>value</code>
+      prop
+      <em>in addition to</em>
+      the
+      <code>title</code>
+      prop) you can register a handler for the header's
       <code>titleClick</code>
-      event. Within your event handler you can access the DOM event object with the
+      event.
+    </p>
+    <p>
+      Within your event handler you can access the DOM event object with the
       <code>event</code>
       argument passed to the output event handler - e.g. to access the event's
       <code>currentTarget</code>
       as shown in the example below.
     </p>
     <p>
-      You should also add affordance to your interactive title by slotting a
+      You should also add affordance to your interactive title (in key value scenarios) by slotting
+      a
       <code>kirby-icon</code>
       into the header and decorate it with the
       <code>*kirbyHeaderTitleActionIcon</code>

--- a/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.ts
@@ -86,7 +86,7 @@ export class HeaderShowcaseComponent {
     {
       name: '*kirbyHeaderTitleActionIcon',
       description:
-        'For an interactive title (i.e. handling the `titleClick` event) the `*kirbyHeaderTitleActionIcon` directive can be applied to a `kirby-icon` element which will then be shown next to the title element for affordance.',
+        'For an interactive title (i.e. handling the `titleClick` event) the `*kirbyHeaderTitleActionIcon` directive can be applied to a `kirby-icon` element which will then be shown next to the title element for affordance.\n\n**Please note: this only applies in key value scenarios.',
     },
   ];
 
@@ -94,7 +94,7 @@ export class HeaderShowcaseComponent {
     {
       name: 'titleClick',
       description:
-        'Emitted when the title element is clicked (in either the header or the toolbar).',
+        'Emitted when the title element is clicked (in either the header or the toolbar).\n\n**Please note: this only applies in key value scenarios.',
       signature: 'EventEmitter<PointerEvent>',
     },
   ];

--- a/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.ts
@@ -1,6 +1,9 @@
 import { Component } from '@angular/core';
+
 import { HeaderWithActionGroupExampleComponent } from '~/app/examples/header-example/examples/action-group';
 import { HeaderWithCustomActionsExampleComponent } from '~/app/examples/header-example/examples/custom-actions';
+import { HeaderWithInteractiveTitleExampleComponent } from '~/app/examples/header-example/examples/interactive-title';
+import { ApiDescriptionEvent } from '~/app/shared/api-description/api-description-events/api-description-events.component';
 import {
   ApiDescriptionProperty,
   ApiDescriptionPropertyColumns,
@@ -15,6 +18,8 @@ import {
 export class HeaderShowcaseComponent {
   actionGroupTemplate: string = HeaderWithActionGroupExampleComponent.template;
   customActionsTemplate: string = HeaderWithCustomActionsExampleComponent.template;
+  interactiveTitleTemplate: string = HeaderWithInteractiveTitleExampleComponent.template;
+  interactiveTitleSnippet: string = HeaderWithInteractiveTitleExampleComponent.codeSnippet;
 
   properties: ApiDescriptionProperty[] = [
     {
@@ -66,6 +71,33 @@ export class HeaderShowcaseComponent {
     name: 'Name',
     description: 'Description',
   };
+
+  directives: ApiDescriptionProperty[] = [
+    {
+      name: '*kirbyHeaderActions',
+      description:
+        'The `*kirbyHeaderActions` directive should be applied to the host or container element (e.g. `kirby-action-group` or an `ng-container`) for the page and header components to render the actions in both locations',
+    },
+    {
+      name: '*kirbyHeaderCustomSection',
+      description:
+        'The `*kirbyHeaderCustomSection` directive can be applied to any host or container element which will then be shown just below the title (and any subtitles) at the top of the page.',
+    },
+    {
+      name: '*kirbyHeaderTitleActionIcon',
+      description:
+        'For an interactive title (i.e. handling the `titleClick` event) the `*kirbyHeaderTitleActionIcon` directive can be applied to a `kirby-icon` element which will then be shown next to the title element for affordance.',
+    },
+  ];
+
+  events: ApiDescriptionEvent[] = [
+    {
+      name: 'titleClick',
+      description:
+        'Emitted when the title element is clicked (in either the header or the toolbar).',
+      signature: 'EventEmitter<PointerEvent>',
+    },
+  ];
 
   scrollTo(target: Element) {
     target.scrollIntoView({ behavior: 'smooth' });

--- a/libs/designsystem/header/src/header.component.html
+++ b/libs/designsystem/header/src/header.component.html
@@ -8,8 +8,9 @@
 
 <div class="container">
     <!-- Title and value - title: -->
-  <h1 *ngIf="!!title && !!value" #titleElement class="title kirby-text-medium">
+  <h1 *ngIf="!!title && !!value" #titleElement class="title kirby-text-medium" [class.clickable]="titleClick.observed" [class.has-icon]="!!titleIconTemplate" (click)="onTitleClick($event)">
     {{ title }}
+    <ng-container *ngTemplateOutlet="titleIconTemplate"></ng-container>
   </h1>
   <div class="title-container">
     <!-- Only title, no value: -->

--- a/libs/designsystem/header/src/header.component.html
+++ b/libs/designsystem/header/src/header.component.html
@@ -8,9 +8,9 @@
 
 <div class="container">
     <!-- Title and value - title: -->
-  <h1 *ngIf="!!title && !!value" #titleElement class="title kirby-text-medium" [class.clickable]="titleClick.observed" [class.has-icon]="!!titleIconTemplate" (click)="onTitleClick($event)">
+  <h1 *ngIf="!!title && !!value" #titleElement class="title kirby-text-medium" [class.clickable]="titleClick.observed" [class.has-icon]="!!titleActionIconTemplate" (click)="onTitleClick($event)">
     {{ title }}
-    <ng-container *ngTemplateOutlet="titleIconTemplate"></ng-container>
+    <ng-container *ngTemplateOutlet="titleActionIconTemplate"></ng-container>
   </h1>
   <div class="title-container">
     <!-- Only title, no value: -->

--- a/libs/designsystem/header/src/header.component.scss
+++ b/libs/designsystem/header/src/header.component.scss
@@ -89,6 +89,16 @@
 
 .title {
   margin-bottom: utils.size('xxxxs');
+
+  &.clickable {
+    cursor: pointer;
+  }
+
+  &.has-icon {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
 }
 
 .value {

--- a/libs/designsystem/header/src/header.component.ts
+++ b/libs/designsystem/header/src/header.component.ts
@@ -5,10 +5,12 @@ import {
   ContentChild,
   Directive,
   ElementRef,
+  EventEmitter,
   HostBinding,
   Injector,
   Input,
   OnInit,
+  Output,
   TemplateRef,
   ViewChild,
 } from '@angular/core';
@@ -28,6 +30,11 @@ export class HeaderActionsDirective {}
   selector: '[kirbyHeaderCustomSection]',
 })
 export class HeaderCustomSectionDirective {}
+
+@Directive({
+  selector: '[kirbyHeaderTitleActionIcon]',
+})
+export class HeaderTitleActionIconDirective {}
 
 @Component({
   selector: 'kirby-header',
@@ -66,11 +73,20 @@ export class HeaderComponent implements AfterContentInit, OnInit {
   @ContentChild(HeaderCustomSectionDirective, { read: TemplateRef<HeaderCustomSectionDirective> })
   customSectionTemplate?: TemplateRef<HeaderCustomSectionDirective>;
 
+  @ContentChild(HeaderTitleActionIconDirective, { read: TemplateRef })
+  titleActionIconTemplate: TemplateRef<HeaderTitleActionIconDirective>;
+
   @Input() title: string = null;
   @Input() value: string = null;
   @Input() valueUnit: string = null;
   @Input() subtitle1: string = null;
   @Input() subtitle2: string = null;
+
+  @Output() titleClick = new EventEmitter<PointerEvent>();
+
+  onTitleClick(event: PointerEvent) {
+    this.titleClick.emit(event);
+  }
 
   _actionGroupInjector: Injector;
 

--- a/libs/designsystem/header/src/header.module.ts
+++ b/libs/designsystem/header/src/header.module.ts
@@ -6,9 +6,15 @@ import {
   HeaderActionsDirective,
   HeaderComponent,
   HeaderCustomSectionDirective,
+  HeaderTitleActionIconDirective,
 } from './header.component';
 
-const declarations = [HeaderComponent, HeaderActionsDirective, HeaderCustomSectionDirective];
+const declarations = [
+  HeaderComponent,
+  HeaderActionsDirective,
+  HeaderCustomSectionDirective,
+  HeaderTitleActionIconDirective,
+];
 
 @NgModule({
   declarations: declarations,

--- a/libs/designsystem/header/src/public_api.ts
+++ b/libs/designsystem/header/src/public_api.ts
@@ -2,6 +2,7 @@ export {
   HeaderComponent,
   HeaderActionsDirective,
   HeaderCustomSectionDirective,
+  HeaderTitleActionIconDirective,
 } from './header.component';
 
 export { HeaderModule } from './header.module';

--- a/libs/designsystem/page/src/page.component.html
+++ b/libs/designsystem/page/src/page.component.html
@@ -10,7 +10,14 @@
     </ion-buttons>
     <ion-title [class.slide-and-fade-in]="toolbarTitleVisible">
       <div class="toolbar-title">
-        <ng-container *ngTemplateOutlet="toolbarTitleTemplate"></ng-container>
+        <span
+          [class.clickable]="hasInteractiveTitle"
+          [class.has-icon]="!!titleActionIconTemplate"
+          (click)="onTitleClick($event)"
+        >
+          <ng-container *ngTemplateOutlet="toolbarTitleTemplate"></ng-container>
+          <ng-container *ngTemplateOutlet="titleActionIconTemplate"></ng-container>
+        </span>
       </div>
     </ion-title>
     <ion-buttons

--- a/libs/designsystem/page/src/page.component.scss
+++ b/libs/designsystem/page/src/page.component.scss
@@ -101,6 +101,17 @@ ion-toolbar {
       overflow: hidden;
       font-weight: utils.font-weight('bold');
 
+      span.clickable {
+        cursor: pointer;
+      }
+
+      span.has-icon {
+        display: inline-flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: center;
+      }
+
       @include utils.slotted('*') {
         text-overflow: ellipsis;
         white-space: nowrap;

--- a/libs/designsystem/page/src/page.component.ts
+++ b/libs/designsystem/page/src/page.component.ts
@@ -51,7 +51,11 @@ import {
   ModalWrapperComponent,
 } from '@kirbydesign/designsystem/modal';
 import { FitHeadingConfig, ResizeObserverService } from '@kirbydesign/designsystem/shared';
-import { HeaderActionsDirective, HeaderComponent } from '@kirbydesign/designsystem/header';
+import {
+  HeaderActionsDirective,
+  HeaderComponent,
+  HeaderTitleActionIconDirective,
+} from '@kirbydesign/designsystem/header';
 import { ACTIONGROUP_CONFIG, ActionGroupConfig } from '@kirbydesign/designsystem/action-group';
 
 /**
@@ -282,6 +286,9 @@ export class PageComponent
   fixedActionsTemplate: TemplateRef<any>;
   stickyContentTemplate: TemplateRef<PageStickyContentDirective>;
   headerActionsTemplate: TemplateRef<HeaderActionsDirective>;
+  titleActionIconTemplate: TemplateRef<HeaderTitleActionIconDirective>;
+  headerTitleClick?: EventEmitter<PointerEvent>;
+  hasInteractiveTitle = false;
 
   private titleIntersectionObserver?: IntersectionObserver;
   private stickyActionsIntersectionObserver?: IntersectionObserver;
@@ -447,6 +454,10 @@ export class PageComponent
     return `max-width-${this.maxWidth}`;
   }
 
+  onTitleClick(event: PointerEvent) {
+    this.headerTitleClick?.emit(event);
+  }
+
   private removeWrapper() {
     const parent = this.elementRef.nativeElement.parentNode;
     this.renderer.removeChild(parent, this.elementRef.nativeElement);
@@ -513,6 +524,13 @@ export class PageComponent
   private initializeHeader() {
     if (this.hasHeader === undefined && !!this.header) {
       this.hasHeader = true;
+      // Header could later be removed from DOM (e.g. in virtual scrolling scenarios),
+      // so store a reference to `header.titleActionIconTemplate` and `header.titleClick`:
+      this.titleActionIconTemplate = this.header.titleActionIconTemplate;
+      if (this.header.titleClick.observed) {
+        this.hasInteractiveTitle = true;
+        this.headerTitleClick = this.header.titleClick;
+      }
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3032 

## What is the new behavior?

Option to add interactivity to the header's title element in key value scenarios.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

