### PR TITLE
Remove build step from generate-mocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "transpile:generate-mocks": "tsc -b tools/generate-mocks",
     "coverage-report": "cat ./coverage/lcov.info | coveralls",
     "extract-scss-variables": "node ./scripts/sass-extract-to-ts.js",
-    "generate-mocks": "npm run build:core && node ./scripts/generate-mocks.js",
+    "generate-mocks": "node ./scripts/generate-mocks.js",
     "affected:apps": "nx affected:apps",
     "affected:libs": "nx affected:libs",
     "affected:build": "nx affected:build",


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue 🥷 

## What is the new behavior?
We are currently running the build:core step before generating mocks because we need want changes to the core components APIs to sync to the Angular proxies file, so we can generate mocks for them. 

This is not in itself a problem when running the generate-mocks scrip on its own, but since generate-mocks runs in our pre-commit hook, committing takes a very long time. This change should reduce the time for committing significantly. 

It seems very unlikely that the build step would not have run sometime before committing anyways, and we very rarely touch the core package so I think the pragmatic approach is to just remove it.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

