### PR TITLE
Refactor the solution to show an alert before closing the modal

### DIFF
--- a/apps/cookbook/src/app/examples/examples.routes.ts
+++ b/apps/cookbook/src/app/examples/examples.routes.ts
@@ -87,6 +87,7 @@ import { MenuExampleComponent } from './menu-example/menu-example.component';
 import { ModalExampleSimpleComponent } from './modal-example/modal-example-simple.component';
 import { ModalExampleAdvancedComponent } from './modal-example/modal-example-advanced.component';
 import { ModalExampleOutletComponent } from './modal-example/modal-example-outlet.component';
+import { ModalExampleAlertComponent } from './modal-example/modal-example-alert.component';
 
 export const routes: ModalEnabledRoutes = [
   {
@@ -258,6 +259,10 @@ export const routes: ModalEnabledRoutes = [
       {
         path: 'modal-simple',
         component: ModalExampleSimpleComponent,
+      },
+      {
+        path: 'modal-alert',
+        component: ModalExampleAlertComponent,
       },
       {
         path: 'modal-route',

--- a/apps/cookbook/src/app/examples/modal-example/alert-example/modal-example-embedded-alert.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/alert-example/modal-example-embedded-alert.component.ts
@@ -6,6 +6,8 @@ const config = {
   template: `
     <kirby-page-title>Modal with alert</kirby-page-title>
     <p>
+    <strong>Please note:</strong>
+
       <em>
         This modal will ask the user if they are sure they want to close the modal if they have
         entered data in any of the form fields.

--- a/apps/cookbook/src/app/examples/modal-example/alert-example/modal-example-embedded-alert.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/alert-example/modal-example-embedded-alert.component.ts
@@ -6,15 +6,27 @@ const config = {
   template: `
     <kirby-page-title>Modal with alert</kirby-page-title>
     <p>
-      This modal will ask the user if they are sure they want to close the modal if they have
-      entered data in any of the form fields.
+      <em>
+        This modal will ask the user if they are sure they want to close the modal if they have
+        entered data in any of the form fields.
+      </em>
     </p>
+
+    <h4>The standard Lorem Ipsum passage, used since the 1500s</h4>
+      <p>
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt
+        ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+        laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+        cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+      </p>
+      
     <kirby-form-field>
-      <input kirby-input placeholder="First name" (input)="updateFirstName($event.target.value)" />
+      <input kirby-input placeholder="First name" (input)="firstName =$event.target.value" />
     </kirby-form-field>
 
     <kirby-form-field>
-      <input kirby-input placeholder="Last name" (input)="updateLastName($event.target.value)" />
+      <input kirby-input placeholder="Last name" (input)="lastName = $event.target.value" />
     </kirby-form-field>
   `,
   canDismissCodeSnippet: `// Inside the embedded component
@@ -60,14 +72,6 @@ export class ModalEmbeddedAlertExampleComponent implements OnInit {
 
   ngOnInit() {
     this.modal.canDismiss = () => this.validate();
-  }
-
-  updateFirstName(firstName: string) {
-    this.firstName = firstName;
-  }
-
-  updateLastName(lastName: string) {
-    this.lastName = lastName;
   }
 
   validate() {

--- a/apps/cookbook/src/app/examples/modal-example/alert-example/modal-example-embedded-alert.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/alert-example/modal-example-embedded-alert.component.ts
@@ -1,0 +1,89 @@
+import { Component, OnInit, Optional, SkipSelf } from '@angular/core';
+import { AlertConfig, Modal } from '@kirbydesign/designsystem';
+
+const config = {
+  selector: 'cookbook-modal-embedded-alert-example',
+  template: `
+    <kirby-page-title>Modal with alert</kirby-page-title>
+    <p>
+      This modal will ask the user if they are sure they want to close the modal if they have
+      entered data in any of the form fields.
+    </p>
+    <kirby-form-field>
+      <input kirby-input placeholder="First name" (input)="updateFirstName($event.target.value)" />
+    </kirby-form-field>
+
+    <kirby-form-field>
+      <input kirby-input placeholder="Last name" (input)="updateLastName($event.target.value)" />
+    </kirby-form-field>
+  `,
+  canDismissCodeSnippet: `// Inside the embedded component
+constructor(@Optional() @SkipSelf() private modal: Modal) {}
+
+firstName: string;
+lastName: string;
+
+ngOnInit() {
+  this.modal.canDismiss = () => this.validate();
+}
+
+validate(): boolean | AlertConfig {
+  if (!this.firstName && !this.lastName) return true;
+
+  const config: AlertConfig = {
+    title: 'Are you sure you want to close?',
+    message: 'All unsaved data will be lost.',
+    okBtn: 'Close',
+    cancelBtn: 'Cancel',
+    icon: {
+      name: 'warning',
+      themeColor: 'warning',
+    },
+  };
+
+  return config;
+}
+  `,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+})
+export class ModalEmbeddedAlertExampleComponent implements OnInit {
+  constructor(@Optional() @SkipSelf() private modal: Modal) {}
+
+  static readonly canDismissCodeSnippet = config.canDismissCodeSnippet;
+
+  firstName: string;
+  lastName: string;
+
+  ngOnInit() {
+    this.modal.canDismiss = () => this.validate();
+  }
+
+  updateFirstName(firstName: string) {
+    this.firstName = firstName;
+  }
+
+  updateLastName(lastName: string) {
+    this.lastName = lastName;
+  }
+
+  validate() {
+    if (!this.firstName && !this.lastName) return true;
+
+    const config: AlertConfig = {
+      title: 'Are you sure you want to close?',
+      message: 'All unsaved data will be lost.',
+      okBtn: 'Close',
+      cancelBtn: 'Cancel',
+      icon: {
+        name: 'warning',
+        themeColor: 'warning',
+      },
+    };
+
+    return config;
+  }
+}

--- a/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.html
+++ b/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.html
@@ -21,13 +21,6 @@
   ></cookbook-modal-example-configuration>
 </cookbook-example-configuration-wrapper>
 
-<kirby-checkbox
-  *ngIf="alertBeforeClose"
-  attentionLevel="1"
-  [checked]="disableAlertBeforeClose"
-  text="Disable alert before closing modal"
-  (checkedChange)="disableAlertBeforeClose = $event"
-></kirby-checkbox>
 <kirby-loading-overlay [isLoading]="isLoading">
   <div *ngIf="!isLoading">
     <!-- configuration of nested modals opened on top of current modal -->
@@ -64,6 +57,13 @@
         </ng-container>
       </details>
     </kirby-card>
+
+    <kirby-checkbox
+      attentionLevel="1"
+      [checked]="alertBeforeClose"
+      text="Alert before closing modal"
+      (checkedChange)="_toggleAlertBeforeClose($event)"
+    ></kirby-checkbox>
 
     <div *ngIf="showStaticDummyContent">
       <h4>The standard Lorem Ipsum passage, used since the 1500s</h4>

--- a/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.html
+++ b/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.html
@@ -21,6 +21,13 @@
   ></cookbook-modal-example-configuration>
 </cookbook-example-configuration-wrapper>
 
+<kirby-checkbox
+  *ngIf="alertBeforeClose"
+  attentionLevel="1"
+  [checked]="disableAlertBeforeClose"
+  text="Disable alert before closing modal"
+  (checkedChange)="disableAlertBeforeClose = $event"
+></kirby-checkbox>
 <kirby-loading-overlay [isLoading]="isLoading">
   <div *ngIf="!isLoading">
     <!-- configuration of nested modals opened on top of current modal -->

--- a/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.html
+++ b/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.html
@@ -18,6 +18,7 @@
     [(showFooter)]="showFooter"
     [(snapFooterToKeyboard)]="snapFooterToKeyboard"
     [(displayFooterAsInline)]="displayFooterAsInline"
+    [(alertBeforeClose)]="alertBeforeClose"
   ></cookbook-modal-example-configuration>
 </cookbook-example-configuration-wrapper>
 
@@ -57,13 +58,6 @@
         </ng-container>
       </details>
     </kirby-card>
-
-    <kirby-checkbox
-      attentionLevel="1"
-      [checked]="alertBeforeClose"
-      text="Alert before closing modal"
-      (checkedChange)="_toggleAlertBeforeClose($event)"
-    ></kirby-checkbox>
 
     <div *ngIf="showStaticDummyContent">
       <h4>The standard Lorem Ipsum passage, used since the 1500s</h4>

--- a/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.ts
@@ -53,7 +53,6 @@ export class EmbeddedModalExampleComponent implements OnInit {
   showModalSizeSelector: boolean;
   selectedModalSize: ModalSize;
   alertBeforeClose: boolean;
-  disableAlertBeforeClose: boolean = false;
 
   get _footerType(): 'inline' | 'fixed' {
     return this.displayFooterAsInline ? 'inline' : 'fixed';
@@ -81,12 +80,12 @@ export class EmbeddedModalExampleComponent implements OnInit {
     }
 
     if (this.alertBeforeClose) {
-      this.modal.canDismiss = () => this.validate();
+      this.modal.canDismiss = () => this.canDismiss();
     }
   }
 
-  private validate() {
-    if (this.disableAlertBeforeClose) return true;
+  private canDismiss() {
+    if (!this.alertBeforeClose) return true;
 
     const config: AlertConfig = {
       title: 'Are you sure you want to close?',
@@ -99,6 +98,14 @@ export class EmbeddedModalExampleComponent implements OnInit {
     };
 
     return config;
+  }
+
+  _toggleAlertBeforeClose(checked) {
+    this.alertBeforeClose = checked;
+
+    if (checked && !this.modal.canDismiss) {
+      this.modal.canDismiss = () => this.canDismiss();
+    }
   }
 
   private showNestedOverlay(flavor: 'modal' | 'drawer') {

--- a/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.ts
@@ -79,9 +79,7 @@ export class EmbeddedModalExampleComponent implements OnInit {
       }
     }
 
-    if (this.alertBeforeClose) {
-      this.modal.canDismiss = () => this.canDismiss();
-    }
+    this.modal.canDismiss = () => this.canDismiss();
   }
 
   private canDismiss() {
@@ -102,10 +100,7 @@ export class EmbeddedModalExampleComponent implements OnInit {
 
   _toggleAlertBeforeClose(checked) {
     this.alertBeforeClose = checked;
-
-    if (checked && !this.modal.canDismiss) {
-      this.modal.canDismiss = () => this.canDismiss();
-    }
+    this.modal.canDismiss = () => this.canDismiss();
   }
 
   private showNestedOverlay(flavor: 'modal' | 'drawer') {

--- a/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.ts
@@ -98,11 +98,6 @@ export class EmbeddedModalExampleComponent implements OnInit {
     return config;
   }
 
-  _toggleAlertBeforeClose(checked) {
-    this.alertBeforeClose = checked;
-    this.modal.canDismiss = () => this.canDismiss();
-  }
-
   private showNestedOverlay(flavor: 'modal' | 'drawer') {
     const title = flavor === 'modal' ? 'Nested Modal Title' : 'Nested Drawer Title';
     const config: ModalConfig = {

--- a/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.ts
@@ -52,6 +52,8 @@ export class EmbeddedModalExampleComponent implements OnInit {
 
   showModalSizeSelector: boolean;
   selectedModalSize: ModalSize;
+  alertBeforeClose: boolean;
+  disableAlertBeforeClose: boolean = false;
 
   get _footerType(): 'inline' | 'fixed' {
     return this.displayFooterAsInline ? 'inline' : 'fixed';
@@ -77,6 +79,26 @@ export class EmbeddedModalExampleComponent implements OnInit {
         setTimeout(() => (this.isLoadingAdditionalContent = false), 2000);
       }
     }
+
+    if (this.alertBeforeClose) {
+      this.modal.canDismiss = () => this.validate();
+    }
+  }
+
+  private validate() {
+    if (this.disableAlertBeforeClose) return true;
+
+    const config: AlertConfig = {
+      title: 'Are you sure you want to close?',
+      okBtn: 'Yes',
+      cancelBtn: 'Take me back',
+      icon: {
+        name: 'warning',
+        themeColor: 'warning',
+      },
+    };
+
+    return config;
   }
 
   private showNestedOverlay(flavor: 'modal' | 'drawer') {

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-advanced.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-advanced.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 
-import { AlertConfig, ModalConfig, ModalController } from '@kirbydesign/designsystem';
+import { ModalConfig, ModalController } from '@kirbydesign/designsystem';
 import { WindowRef } from '@kirbydesign/designsystem/types';
 
 import { ModalCompactExampleComponent } from './compact-example/modal-compact-example.component';
@@ -114,21 +114,6 @@ export class EmbeddedComponent() {
   const returnData: CustomDataType = {...};
   this.modal?.close(returnData);
 }`,
-  alertBeforeCloseCodeSnippet: `// Inside the parent (caller) component:
-@Component()
-export class ParentComponent() {
-  const alertConfig: AlertConfig = {
-    title: 'Do you want to close the modal?',
-    okBtn: {
-      text: 'Yes',
-      isDestructive: true,
-    },
-    cancelBtn: 'No',
-  };
-
-  this.modalController.showModal(config, null, alertConfig)
-}
-`,
   scrollingCodeSnippet: `import { KirbyAnimation, Modal } from '@kirbydesign/designsystem';
 ...
 constructor(@Optional() @SkipSelf() private modal: Modal) {}
@@ -209,7 +194,6 @@ export class ModalExampleAdvancedComponent {
   static readonly drawerCodeSnippet = config.drawerCodeSnippet;
   static readonly callbackCodeSnippet = config.callbackCodeSnippet;
   static readonly callbackWithDataCodeSnippet = config.callbackWithDataCodeSnippet;
-  static readonly alertBeforeCloseCodeSnippet = config.alertBeforeCloseCodeSnippet;
   static readonly didPresentCodeSnippet = config.didPresentCodeSnippet;
   static readonly willCloseCodeSnippet = config.willCloseCodeSnippet;
   static readonly scrollingCodeSnippet = config.scrollingCodeSnippet;
@@ -277,6 +261,7 @@ export class ModalExampleAdvancedComponent {
         showModalSizeSelector: true,
         disableScroll: this.disableScroll,
         showNestedCollapseTitle: this.showNestedCollapseTitle,
+        alertBeforeClose: this.alertBeforeClose,
       },
     };
 

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-advanced.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-advanced.component.ts
@@ -266,10 +266,10 @@ export class ModalExampleAdvancedComponent {
       interactWithBackground: this.interactWithBackground,
       cssClass: this.customCssClass ? ['my-custom-modal-class'] : [],
       size: this.openFullHeight ? 'full-height' : null,
-      canDismissConfig: {
-        canDismiss: () => !this.alertBeforeClose,
-        alertConfig: alertConfig,
-      },
+      // canDismissConfig: {
+      //   canDismiss: () => !this.alertBeforeClose,
+      //   alertConfig: alertConfig,
+      // },
       componentProps: {
         title,
         subtitle: 'Hello from the first embedded example component!',

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-advanced.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-advanced.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 
-import { AlertConfig, ModalConfig, ModalController, ModalSize } from '@kirbydesign/designsystem';
+import { AlertConfig, ModalConfig, ModalController } from '@kirbydesign/designsystem';
 import { WindowRef } from '@kirbydesign/designsystem/types';
 
 import { ModalCompactExampleComponent } from './compact-example/modal-compact-example.component';
@@ -250,26 +250,12 @@ export class ModalExampleAdvancedComponent {
       title = flavor === 'modal' ? 'Modal with Custom CSS' : 'Drawer with Custom CSS';
     }
     this.preventInteraction = this.interactWithBackground;
-    // const alertConfig: AlertConfig = {
-    //   title: 'Do you want to close the modal?',
-    //   okBtn: {
-    //     text: 'Yes',
-    //     isDestructive: true,
-    //   },
-    //   cancelBtn: 'No',
-    // };
-
     const config: ModalConfig = {
       flavor,
       collapseTitle: this.collapseTitle,
       component: EmbeddedModalExampleComponent,
       interactWithBackground: this.interactWithBackground,
       cssClass: this.customCssClass ? ['my-custom-modal-class'] : [],
-      size: this.openFullHeight ? 'full-height' : null,
-      // canDismissConfig: {
-      //   canDismiss: () => !this.alertBeforeClose,
-      //   alertConfig: alertConfig,
-      // },
       componentProps: {
         title,
         subtitle: 'Hello from the first embedded example component!',
@@ -294,19 +280,7 @@ export class ModalExampleAdvancedComponent {
       },
     };
 
-    let alertConfig: AlertConfig = null;
-    if (this.alertBeforeClose) {
-      alertConfig = {
-        title: 'Do you want to close the modal?',
-        okBtn: {
-          text: 'Yes',
-          isDestructive: true,
-        },
-        cancelBtn: 'No',
-      };
-    }
-
-    await this.modalController.showModal(config, this.onOverlayClose.bind(this), alertConfig);
+    await this.modalController.showModal(config, this.onOverlayClose.bind(this));
   }
 
   async showModal() {

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-advanced.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-advanced.component.ts
@@ -250,12 +250,26 @@ export class ModalExampleAdvancedComponent {
       title = flavor === 'modal' ? 'Modal with Custom CSS' : 'Drawer with Custom CSS';
     }
     this.preventInteraction = this.interactWithBackground;
+    const alertConfig: AlertConfig = {
+      title: 'Do you want to close the modal?',
+      okBtn: {
+        text: 'Yes',
+        isDestructive: true,
+      },
+      cancelBtn: 'No',
+    };
+
     const config: ModalConfig = {
       flavor,
       collapseTitle: this.collapseTitle,
       component: EmbeddedModalExampleComponent,
       interactWithBackground: this.interactWithBackground,
       cssClass: this.customCssClass ? ['my-custom-modal-class'] : [],
+      size: this.openFullHeight ? 'full-height' : null,
+      canDismissConfig: {
+        canDismiss: () => !this.alertBeforeClose,
+        alertConfig: alertConfig,
+      },
       componentProps: {
         title,
         subtitle: 'Hello from the first embedded example component!',
@@ -280,19 +294,7 @@ export class ModalExampleAdvancedComponent {
       },
     };
 
-    let alertConfig: AlertConfig = null;
-    if (this.alertBeforeClose) {
-      alertConfig = {
-        title: 'Do you want to close the modal?',
-        okBtn: {
-          text: 'Yes',
-          isDestructive: true,
-        },
-        cancelBtn: 'No',
-      };
-    }
-
-    await this.modalController.showModal(config, this.onOverlayClose.bind(this), alertConfig);
+    await this.modalController.showModal(config, this.onOverlayClose.bind(this));
   }
 
   async showModal() {

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-advanced.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-advanced.component.ts
@@ -250,14 +250,14 @@ export class ModalExampleAdvancedComponent {
       title = flavor === 'modal' ? 'Modal with Custom CSS' : 'Drawer with Custom CSS';
     }
     this.preventInteraction = this.interactWithBackground;
-    const alertConfig: AlertConfig = {
-      title: 'Do you want to close the modal?',
-      okBtn: {
-        text: 'Yes',
-        isDestructive: true,
-      },
-      cancelBtn: 'No',
-    };
+    // const alertConfig: AlertConfig = {
+    //   title: 'Do you want to close the modal?',
+    //   okBtn: {
+    //     text: 'Yes',
+    //     isDestructive: true,
+    //   },
+    //   cancelBtn: 'No',
+    // };
 
     const config: ModalConfig = {
       flavor,
@@ -294,7 +294,19 @@ export class ModalExampleAdvancedComponent {
       },
     };
 
-    await this.modalController.showModal(config, this.onOverlayClose.bind(this));
+    let alertConfig: AlertConfig = null;
+    if (this.alertBeforeClose) {
+      alertConfig = {
+        title: 'Do you want to close the modal?',
+        okBtn: {
+          text: 'Yes',
+          isDestructive: true,
+        },
+        cancelBtn: 'No',
+      };
+    }
+
+    await this.modalController.showModal(config, this.onOverlayClose.bind(this), alertConfig);
   }
 
   async showModal() {

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-alert.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-alert.component.ts
@@ -30,7 +30,7 @@ validate() {
   openModal() {
     const config: ModalConfig = {
         component: EmbeddedComponent,
-        showAlert: () => this.validate(),
+        canDismiss: () => this.validate(),
     }
 
     this.modalController.showModal(config);

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-alert.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-alert.component.ts
@@ -1,0 +1,60 @@
+import { Component } from '@angular/core';
+
+import { ModalController, ModalFlavor } from '@kirbydesign/designsystem';
+
+import { ModalEmbeddedAlertExampleComponent } from './alert-example/modal-example-embedded-alert.component';
+
+const config = {
+  selector: 'cookbook-modal-example-alert',
+  template: `<button kirby-button size="lg" (click)="showModal('modal', size)">Show modal</button>
+<button kirby-button size="lg"(click)="showModal('drawer')">Show drawer</button>`,
+  codeSnippet: `constructor(private myService: MyService) {}
+
+validate() {
+    if(this.myService.dataIsValid()) return true;
+
+    const config: AlertConfig = {
+        title: 'Data is invalid',
+        message: 'Check the following fields: this.myService.getInvalidFields()',
+        okBtn: 'Close',
+        cancelBtn: 'Cancel',
+        icon: {
+          name: 'warning',
+          themeColor: 'warning',
+        },
+      };
+    
+      return config;
+  }
+
+  openModal() {
+    const config: ModalConfig = {
+        component: EmbeddedComponent,
+        showAlert: () => this.validate(),
+    }
+
+    this.modalController.showModal(config);
+  }
+`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+  styleUrls: ['./modal-example-simple.component.scss'],
+})
+export class ModalExampleAlertComponent {
+  static readonly template = config.template;
+  static readonly codeSnippet = config.codeSnippet;
+
+  constructor(private modalController: ModalController) {}
+
+  async showModal(flavor: ModalFlavor) {
+    const config = {
+      component: ModalEmbeddedAlertExampleComponent,
+      flavor,
+    };
+
+    await this.modalController.showModal(config);
+  }
+}

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-alert.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-alert.component.ts
@@ -11,7 +11,7 @@ const config = {
   codeSnippet: `constructor(private myService: MyService) {}
 
 validate() {
-    if(this.myService.dataIsValid()) return true;
+    if(this.myService.isDataValid()) return true;
 
     const config: AlertConfig = {
         title: 'Data is invalid',

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-alert.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-alert.component.ts
@@ -6,8 +6,8 @@ import { ModalEmbeddedAlertExampleComponent } from './alert-example/modal-exampl
 
 const config = {
   selector: 'cookbook-modal-example-alert',
-  template: `<button kirby-button size="lg" (click)="showModal('modal')">Show modal</button>
-<button kirby-button size="lg"(click)="showModal('drawer')">Show drawer</button>`,
+  template: `<button kirby-button size="lg" (click)="showModal('modal')">Show modal (with alert)</button>
+<button kirby-button size="lg"(click)="showModal('drawer')">Show drawer (with alert)</button>`,
   codeSnippet: `constructor(private myService: MyService) {}
 
 validate() {

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-alert.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-alert.component.ts
@@ -6,7 +6,7 @@ import { ModalEmbeddedAlertExampleComponent } from './alert-example/modal-exampl
 
 const config = {
   selector: 'cookbook-modal-example-alert',
-  template: `<button kirby-button size="lg" (click)="showModal('modal', size)">Show modal</button>
+  template: `<button kirby-button size="lg" (click)="showModal('modal')">Show modal</button>
 <button kirby-button size="lg"(click)="showModal('drawer')">Show drawer</button>`,
   codeSnippet: `constructor(private myService: MyService) {}
 

--- a/apps/cookbook/src/app/examples/modal-example/modal-example.module.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example.module.ts
@@ -17,6 +17,8 @@ import { ModalExampleOutletComponent } from './modal-example-outlet.component';
 import { ModalExampleComponent } from './modal-example.component';
 import { ModalRoutePage1ExampleComponent } from './modal-route-example/modal-route-page1-example.component';
 import { ModalRoutePage2ExampleComponent } from './modal-route-example/modal-route-page2-example.component';
+import { ModalExampleAlertComponent } from './modal-example-alert.component';
+import { ModalEmbeddedAlertExampleComponent } from './alert-example/modal-example-embedded-alert.component';
 
 const COMPONENT_DECLARATIONS = [
   ModalExampleComponent,
@@ -29,6 +31,8 @@ const COMPONENT_DECLARATIONS = [
   ModalCompactExampleComponent,
   ModalRoutePage1ExampleComponent,
   ModalRoutePage2ExampleComponent,
+  ModalExampleAlertComponent,
+  ModalEmbeddedAlertExampleComponent,
 ];
 
 @NgModule({

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
@@ -379,7 +379,7 @@
   is being returned, an alert will appear, when the user tries to dismiss the modal. This callback
   can be set on the parent modal from your own embedded component, or be provided to the
   <code>ModalConfig</code>
-  . The callback can be both synchronous and asynchronous. .
+  . The callback can be both synchronous and asynchronous.
 </p>
 
 <cookbook-iphone
@@ -395,9 +395,11 @@
   Inside the embedded component you can set the
   <code>canDismiss</code>
   property on the parent modal. This makes it possible to validate if the modal can be dismissed
-  based on data inside your component.
+  based on the data inside your component.
 </p>
-<cookbook-example-viewer [ts]="alertExample.canDismissCodeSnippet"></cookbook-example-viewer>
+<cookbook-example-viewer
+  [ts]="alertEmbeddedExample.canDismissCodeSnippet"
+></cookbook-example-viewer>
 
 <h4>Modal config</h4>
 <p>

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
@@ -370,7 +370,9 @@
 </h2>
 
 <p>
-  It is possible to provide a callback to the modal that returns either
+  It is possible to provide a
+  <code>canDismiss</code>
+  callback to the modal that returns either
   <code>true</code>
   or an
   <code>AlertConfig</code>
@@ -406,7 +408,7 @@
   It is also possible to provide the callback in the
   <code>ModalConfig</code>
   that is passed to the modal controller. The callback is passed to the config as
-  <code>showAlert</code>
+  <code>canDismiss</code>
   .
 </p>
 

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
@@ -32,11 +32,10 @@
       <a href="#" (click)="scrollTo(returnData)">returning data</a>
       from the modal to the parent/caller component
     </li>
-    <!-- Add back when alert before close is a callback and we want people to use it
-      <li>
+    <li>
       Support for
       <a href="#" (click)="scrollTo(alertBeforeClose)">showing an alert before closing</a>
-    </li> -->
+    </li>
     <li>
       Support for programmatically
       <a href="#" (click)="scrollTo(scrolling)">scrolling</a>
@@ -364,17 +363,52 @@
   [ts]="outletExample.modalControllerWithinModalOutletCodeSnippet"
 ></cookbook-example-viewer>
 
-<!-- Add back when alert before close is a callback and we want people to use it
-  <h2 #alertBeforeClose>
+<h2 #alertBeforeClose>
   Show an alert before dismissing the modal
   <em>(optional)</em>
   :
 </h2>
+
 <p>
-  If you need the user to confirm that the modal should be closed, you can pass an AlertConfig as an
-  optional third argument
-  <cookbook-code-viewer [ts]="advancedConfigExample.alertBeforeCloseCodeSnippet"></cookbook-code-viewer>
-</p> -->
+  It is possible to provide a callback to the modal that returns either
+  <code>true</code>
+  or an
+  <code>AlertConfig</code>
+  . If an
+  <code>AlertConfig</code>
+  is being returned, an alert will appear, when the user tries to dismiss the modal. This callback
+  can be set on the parent modal from your own embedded component, or be provided to the
+  <code>ModalConfig</code>
+  . The callback can be both synchronous and asynchronous. .
+</p>
+
+<cookbook-iphone
+  class="large-example"
+  src="/examples/modal-alert"
+  viewMode="full-size"
+  [showViewModeToggle]="true"
+  showExternalLink="true"
+></cookbook-iphone>
+
+<h4>Embedded component</h4>
+<p>
+  Inside the embedded component you can set the
+  <code>canDismiss</code>
+  property on the parent modal. This makes it possible to validate if the modal can be dismissed
+  based on data inside your component.
+</p>
+<cookbook-example-viewer [ts]="alertExample.canDismissCodeSnippet"></cookbook-example-viewer>
+
+<h4>Modal config</h4>
+<p>
+  It is also possible to provide the callback in the
+  <code>ModalConfig</code>
+  that is passed to the modal controller. The callback is passed to the config as
+  <code>showAlert</code>
+  .
+</p>
+
+<cookbook-example-viewer [ts]="alertModalConfigExample.codeSnippet"></cookbook-example-viewer>
 
 <h2 #modalEvents>Modal events</h2>
 <h3>Modal presented</h3>

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
@@ -2,11 +2,13 @@ import { Component } from '@angular/core';
 import { ModalExampleAdvancedComponent } from '~/app/examples/modal-example/modal-example-advanced.component';
 import { ModalExampleOutletComponent } from '~/app/examples/modal-example/modal-example-outlet.component';
 import { ModalExampleSimpleComponent } from '~/app/examples/modal-example/modal-example-simple.component';
+import { ModalExampleAlertComponent } from '~/app/examples/modal-example/modal-example-alert.component';
 import { ApiDescriptionEvent } from '~/app/shared/api-description/api-description-events/api-description-events.component';
 import {
   ApiDescriptionProperty,
   ApiDescriptionPropertyColumns,
 } from '~/app/shared/api-description/api-description-properties/api-description-properties.component';
+import { ModalEmbeddedAlertExampleComponent } from '~/app/examples/modal-example/alert-example/modal-example-embedded-alert.component';
 
 @Component({
   selector: 'cookbook-modal-showcase',
@@ -18,6 +20,8 @@ export class ModalShowcaseComponent {
   advancedConfigExample = ModalExampleAdvancedComponent;
   basicConfigExample = ModalExampleSimpleComponent;
   outletExample = ModalExampleOutletComponent;
+  alertExample = ModalEmbeddedAlertExampleComponent;
+  alertModalConfigExample = ModalExampleAlertComponent;
 
   scrollTo(target: Element) {
     target.scrollIntoView({ behavior: 'smooth' });

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
@@ -20,7 +20,7 @@ export class ModalShowcaseComponent {
   advancedConfigExample = ModalExampleAdvancedComponent;
   basicConfigExample = ModalExampleSimpleComponent;
   outletExample = ModalExampleOutletComponent;
-  alertExample = ModalEmbeddedAlertExampleComponent;
+  alertEmbeddedExample = ModalEmbeddedAlertExampleComponent;
   alertModalConfigExample = ModalExampleAlertComponent;
 
   scrollTo(target: Element) {

--- a/libs/designsystem/modal/src/modal-wrapper/compact/modal-compact-wrapper.component.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/compact/modal-compact-wrapper.component.ts
@@ -3,9 +3,10 @@ import { firstValueFrom, Subject } from 'rxjs';
 import { WindowRef } from '@kirbydesign/designsystem/types';
 
 import { CommonModule } from '@angular/common';
-import { ModalConfig } from '../config/modal-config';
+import { CanDismissConfig, ModalConfig } from '../config/modal-config';
 import { COMPONENT_PROPS } from '../config/modal-config.helper';
 import { Modal } from '../../modal.interfaces';
+import { CanDismissHelper } from '../../modal/services/can-dismiss.helper';
 
 @Component({
   standalone: true,
@@ -32,7 +33,8 @@ export class ModalCompactWrapperComponent implements Modal, OnInit {
   constructor(
     private injector: Injector,
     private elementRef: ElementRef<HTMLElement>,
-    private windowRef: WindowRef
+    private windowRef: WindowRef,
+    private canDismissHelper: CanDismissHelper
   ) {}
 
   ngOnInit(): void {
@@ -68,6 +70,10 @@ export class ModalCompactWrapperComponent implements Modal, OnInit {
     if (ionModalElement) {
       await ionModalElement.dismiss(data);
     }
+  }
+
+  public setCanDismissConfig(canDismissConfig: CanDismissConfig) {
+    this.ionModalElement.canDismiss = this.canDismissHelper.getCanDismissCallback(canDismissConfig);
   }
 
   scrollToTop: (_?: any) => void;

--- a/libs/designsystem/modal/src/modal-wrapper/compact/modal-compact-wrapper.component.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/compact/modal-compact-wrapper.component.ts
@@ -3,7 +3,7 @@ import { firstValueFrom, Subject } from 'rxjs';
 import { WindowRef } from '@kirbydesign/designsystem/types';
 
 import { CommonModule } from '@angular/common';
-import { CanDismissConfig, ModalConfig } from '../config/modal-config';
+import { ModalConfig, ShowAlertCallback } from '../config/modal-config';
 import { COMPONENT_PROPS } from '../config/modal-config.helper';
 import { Modal } from '../../modal.interfaces';
 import { CanDismissHelper } from '../../modal/services/can-dismiss.helper';
@@ -72,8 +72,8 @@ export class ModalCompactWrapperComponent implements Modal, OnInit {
     }
   }
 
-  public setCanDismissConfig(canDismissConfig: CanDismissConfig) {
-    this.ionModalElement.canDismiss = this.canDismissHelper.getCanDismissCallback(canDismissConfig);
+  set canDismiss(callback: ShowAlertCallback) {
+    this.ionModalElement.canDismiss = this.canDismissHelper.getCanDismissCallback(callback);
   }
 
   scrollToTop: (_?: any) => void;

--- a/libs/designsystem/modal/src/modal-wrapper/config/modal-config.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/config/modal-config.ts
@@ -7,9 +7,7 @@ import { DrawerSupplementaryAction } from './drawer-supplementary-action';
 export type ModalFlavor = 'modal' | 'drawer' | 'compact';
 export type ModalSize = 'small' | 'medium' | 'large' | 'full-height';
 
-export type ShowAlertCallback =
-  | (() => Promise<boolean | AlertConfig>)
-  | (() => boolean | AlertConfig);
+export type ShowAlertCallback = () => boolean | AlertConfig | Promise<boolean | AlertConfig>;
 
 export interface ModalConfig {
   collapseTitle?: boolean;
@@ -20,7 +18,7 @@ export interface ModalConfig {
   siblingModalRouteActivated$?: Observable<ActivatedRoute>;
   flavor?: ModalFlavor;
   componentProps?: { [key: string]: any };
-  showAlert?: ShowAlertCallback;
+  canDismiss?: ShowAlertCallback;
   // the supplementary action is only available in the drawer
   drawerSupplementaryAction?: DrawerSupplementaryAction;
   // drawer properties

--- a/libs/designsystem/modal/src/modal-wrapper/config/modal-config.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/config/modal-config.ts
@@ -26,7 +26,6 @@ export interface ModalConfig {
   // drawer properties
   interactWithBackground?: boolean;
   cssClass?: string | string[];
-  // canDismissConfig?: CanDismissConfig;
 }
 
 /**

--- a/libs/designsystem/modal/src/modal-wrapper/config/modal-config.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/config/modal-config.ts
@@ -7,7 +7,7 @@ import { DrawerSupplementaryAction } from './drawer-supplementary-action';
 export type ModalFlavor = 'modal' | 'drawer' | 'compact';
 export type ModalSize = 'small' | 'medium' | 'large' | 'full-height';
 export type CanDismissConfig = {
-  canDismiss: (() => Promise<boolean>) | (() => boolean) | true;
+  canDismiss: (() => Promise<boolean>) | (() => boolean);
   alertConfig: AlertConfig;
 };
 

--- a/libs/designsystem/modal/src/modal-wrapper/config/modal-config.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/config/modal-config.ts
@@ -1,10 +1,15 @@
 import { ActivatedRoute, Data, Route } from '@angular/router';
 import { Observable } from 'rxjs';
 
+import { AlertConfig } from '../../public_api';
 import { DrawerSupplementaryAction } from './drawer-supplementary-action';
 
 export type ModalFlavor = 'modal' | 'drawer' | 'compact';
 export type ModalSize = 'small' | 'medium' | 'large' | 'full-height';
+export type CanDismissConfig = {
+  canDismiss: (() => Promise<boolean>) | (() => boolean) | true;
+  alertConfig: AlertConfig;
+};
 
 export interface ModalConfig {
   collapseTitle?: boolean;
@@ -20,6 +25,7 @@ export interface ModalConfig {
   // drawer properties
   interactWithBackground?: boolean;
   cssClass?: string | string[];
+  canDismissConfig?: CanDismissConfig;
 }
 
 /**

--- a/libs/designsystem/modal/src/modal-wrapper/config/modal-config.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/config/modal-config.ts
@@ -6,10 +6,10 @@ import { DrawerSupplementaryAction } from './drawer-supplementary-action';
 
 export type ModalFlavor = 'modal' | 'drawer' | 'compact';
 export type ModalSize = 'small' | 'medium' | 'large' | 'full-height';
-export type CanDismissConfig = {
-  canDismiss: (() => Promise<boolean>) | (() => boolean);
-  alertConfig: AlertConfig;
-};
+
+export type ShowAlertCallback =
+  | (() => Promise<boolean | AlertConfig>)
+  | (() => boolean | AlertConfig);
 
 export interface ModalConfig {
   collapseTitle?: boolean;
@@ -20,12 +20,13 @@ export interface ModalConfig {
   siblingModalRouteActivated$?: Observable<ActivatedRoute>;
   flavor?: ModalFlavor;
   componentProps?: { [key: string]: any };
+  showAlert?: ShowAlertCallback;
   // the supplementary action is only available in the drawer
   drawerSupplementaryAction?: DrawerSupplementaryAction;
   // drawer properties
   interactWithBackground?: boolean;
   cssClass?: string | string[];
-  canDismissConfig?: CanDismissConfig;
+  // canDismissConfig?: CanDismissConfig;
 }
 
 /**

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.integration.spec.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.integration.spec.ts
@@ -5,6 +5,7 @@ import { TestHelper } from '@kirbydesign/designsystem/testing';
 
 import { PageProgressComponent, PageTitleComponent } from '@kirbydesign/designsystem/page';
 import { ModalFooterComponent } from '../modal/footer/modal-footer.component';
+import { CanDismissHelper } from '../modal/services/can-dismiss.helper';
 import { ModalWrapperComponent } from './modal-wrapper.component';
 import {
   DynamicFooterEmbeddedComponent,
@@ -20,6 +21,7 @@ describe('ModalWrapperComponent + ModalFooterComponent', () => {
     component: ModalWrapperComponent,
     imports: [RouterTestingModule, ModalFooterComponent],
     entryComponents: [StaticFooterEmbeddedComponent, DynamicFooterEmbeddedComponent],
+    mocks: [CanDismissHelper],
   });
 
   let modalWrapperTestBuilder: ModalWrapperTestBuilder;
@@ -223,6 +225,7 @@ describe('ModalWrapperComponent + PageTitleComponent', () => {
     imports: [RouterTestingModule],
     entryComponents: [TitleEmbeddedComponent],
     declarations: [PageTitleComponent],
+    mocks: [CanDismissHelper],
   });
 
   let modalWrapperTestBuilder: ModalWrapperTestBuilder;
@@ -281,6 +284,7 @@ describe('ModalWrapperComponent + PageProgressComponent', () => {
     imports: [RouterTestingModule],
     entryComponents: [StaticPageProgressEmbeddedComponent, DynamicPageProgressEmbeddedComponent],
     declarations: [PageProgressComponent],
+    mocks: [CanDismissHelper],
   });
 
   let modalWrapperTestBuilder: ModalWrapperTestBuilder;

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
@@ -9,6 +9,7 @@ import { IconComponent } from '@kirbydesign/designsystem/icon';
 import { DesignTokenHelper, KirbyAnimation } from '@kirbydesign/designsystem/helpers';
 
 import { ButtonComponent } from '@kirbydesign/designsystem/button';
+import { CanDismissHelper } from '../modal/services/can-dismiss.helper';
 import { ModalWrapperComponent } from './modal-wrapper.component';
 import {
   DynamicFooterEmbeddedComponent,
@@ -38,6 +39,7 @@ describe('ModalWrapperComponent', () => {
       },
     ],
     declarations: [MockComponents(ButtonComponent)],
+    mocks: [CanDismissHelper],
   });
 
   let modalWrapperTestBuilder: ModalWrapperTestBuilder;

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
@@ -40,7 +40,8 @@ import { KirbyAnimation } from '@kirbydesign/designsystem/helpers';
 import { ButtonComponent } from '@kirbydesign/designsystem/button';
 
 import { Modal, ModalElementsAdvertiser, ModalElementType } from '../modal.interfaces';
-import { ModalConfig } from './config/modal-config';
+import { CanDismissHelper } from '../modal/services/can-dismiss.helper';
+import { CanDismissConfig, ModalConfig } from './config/modal-config';
 import { COMPONENT_PROPS } from './config/modal-config.helper';
 import { ModalElementsMoverDelegate } from './modal-elements-mover.delegate';
 
@@ -153,7 +154,8 @@ export class ModalWrapperComponent
     private resizeObserverService: ResizeObserverService,
     private componentFactoryResolver: ComponentFactoryResolver,
     private windowRef: WindowRef,
-    private platform: PlatformService
+    private platform: PlatformService,
+    private canDismissHelper: CanDismissHelper
   ) {
     this.setViewportHeight();
     this.observeViewportResize();
@@ -238,6 +240,10 @@ export class ModalWrapperComponent
     }[type];
 
     removeModalElementFn();
+  }
+
+  public setCanDismissConfig(canDismissConfig: CanDismissConfig) {
+    this.ionModalElement.canDismiss = this.canDismissHelper.getCanDismissCallback(canDismissConfig);
   }
 
   private initializeResizeModalToModalWrapper() {

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
@@ -41,7 +41,7 @@ import { ButtonComponent } from '@kirbydesign/designsystem/button';
 
 import { Modal, ModalElementsAdvertiser, ModalElementType } from '../modal.interfaces';
 import { CanDismissHelper } from '../modal/services/can-dismiss.helper';
-import { CanDismissConfig, ModalConfig } from './config/modal-config';
+import { ModalConfig, ShowAlertCallback } from './config/modal-config';
 import { COMPONENT_PROPS } from './config/modal-config.helper';
 import { ModalElementsMoverDelegate } from './modal-elements-mover.delegate';
 
@@ -74,6 +74,10 @@ export class ModalWrapperComponent
 
   set scrollDisabled(disabled: boolean) {
     this.ionContent.scrollY = !disabled;
+  }
+
+  set canDismiss(callback: ShowAlertCallback) {
+    this.ionModalElement.canDismiss = this.canDismissHelper.getCanDismissCallback(callback);
   }
 
   @Input() config: ModalConfig;
@@ -240,10 +244,6 @@ export class ModalWrapperComponent
     }[type];
 
     removeModalElementFn();
-  }
-
-  public setCanDismissConfig(canDismissConfig: CanDismissConfig) {
-    this.ionModalElement.canDismiss = this.canDismissHelper.getCanDismissCallback(canDismissConfig);
   }
 
   private initializeResizeModalToModalWrapper() {

--- a/libs/designsystem/modal/src/modal.interfaces.ts
+++ b/libs/designsystem/modal/src/modal.interfaces.ts
@@ -2,7 +2,7 @@ import { AfterViewInit, Component, ElementRef, OnDestroy, Optional } from '@angu
 import { ActivatedRoute } from '@angular/router';
 
 import { KirbyAnimation } from '@kirbydesign/designsystem/helpers';
-import { AlertConfig } from './public_api';
+import { AlertConfig, CanDismissConfig } from './public_api';
 export interface OverlayEventDetail<T = any> {
   data?: T;
   role?: string;
@@ -35,6 +35,7 @@ export abstract class Modal {
   scrollToTop: (scrollDuration?: KirbyAnimation.Duration) => void;
   scrollToBottom: (scrollDuration?: KirbyAnimation.Duration) => void;
   scrollDisabled: boolean;
+  setCanDismissConfig: (canDismissConfig: CanDismissConfig) => void;
 }
 /**
  * WARNING: This is for internal use only and should not be used outside of Kirby.

--- a/libs/designsystem/modal/src/modal.interfaces.ts
+++ b/libs/designsystem/modal/src/modal.interfaces.ts
@@ -2,7 +2,7 @@ import { AfterViewInit, Component, ElementRef, OnDestroy, Optional } from '@angu
 import { ActivatedRoute } from '@angular/router';
 
 import { KirbyAnimation } from '@kirbydesign/designsystem/helpers';
-import { AlertConfig, CanDismissConfig } from './public_api';
+import { AlertConfig, ShowAlertCallback } from './public_api';
 export interface OverlayEventDetail<T = any> {
   data?: T;
   role?: string;
@@ -35,7 +35,7 @@ export abstract class Modal {
   scrollToTop: (scrollDuration?: KirbyAnimation.Duration) => void;
   scrollToBottom: (scrollDuration?: KirbyAnimation.Duration) => void;
   scrollDisabled: boolean;
-  setCanDismissConfig: (canDismissConfig: CanDismissConfig) => void;
+  canDismiss: ShowAlertCallback;
 }
 /**
  * WARNING: This is for internal use only and should not be used outside of Kirby.

--- a/libs/designsystem/modal/src/modal/services/can-dismiss.helper.spec.ts
+++ b/libs/designsystem/modal/src/modal/services/can-dismiss.helper.spec.ts
@@ -1,0 +1,41 @@
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator';
+import { AlertConfig } from '../alert';
+import { CanDismissHelper } from './can-dismiss.helper';
+import { AlertHelper } from './alert.helper';
+
+describe('CanDismissHelper', () => {
+  let spectator: SpectatorService<CanDismissHelper>;
+
+  const createService = createServiceFactory({
+    service: CanDismissHelper,
+    mocks: [AlertHelper],
+  });
+
+  beforeEach(() => {
+    spectator = createService();
+  });
+
+  describe('getCanDismissCallback', () => {
+    it('should return an async function that returns true, if the provided callback return true', async () => {
+      const callback = () => true;
+
+      const canDismissCallback = spectator.service.getCanDismissCallback(callback);
+      const result = await canDismissCallback();
+
+      expect(result).toBe(true);
+    });
+
+    it('should call the showAlert method, if the provided callback return an AlertConfig', async () => {
+      //@ts-ignore
+      const showAlertSpy = spyOn(spectator.service, 'showAlert');
+      const alertConfig: AlertConfig = { title: 'Test alert' };
+      const callback = () => alertConfig;
+
+      const canDismissCallback = spectator.service.getCanDismissCallback(callback);
+      await canDismissCallback();
+
+      expect(showAlertSpy).toHaveBeenCalledTimes(1);
+      expect(showAlertSpy).toHaveBeenCalledWith(alertConfig);
+    });
+  });
+});

--- a/libs/designsystem/modal/src/modal/services/can-dismiss.helper.spec.ts
+++ b/libs/designsystem/modal/src/modal/services/can-dismiss.helper.spec.ts
@@ -26,7 +26,6 @@ describe('CanDismissHelper', () => {
     });
 
     it('should call the showAlert method, if the provided callback return an AlertConfig', async () => {
-      //@ts-ignore
       const showAlertSpy = spyOn(spectator.service, 'showAlert');
       const alertConfig: AlertConfig = { title: 'Test alert' };
       const callback = () => alertConfig;

--- a/libs/designsystem/modal/src/modal/services/can-dismiss.helper.ts
+++ b/libs/designsystem/modal/src/modal/services/can-dismiss.helper.ts
@@ -20,7 +20,7 @@ export class CanDismissHelper {
 
   public async showAlert(config: AlertConfig): Promise<boolean> {
     const alert = await this.alertHelper.showAlert(config);
-    const result = await alert.onDidDismiss;
+    const result = await alert.onWillDismiss;
     return result.data;
   }
 }

--- a/libs/designsystem/modal/src/modal/services/can-dismiss.helper.ts
+++ b/libs/designsystem/modal/src/modal/services/can-dismiss.helper.ts
@@ -18,7 +18,7 @@ export class CanDismissHelper {
     };
   }
 
-  private async showAlert(config: AlertConfig): Promise<boolean> {
+  public async showAlert(config: AlertConfig): Promise<boolean> {
     const alert = await this.alertHelper.showAlert(config);
     const result = await alert.onDidDismiss;
     return result.data;

--- a/libs/designsystem/modal/src/modal/services/can-dismiss.helper.ts
+++ b/libs/designsystem/modal/src/modal/services/can-dismiss.helper.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { CanDismissConfig } from '../../modal-wrapper/config';
+import { ShowAlertCallback } from '../../modal-wrapper/config';
 import { AlertConfig } from '../alert';
 import { AlertHelper } from './alert.helper';
 
@@ -7,17 +7,13 @@ import { AlertHelper } from './alert.helper';
 export class CanDismissHelper {
   constructor(private alertHelper: AlertHelper) {}
 
-  public getCanDismissCallback(
-    canDismissConfig: CanDismissConfig
-  ): boolean | (() => Promise<boolean>) {
-    const { canDismiss, alertConfig } = canDismissConfig;
-
+  public getCanDismissCallback(callback: ShowAlertCallback) {
     return async () => {
-      const conditionIsMet = await canDismiss();
+      const result = await callback();
 
-      if (!conditionIsMet) {
-        const result = await this.showAlert(alertConfig);
-        return result;
+      if (typeof result !== 'boolean') {
+        const canCloseModal = await this.showAlert(result);
+        return canCloseModal;
       }
 
       return true;

--- a/libs/designsystem/modal/src/modal/services/can-dismiss.helper.ts
+++ b/libs/designsystem/modal/src/modal/services/can-dismiss.helper.ts
@@ -11,18 +11,16 @@ export class CanDismissHelper {
     return async () => {
       const result = await callback();
 
-      if (typeof result !== 'boolean') {
-        const canCloseModal = await this.showAlert(result);
-        return canCloseModal;
-      }
+      if (typeof result === 'boolean') return result;
 
-      return true;
+      const canCloseModal = await this.showAlert(result);
+      return canCloseModal;
     };
   }
 
   private async showAlert(config: AlertConfig): Promise<boolean> {
     const alert = await this.alertHelper.showAlert(config);
-    const result = await alert.onWillDismiss;
+    const result = await alert.onDidDismiss;
     return result.data;
   }
 }

--- a/libs/designsystem/modal/src/modal/services/can-dismiss.helper.ts
+++ b/libs/designsystem/modal/src/modal/services/can-dismiss.helper.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { CanDismissConfig } from '../../modal-wrapper/config';
+import { AlertConfig } from '../alert';
+import { AlertHelper } from './alert.helper';
+
+@Injectable()
+export class CanDismissHelper {
+  constructor(private alertHelper: AlertHelper) {}
+
+  public getCanDismissCallback(
+    canDismissConfig: CanDismissConfig
+  ): boolean | (() => Promise<boolean>) {
+    const { canDismiss, alertConfig } = canDismissConfig;
+
+    return async () => {
+      const conditionIsMet = await canDismiss();
+
+      if (!conditionIsMet) {
+        const result = await this.showAlert(alertConfig);
+        return result;
+      }
+
+      return true;
+    };
+  }
+
+  private async showAlert(config: AlertConfig): Promise<boolean> {
+    const alert = await this.alertHelper.showAlert(config);
+    const result = await alert.onWillDismiss;
+    return result.data;
+  }
+}

--- a/libs/designsystem/modal/src/modal/services/index.ts
+++ b/libs/designsystem/modal/src/modal/services/index.ts
@@ -2,3 +2,4 @@ export * from './modal.helper';
 export * from './action-sheet.helper';
 export * from './alert.helper';
 export * from './modal.controller';
+export * from './can-dismiss.helper';

--- a/libs/designsystem/modal/src/modal/services/modal.controller.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.controller.ts
@@ -75,15 +75,8 @@ export class ModalController implements OnDestroy {
       });
   }
 
-  public async showModal(
-    config: ModalConfig,
-    onClose?: (data?: any) => void,
-    alertConfig?: AlertConfig
-  ): Promise<void> {
-    await this.showAndRegisterOverlay(
-      () => this.modalHelper.showModalWindow(config, alertConfig),
-      onClose
-    );
+  public async showModal(config: ModalConfig, onClose?: (data?: any) => void): Promise<void> {
+    await this.showAndRegisterOverlay(() => this.modalHelper.showModalWindow(config), onClose);
   }
 
   public async navigateToModal(
@@ -111,7 +104,7 @@ export class ModalController implements OnDestroy {
       siblingModalRouteActivated$: siblingModalRouteActivated$,
     };
     await this.showAndRegisterOverlay(
-      () => this.modalHelper.showModalWindow(config, modalData?.alertConfig),
+      () => this.modalHelper.showModalWindow(config),
       null,
       onWillClose
     );

--- a/libs/designsystem/modal/src/modal/services/modal.controller.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.controller.ts
@@ -75,8 +75,15 @@ export class ModalController implements OnDestroy {
       });
   }
 
-  public async showModal(config: ModalConfig, onClose?: (data?: any) => void): Promise<void> {
-    await this.showAndRegisterOverlay(() => this.modalHelper.showModalWindow(config), onClose);
+  public async showModal(
+    config: ModalConfig,
+    onClose?: (data?: any) => void,
+    alertConfig?: AlertConfig
+  ): Promise<void> {
+    await this.showAndRegisterOverlay(
+      () => this.modalHelper.showModalWindow(config, alertConfig),
+      onClose
+    );
   }
 
   public async navigateToModal(
@@ -104,7 +111,7 @@ export class ModalController implements OnDestroy {
       siblingModalRouteActivated$: siblingModalRouteActivated$,
     };
     await this.showAndRegisterOverlay(
-      () => this.modalHelper.showModalWindow(config),
+      () => this.modalHelper.showModalWindow(config, modalData?.alertConfig),
       null,
       onWillClose
     );

--- a/libs/designsystem/modal/src/modal/services/modal.helper.spec.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.helper.spec.ts
@@ -13,7 +13,12 @@ import { ButtonComponent } from '@kirbydesign/designsystem/button';
 import { Modal, Overlay } from '../../modal.interfaces';
 import { AlertConfig } from '../alert/config/alert-config';
 import { ModalFooterComponent } from '../footer/modal-footer.component';
-import { ModalCompactWrapperComponent, ModalConfig, ModalSize } from '../../modal-wrapper';
+import {
+  CanDismissConfig,
+  ModalCompactWrapperComponent,
+  ModalConfig,
+  ModalSize,
+} from '../../modal-wrapper';
 import { ModalNavigationService } from '../../modal-navigation.service';
 import { ModalHelper } from './modal.helper';
 import { AlertHelper } from './alert.helper';
@@ -129,15 +134,19 @@ describe('ModalHelper', () => {
     await overlay.dismiss();
   });
 
-  const openOverlay = async (config: ModalConfig, alertConfig?: AlertConfig) => {
-    overlay = await modalHelper.showModalWindow(config, alertConfig);
+  const openOverlay = async (config: ModalConfig) => {
+    overlay = await modalHelper.showModalWindow(config);
     ionModal = await ionModalController.getTop();
 
     expect(ionModal).toBeTruthy();
   };
 
-  const openModal = async (component?: any, size?: ModalSize, alertConfig?: AlertConfig) => {
-    await openOverlay({ flavor: 'modal', component, size }, alertConfig);
+  const openModal = async (
+    component?: any,
+    size?: ModalSize,
+    canDismissConfig?: CanDismissConfig
+  ) => {
+    await openOverlay({ flavor: 'modal', component, size, canDismissConfig });
   };
 
   const openDrawer = async (
@@ -162,23 +171,29 @@ describe('ModalHelper', () => {
     });
 
     describe('canDismiss', () => {
-      it('should pass "true" to "canDismiss", if no alertConfig is provided', async () => {
+      it('should pass "true" to "canDismiss", if no canDismissConfig is provided', async () => {
         await openModal();
 
         expect(ionModal.canDismiss).toEqual(true);
       });
 
-      it('should pass a function to "canDismiss", if an alertConfig is provided', async () => {
+      it('should pass a function to "canDismiss", if a canDismissConfig is provided', async () => {
         const alertConfig: AlertConfig = {
           title: 'Do you want to close the modal?',
           okBtn: 'Yes',
           cancelBtn: 'No',
         };
+
+        const canDismissConfig: CanDismissConfig = {
+          canDismiss: () => true,
+          alertConfig: alertConfig,
+        };
+
         // Mock 'showAlert' to prevent the test from timing out
         // due to nested async that is not resolved
         spectator.service.showAlert = async () => true;
 
-        await openModal(null, null, alertConfig);
+        await openModal(null, null, canDismissConfig);
 
         expect(typeof ionModal?.canDismiss).toEqual('function');
       });

--- a/libs/designsystem/modal/src/modal/services/modal.helper.spec.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.helper.spec.ts
@@ -167,13 +167,13 @@ describe('ModalHelper', () => {
     });
 
     describe('canDismiss', () => {
-      it('should pass "true" to "canDismiss", if no showAlert callback is provided', async () => {
+      it('should pass "true" to "canDismiss", if no config.canDismiss callback is provided', async () => {
         await openModal();
 
         expect(ionModal.canDismiss).toEqual(true);
       });
 
-      it('should call the getCanDismissCallback method, if a showAlert callback is provided', async () => {
+      it('should call the getCanDismissCallback method, if a config.canDismiss callback is provided', async () => {
         const canDismissHelper = spectator.inject(CanDismissHelper);
         const showAlertCallback = () => true;
 

--- a/libs/designsystem/modal/src/modal/services/modal.helper.spec.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.helper.spec.ts
@@ -141,8 +141,8 @@ describe('ModalHelper', () => {
     expect(ionModal).toBeTruthy();
   };
 
-  const openModal = async (component?: any, size?: ModalSize, showAlert?: ShowAlertCallback) => {
-    await openOverlay({ flavor: 'modal', component, size, showAlert });
+  const openModal = async (component?: any, size?: ModalSize, canDismiss?: ShowAlertCallback) => {
+    await openOverlay({ flavor: 'modal', component, size, canDismiss });
   };
 
   const openDrawer = async (

--- a/libs/designsystem/modal/src/modal/services/modal.helper.spec.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.helper.spec.ts
@@ -21,6 +21,7 @@ import {
 import { ModalNavigationService } from '../../modal-navigation.service';
 import { ModalHelper } from './modal.helper';
 import { CanDismissHelper } from './can-dismiss.helper';
+import { AlertHelper } from './alert.helper';
 
 @Component({
   template: `
@@ -104,7 +105,7 @@ describe('ModalHelper', () => {
       ContentOverflowsWithFooterEmbeddedComponent,
       ContentWithNoOverflowEmbeddedComponent,
     ],
-    mocks: [ModalNavigationService, CanDismissHelper],
+    mocks: [ModalNavigationService, CanDismissHelper, AlertHelper],
   });
 
   beforeAll(() => {

--- a/libs/designsystem/modal/src/modal/services/modal.helper.spec.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.helper.spec.ts
@@ -105,7 +105,7 @@ describe('ModalHelper', () => {
       ContentOverflowsWithFooterEmbeddedComponent,
       ContentWithNoOverflowEmbeddedComponent,
     ],
-    mocks: [ModalNavigationService, CanDismissHelper, AlertHelper],
+    mocks: [ModalNavigationService, AlertHelper, CanDismissHelper],
   });
 
   beforeAll(() => {

--- a/libs/designsystem/modal/src/modal/services/modal.helper.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.helper.ts
@@ -82,7 +82,7 @@ export class ModalHelper {
       let canBeDismissed = false;
       canDismiss = async () => {
         if (!canBeDismissed) {
-          canBeDismissed = await this.showAlert(alertConfig);
+          canBeDismissed = await this.canDismissHelper.showAlert(alertConfig);
         }
 
         return canBeDismissed;
@@ -174,13 +174,5 @@ export class ModalHelper {
     popStateEvent$.pipe(takeUntil(modalClose$)).subscribe(() => {
       modal.dismiss();
     });
-  }
-
-  // This functionality is kept to prevent breaking changes, but should be depracated in the next major.
-  // It is needed to support the old way of passing an alertConfig to the modal.
-  public async showAlert(config: AlertConfig): Promise<boolean> {
-    const alert = await this.alertHelper.showAlert(config);
-    const result = await alert.onWillDismiss;
-    return result.data;
   }
 }

--- a/libs/designsystem/modal/src/modal/services/modal.helper.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.helper.ts
@@ -176,6 +176,8 @@ export class ModalHelper {
     });
   }
 
+  // This functionality is kept to prevent breaking changes, but should be depracated in the next major.
+  // It is needed to support the old way of passing an alertConfig to the modal.
   public async showAlert(config: AlertConfig): Promise<boolean> {
     const alert = await this.alertHelper.showAlert(config);
     const result = await alert.onWillDismiss;

--- a/libs/designsystem/modal/src/modal/services/modal.helper.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.helper.ts
@@ -74,7 +74,7 @@ export class ModalHelper {
     // It will be replaced by the new 'showAlert' callback.
     if (alertConfig) {
       console.warn(
-        "This way of passing an alertConfig to the modal will be deprecated. We recommend using the 'showAlert' callback instead."
+        "This way of passing an alertConfig to the modal will be deprecated in the next major. We recommend using the 'showAlert' callback instead."
       );
 
       // Remembers the modal dismissal response from user to prevent multiple alerts on

--- a/libs/designsystem/modal/src/modal/services/modal.helper.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.helper.ts
@@ -66,15 +66,15 @@ export class ModalHelper {
 
     let canDismiss: boolean | (() => Promise<boolean>) = true;
 
-    if (config.showAlert) {
-      canDismiss = this.canDismissHelper.getCanDismissCallback(config.showAlert);
+    if (config.canDismiss) {
+      canDismiss = this.canDismissHelper.getCanDismissCallback(config.canDismiss);
     }
 
     // This functionality is kept to prevent breaking changes, but should be depracated in the next major.
     // It will be replaced by the new 'showAlert' callback.
     if (alertConfig) {
       console.warn(
-        "This way of passing an alertConfig to the modal will be deprecated in the next major. We recommend using the 'showAlert' callback instead."
+        "This way of passing an alertConfig to the modal will be deprecated in the next major version. We recommend using the 'showAlert' callback instead."
       );
 
       // Remembers the modal dismissal response from user to prevent multiple alerts on
@@ -126,7 +126,7 @@ export class ModalHelper {
 
     // Back button should only be handled manually
     // if the modal is not instantiated through a route.
-    if (!config.modalRoute && !config.showAlert && !alertConfig) {
+    if (!config.modalRoute && !config.canDismiss && !alertConfig) {
       this.handleBrowserBackButton(ionModal);
     }
 

--- a/libs/designsystem/modal/src/modal/services/modal.helper.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.helper.ts
@@ -74,7 +74,7 @@ export class ModalHelper {
     // It will be replaced by the new 'config.canDismiss' callback
     if (alertConfig) {
       console.warn(
-        "This way of passing an alertConfig to the modal will be deprecated in the next major version. We recommend using the 'showAlert' callback instead."
+        "This way of passing an alertConfig to the modal will be deprecated in the next major version. We recommend using the 'config.canDismiss' callback instead."
       );
 
       // Remembers the modal dismissal response from user to prevent multiple alerts on

--- a/libs/designsystem/modal/src/modal/services/modal.helper.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.helper.ts
@@ -71,7 +71,7 @@ export class ModalHelper {
     }
 
     // This functionality is kept to prevent breaking changes, but should be depracated in the next major.
-    // It will be replaced by the new 'showAlert' callback.
+    // It will be replaced by the new 'config.canDismiss' callback
     if (alertConfig) {
       console.warn(
         "This way of passing an alertConfig to the modal will be deprecated in the next major version. We recommend using the 'showAlert' callback instead."

--- a/libs/designsystem/modal/src/modal/services/modal.helper.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.helper.ts
@@ -63,8 +63,8 @@ export class ModalHelper {
 
     let canDismiss: boolean | (() => Promise<boolean>) = true;
 
-    if (config.canDismissConfig) {
-      canDismiss = this.canDismissHelper.getCanDismissCallback(config.canDismissConfig);
+    if (config.showAlert) {
+      canDismiss = this.canDismissHelper.getCanDismissCallback(config.showAlert);
     }
 
     this.isModalOpening = true;
@@ -104,7 +104,7 @@ export class ModalHelper {
 
     // Back button should only be handled manually
     // if the modal is not instantiated through a route.
-    if (!config.modalRoute && !config.canDismissConfig) {
+    if (!config.modalRoute && !config.showAlert) {
       this.handleBrowserBackButton(ionModal);
     }
 

--- a/libs/designsystem/src/lib/kirby.module.ts
+++ b/libs/designsystem/src/lib/kirby.module.ts
@@ -54,6 +54,7 @@ import {
   ActionSheetHelper,
   AlertComponent,
   AlertHelper,
+  CanDismissHelper,
   ModalCompactWrapperComponent,
   ModalController,
   ModalFooterComponent,
@@ -165,6 +166,7 @@ const providers = [
   LoadingOverlayService,
   ResizeObserverFactory,
   ResizeObserverService,
+  CanDismissHelper,
   customElementsInitializer(),
 ];
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3049 

## What is the new behavior?
It is now possible to add a callback to the modal that determines whether to show the alert or not, when the user tries to dismiss the modal. The callback can be set on the parent modal from the embedded component or be provided in the `ModalConfig` object.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?
No.

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

