### PR TITLE
Fix missing highlight of items on keyboard navigation in dropdown when using popover

### DIFF
--- a/libs/designsystem/item/src/item.component.scss
+++ b/libs/designsystem/item/src/item.component.scss
@@ -101,8 +101,9 @@
   --min-height: #{utils.$dropdown-item-height};
 }
 
-// Intented for use with keyboard navigation in <kirby-dropdown>
-:host-context(kirby-dropdown .focused) ion-item {
+// Intented for use with keyboard navigation in <kirby-dropdown> & <kirby-popover>
+:host-context(kirby-dropdown .focused) ion-item,
+:host-context(kirby-popover .focused) ion-item {
   --background: #{interaction-state.get-state-color('white', 'xxxs')};
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3062

## What is the new behavior?
Items will now be highlighted when using the arrow keys to navigate a dropdown with `[usePopover]="true"`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

