### PR TITLE
Fix missing character count on init when using [(ngModel)] on kirby-input

### DIFF
--- a/libs/designsystem/form-field/src/input-counter/input-counter.component.spec.ts
+++ b/libs/designsystem/form-field/src/input-counter/input-counter.component.spec.ts
@@ -82,7 +82,7 @@ describe('InputCounterComponent', () => {
 
   describe('when configured with listenTo = input', () => {
     describe('and input does not have initial value and maxlength', () => {
-      const input = new InputComponent();
+      const input = new InputComponent(null);
       beforeEach(() => {
         component.listenTo = input;
         component.ngOnInit();
@@ -107,7 +107,7 @@ describe('InputCounterComponent', () => {
       const initialValue = 'Test 123';
       const updatedValue = 'Test 123456';
       const maxlength = 99;
-      const input = new InputComponent();
+      const input = new InputComponent(null);
       input.value = initialValue;
       input.maxlength = maxlength;
       beforeEach(() => {

--- a/libs/designsystem/form-field/src/input/input.component.spec.ts
+++ b/libs/designsystem/form-field/src/input/input.component.spec.ts
@@ -179,6 +179,6 @@ describe('ngOnInit', () => {
 
     tick();
 
-    expect(onChangeSpy).toHaveBeenCalledTimes(0);
+    expect(onChangeSpy).not.toHaveBeenCalled();
   }));
 });

--- a/libs/designsystem/form-field/src/input/input.component.spec.ts
+++ b/libs/designsystem/form-field/src/input/input.component.spec.ts
@@ -157,3 +157,28 @@ describe('when configured with size medium', () => {
     });
   });
 });
+
+describe('ngOnInit', () => {
+  const createHost = createHostFactory({
+    component: InputComponent,
+  });
+
+  it('should emit "kirbyChange" if the native input has a value', fakeAsync(() => {
+    const spectator = createHost(`<input kirby-input size="md" value="test value"/>`);
+    const onChangeSpy = spyOn(spectator.component.kirbyChange, 'emit');
+
+    tick();
+
+    expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onChangeSpy).toHaveBeenCalledWith('test value');
+  }));
+
+  it('should not emit "kirbyChange" if the native input does not have a value', fakeAsync(() => {
+    const spectator = createHost(`<input kirby-input size="md"/>`);
+    const onChangeSpy = spyOn(spectator.component.kirbyChange, 'emit');
+
+    tick();
+
+    expect(onChangeSpy).toHaveBeenCalledTimes(0);
+  }));
+});

--- a/libs/designsystem/form-field/src/input/input.component.ts
+++ b/libs/designsystem/form-field/src/input/input.component.ts
@@ -2,11 +2,13 @@ import { CommonModule } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   EventEmitter,
   HostBinding,
   HostListener,
   Input,
   OnChanges,
+  OnInit,
   SimpleChanges,
 } from '@angular/core';
 
@@ -24,7 +26,23 @@ export enum InputSize {
   styleUrls: ['./input.component.scss'],
   template: '',
 })
-export class InputComponent implements OnChanges {
+export class InputComponent implements OnChanges, OnInit {
+  constructor(private _element: ElementRef<HTMLInputElement>) {}
+
+  ngOnInit(): void {
+    // The native input value is emitted here to make sure that
+    // the input counter component receives the value onInit,
+    // when [(ngModel)] is used on kirby-input.
+
+    setTimeout(() => {
+      const inputValue = this._element.nativeElement.value;
+
+      if (inputValue) {
+        this.kirbyChange.emit(inputValue);
+      }
+    });
+  }
+
   private static typeToInputmodeMap = {
     number: 'decimal',
     search: 'search',

--- a/libs/designsystem/form-field/src/input/input.component.ts
+++ b/libs/designsystem/form-field/src/input/input.component.ts
@@ -27,7 +27,7 @@ export enum InputSize {
   template: '',
 })
 export class InputComponent implements OnChanges, OnInit {
-  constructor(private _element: ElementRef<HTMLInputElement>) {}
+  constructor(private elementRef: ElementRef<HTMLInputElement>) {}
 
   ngOnInit(): void {
     // The native input value is emitted here to make sure that
@@ -35,7 +35,7 @@ export class InputComponent implements OnChanges, OnInit {
     // when [(ngModel)] is used on kirby-input.
 
     setTimeout(() => {
-      const inputValue = this._element.nativeElement.value;
+      const inputValue = this.elementRef.nativeElement.value;
 
       if (inputValue) {
         this.kirbyChange.emit(inputValue);

--- a/libs/designsystem/form-field/src/input/input.component.ts
+++ b/libs/designsystem/form-field/src/input/input.component.ts
@@ -31,7 +31,7 @@ export class InputComponent implements OnChanges, OnInit {
 
   ngOnInit(): void {
     // The native input value is emitted here to make sure that
-    // the input counter component receives the value onInit,
+    // the InputCounterComponent receives the value onInit,
     // when [(ngModel)] is used on kirby-input.
 
     setTimeout(() => {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3063

## What is the new behavior?
`kirby-input` will now emit the native element value on init, if the element has a value. This is needed to ensure that `kirby-input-counter` will receive a value on init, when a two way databinding `[(ngModel)]` is used on `kirby-input`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

