### PR TITLE
Enhancement: Page should only show toolbar background and divider on desktop when scrolled

### DIFF
--- a/libs/designsystem/page/src/page.component.scss
+++ b/libs/designsystem/page/src/page.component.scss
@@ -60,7 +60,7 @@ ion-toolbar {
     transition: $toolbar-transition;
   }
 
-  // Only show divider + shaded bg on small screens when content is scrolled:
+  // Only show toolbar divider + shaded bg when content is scrolled:
   &.content-scrolled {
     --background: #{$toolbar-shaded-background};
 
@@ -71,17 +71,6 @@ ion-toolbar {
 
     &:not(.content-pinned)::before {
       background-color: utils.get-color('medium');
-    }
-  }
-
-  // Always show divider + shaded bg on large screens:
-  @include utils.media('>=medium') {
-    --background: #{$toolbar-shaded-background};
-
-    // Divider:
-    &:not(.content-pinned)::before {
-      background-color: utils.get-color('medium');
-      transition-duration: $toolbar-transition-duration-out;
     }
   }
 

--- a/libs/designsystem/page/src/page.component.scss
+++ b/libs/designsystem/page/src/page.component.scss
@@ -74,6 +74,12 @@ ion-toolbar {
     }
   }
 
+  &.content-pinned {
+    &::before {
+      transition: none;
+    }
+  }
+
   /*
   * This overrides Ionic's default ios styling for the position of secondary action buttons which are to the left of content: https://ionicframework.com/docs/api/toolbar#buttons
   * We would like the seconday actions to be to the far right after primary actions (usually as a falafel):
@@ -299,7 +305,6 @@ ion-content {
     left: calc(-1 * var(--padding-start));
     right: calc(-1 * var(--padding-end));
     bottom: 0;
-    transition: $toolbar-transition;
   }
 
   &::before {
@@ -317,11 +322,6 @@ ion-content {
   }
 
   &.content-pinned {
-    &::before,
-    &::after {
-      transition-duration: $toolbar-transition-duration-in;
-    }
-
     &::before {
       /* Background - pinned */
       background-color: $toolbar-shaded-background;

--- a/libs/designsystem/page/src/page.component.spec.ts
+++ b/libs/designsystem/page/src/page.component.spec.ts
@@ -187,6 +187,9 @@ describe('PageComponent', () => {
               expect(ionToolbar).toHaveComputedStyle(
                 {
                   'background-color': getColor('medium'),
+                  content: '""',
+                  height: '1px',
+                  width: `${ionToolbar.offsetWidth}px`,
                 },
                 ':before'
               );
@@ -237,19 +240,52 @@ describe('PageComponent', () => {
           });
         });
 
-        it('should render toolbar divider by default', () => {
-          expect(ionToolbar).toHaveComputedStyle(
-            {
-              'background-color': getColor('medium'),
-            },
-            ':before'
-          );
-        });
+        describe('divider and shaded background', () => {
+          describe('before scroll', () => {
+            it('should not render toolbar divider', () => {
+              expect(ionToolbar).toHaveComputedStyle(
+                {
+                  'background-color': 'rgba(0, 0, 0, 0)',
+                },
+                ':before'
+              );
+            });
 
-        it('should render shaded toolbar background by default', () => {
-          const toolbarBackground = ionToolbar.shadowRoot.querySelector('.toolbar-background');
-          expect(toolbarBackground).toHaveComputedStyle({
-            'background-color': shadedBackgroundColor,
+            it('should not render shaded toolbar background', () => {
+              const toolbarBackground = ionToolbar.shadowRoot.querySelector('.toolbar-background');
+              expect(toolbarBackground).toHaveComputedStyle({
+                'background-color': getColor('background-color'),
+              });
+            });
+          });
+
+          describe('after scrolling page title above content top', () => {
+            beforeEach(async () => {
+              // Scroll page title above content top:
+              const pageTitle: HTMLElement = ionContent.querySelector('.page-title');
+              const andThenSome = 10;
+              const verticalScrollAmount =
+                pageTitle.offsetTop + pageTitle.offsetHeight + andThenSome;
+
+              await ionContent.scrollToPoint(0, verticalScrollAmount, 0);
+              await TestHelper.whenTrue(() => spectator.component.isContentScrolled);
+            });
+
+            it('should render toolbar divider', () => {
+              expect(ionToolbar).toHaveComputedStyle(
+                {
+                  'background-color': getColor('medium'),
+                },
+                ':before'
+              );
+            });
+
+            it('should render shaded toolbar background', () => {
+              const toolbarBackground = ionToolbar.shadowRoot.querySelector('.toolbar-background');
+              expect(toolbarBackground).toHaveComputedStyle({
+                'background-color': shadedBackgroundColor,
+              });
+            });
           });
         });
       });
@@ -814,7 +850,35 @@ describe('PageComponent', () => {
       });
 
       describe('before scroll', () => {
-        it('should render toolbar divider by default', () => {
+        it('should not render toolbar divider', () => {
+          expect(ionToolbar).toHaveComputedStyle(
+            {
+              'background-color': 'rgba(0, 0, 0, 0)',
+            },
+            ':before'
+          );
+        });
+
+        it('should not render shaded toolbar background', () => {
+          const toolbarBackground = ionToolbar.shadowRoot.querySelector('.toolbar-background');
+          expect(toolbarBackground).toHaveComputedStyle({
+            'background-color': getColor('background-color'),
+          });
+        });
+      });
+
+      describe('after scrolling page title above content top', () => {
+        beforeEach(async () => {
+          // Scroll page title above content top:
+          const pageTitle: HTMLElement = ionContent.querySelector('.page-title');
+          const andThenSome = 10;
+          const verticalScrollAmount = pageTitle.offsetTop + pageTitle.offsetHeight + andThenSome;
+
+          await ionContent.scrollToPoint(0, verticalScrollAmount, 0);
+          await TestHelper.whenTrue(() => spectator.component.isContentScrolled);
+        });
+
+        it('should render toolbar divider', () => {
           expect(ionToolbar).toHaveComputedStyle(
             {
               'background-color': getColor('medium'),
@@ -826,7 +890,7 @@ describe('PageComponent', () => {
           );
         });
 
-        it('should render shaded toolbar background by default', () => {
+        it('should render shaded toolbar background', () => {
           const toolbarBackground = ionToolbar.shadowRoot.querySelector('.toolbar-background');
           expect(toolbarBackground).toHaveComputedStyle({
             'background-color': shadedBackgroundColor,


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3076 

## What is the new behavior?

Toolbar background and divider on desktop is only shown when scrolled (same as on small screens)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

No.

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~ (not relevant)

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

