### PR TITLE
Kirby date input shouldn't prefill year

### DIFF
--- a/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
@@ -227,6 +227,12 @@
   [properties]="decimalMaskProperties"
 ></cookbook-api-description-properties>
 
+<h2>Date mask</h2>
+<h4>Properties:</h4>
+<cookbook-api-description-properties
+  [properties]="dateMaskProperties"
+></cookbook-api-description-properties>
+
 <h2>Textarea: Specific properties</h2>
 <h4>Properties:</h4>
 <cookbook-api-description-properties

--- a/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.ts
@@ -1,9 +1,8 @@
 import { Component } from '@angular/core';
+import { InputSize } from '@kirbydesign/designsystem';
 import { ApiDescriptionEvent } from '~/app/shared/api-description/api-description-events/api-description-events.component';
 import { ApiDescriptionMethod } from '~/app/shared/api-description/api-description-methods/api-description-methods.component';
 import { ApiDescriptionProperty } from '~/app/shared/api-description/api-description-properties/api-description-properties.component';
-
-import { InputSize } from '@kirbydesign/designsystem';
 
 @Component({
   selector: 'cookbook-form-field-showcase',
@@ -153,6 +152,15 @@ On native devices this method also ensures the form field is scrolled into the v
       defaultValue: 'false',
       description: 'Disable group seperation',
       type: ['true', 'false'],
+    },
+  ];
+
+  dateMaskProperties: ApiDescriptionProperty[] = [
+    {
+      name: 'prefillYear',
+      defaultValue: 'false',
+      description: 'Enable/disable prefilling of the year.',
+      type: ['boolean'],
     },
   ];
 

--- a/libs/designsystem/form-field/src/directives/date/date-input.directive.spec.ts
+++ b/libs/designsystem/form-field/src/directives/date/date-input.directive.spec.ts
@@ -26,102 +26,122 @@ describe('DateInputDirective', () => {
     ],
   });
 
-  beforeEach(() => {
-    spectator = createDirective(`<input kirby-input type="date" />`);
-  });
-
-  it('should get the instance', () => {
-    const instance = spectator.directive;
-    expect(instance).toBeDefined();
-  });
-
-  it('should have initial date-mask value', () => {
-    // @ts-ignore
-    expect(spectator.element.placeholder).toEqual('mm/dd/yyyy');
-  });
-
-  it('should keep date-mask when typing', () => {
-    spectator.typeInElement('11', spectator.element);
-    expect(spectator.element).toHaveValue('11/dd/yyyy');
-  });
-
-  it('should add leading zero for month > 4', () => {
-    spectator.typeInElement('4', spectator.element);
-    expect(spectator.element).toHaveValue('04/dd/yyyy');
-  });
-
-  it('should add leading zero for day > 4', () => {
-    spectator.typeInElement('01/4', spectator.element);
-    expect(spectator.element).toHaveValue('01/04/yyyy');
-  });
-
-  it('should have inputmode="numeric"', () => {
-    expect((spectator.element as HTMLInputElement).inputMode).toBe('numeric');
-  });
-
-  it('should replace type="date", with type="text"', () => {
-    expect((spectator.element as HTMLInputElement).type).toBe('text');
-  });
-
-  it('should only allow numeric characters', () => {
-    spectator.typeInElement('a', spectator.element);
-    expect(spectator.element).toHaveValue('');
-  });
-
-  it('should handle multiple seperators', () => {
-    spectator.typeInElement('01/01-2021', spectator.element);
-    expect(spectator.element).toHaveValue('01/01/2021');
-
-    spectator.typeInElement('01-01-2021', spectator.element);
-    expect(spectator.element).toHaveValue('01/01/2021');
-
-    spectator.typeInElement('01/01/2021', spectator.element);
-    expect(spectator.element).toHaveValue('01/01/2021');
-  });
-
-  it('should replace yyyy with åååå', () => {
-    locale = 'da';
-
-    // @ts-ignore
-    expect(spectator.element.placeholder).toEqual('mm/dd/yyyy');
-    locale = 'en-GB';
-  });
-
-  describe('datemask element', () => {
-    it('should have the same font-family as input', () => {
-      const datemask = spectator.element.parentNode.querySelector('.date-mask');
-
-      const inputFontFamily = TestHelper.getCssProperty(spectator.element, 'font-family');
-      const datemaskFontFamily = TestHelper.getCssProperty(datemask, 'font-family');
-
-      expect(datemaskFontFamily).toEqual(inputFontFamily);
+  describe('by default', () => {
+    beforeEach(() => {
+      spectator = createDirective(`<input kirby-input type="date" />`);
     });
 
-    it('should have the same font-size as input', () => {
-      const datemask = spectator.element.parentNode.querySelector('.date-mask');
-
-      const inputFontSize = TestHelper.getCssProperty(spectator.element, 'font-size');
-      const datemaskFontSize = TestHelper.getCssProperty(datemask, 'font-size');
-
-      expect(datemaskFontSize).toEqual(inputFontSize);
+    it('should get the instance', () => {
+      const instance = spectator.directive;
+      expect(instance).toBeDefined();
     });
 
-    it('should have the same line-height as input', () => {
-      const datemask = spectator.element.parentNode.querySelector('.date-mask');
-
-      const inputLineHeight = TestHelper.getCssProperty(spectator.element, 'line-height');
-      const datemaskLineHeight = TestHelper.getCssProperty(datemask, 'line-height');
-
-      expect(datemaskLineHeight).toEqual(inputLineHeight);
+    it('should have initial date-mask value', () => {
+      // @ts-ignore
+      expect(spectator.element.placeholder).toEqual('mm/dd/yyyy');
     });
 
-    it('should have same padding as input padding', () => {
-      const datemask = spectator.element.parentNode.querySelector('.date-mask');
+    it('should keep date-mask when typing', () => {
+      spectator.typeInElement('11', spectator.element);
+      expect(spectator.element).toHaveValue('11/dd/yyyy');
+    });
 
-      const inputPadding = TestHelper.getCssProperty(spectator.element, 'padding');
-      const datemaskPadding = TestHelper.getCssProperty(datemask, 'padding');
+    it('should add leading zero for month > 4', () => {
+      spectator.typeInElement('4', spectator.element);
+      expect(spectator.element).toHaveValue('04/dd/yyyy');
+    });
 
-      expect(datemaskPadding).toEqual(inputPadding);
+    it('should add leading zero for day > 4', () => {
+      spectator.typeInElement('01/4', spectator.element);
+      expect(spectator.element).toHaveValue('01/04/yyyy');
+    });
+
+    it('should have inputmode="numeric"', () => {
+      expect((spectator.element as HTMLInputElement).inputMode).toBe('numeric');
+    });
+
+    it('should replace type="date", with type="text"', () => {
+      expect((spectator.element as HTMLInputElement).type).toBe('text');
+    });
+
+    it('should only allow numeric characters', () => {
+      spectator.typeInElement('a', spectator.element);
+      expect(spectator.element).toHaveValue('');
+    });
+
+    it('should not prefill year by default', () => {
+      spectator.typeInElement('10/04/20', spectator.element);
+      expect(spectator.element).toHaveValue('10/04/20yy');
+    });
+
+    it('should handle multiple seperators', () => {
+      spectator.typeInElement('01/01-2021', spectator.element);
+      expect(spectator.element).toHaveValue('01/01/2021');
+
+      spectator.typeInElement('01-01-2021', spectator.element);
+      expect(spectator.element).toHaveValue('01/01/2021');
+
+      spectator.typeInElement('01/01/2021', spectator.element);
+      expect(spectator.element).toHaveValue('01/01/2021');
+    });
+
+    it('should replace yyyy with åååå', () => {
+      locale = 'da';
+
+      // @ts-ignore
+      expect(spectator.element.placeholder).toEqual('mm/dd/yyyy');
+      locale = 'en-GB';
+    });
+
+    describe('datemask element', () => {
+      it('should have the same font-family as input', () => {
+        const datemask = spectator.element.parentNode.querySelector('.date-mask');
+
+        const inputFontFamily = TestHelper.getCssProperty(spectator.element, 'font-family');
+        const datemaskFontFamily = TestHelper.getCssProperty(datemask, 'font-family');
+
+        expect(datemaskFontFamily).toEqual(inputFontFamily);
+      });
+
+      it('should have the same font-size as input', () => {
+        const datemask = spectator.element.parentNode.querySelector('.date-mask');
+
+        const inputFontSize = TestHelper.getCssProperty(spectator.element, 'font-size');
+        const datemaskFontSize = TestHelper.getCssProperty(datemask, 'font-size');
+
+        expect(datemaskFontSize).toEqual(inputFontSize);
+      });
+
+      it('should have the same line-height as input', () => {
+        const datemask = spectator.element.parentNode.querySelector('.date-mask');
+
+        const inputLineHeight = TestHelper.getCssProperty(spectator.element, 'line-height');
+        const datemaskLineHeight = TestHelper.getCssProperty(datemask, 'line-height');
+
+        expect(datemaskLineHeight).toEqual(inputLineHeight);
+      });
+
+      it('should have same padding as input padding', () => {
+        const datemask = spectator.element.parentNode.querySelector('.date-mask');
+
+        const inputPadding = TestHelper.getCssProperty(spectator.element, 'padding');
+        const datemaskPadding = TestHelper.getCssProperty(datemask, 'padding');
+
+        expect(datemaskPadding).toEqual(inputPadding);
+      });
+    });
+  });
+
+  describe('when configured with prefillYear', () => {
+    beforeEach(() => {
+      spectator = createDirective(`<input kirby-input type="date" [prefillYear]="true" />`);
+    });
+
+    it('should prefill year with current year when configured', () => {
+      spectator.typeInElement('10/04/20', spectator.element);
+
+      const currentYear = new Date().getFullYear();
+      expect(spectator.element).toHaveValue(`10/04/${currentYear}`);
     });
   });
 });

--- a/libs/designsystem/form-field/src/directives/date/date-input.directive.ts
+++ b/libs/designsystem/form-field/src/directives/date/date-input.directive.ts
@@ -5,6 +5,7 @@ import {
   ElementRef,
   HostListener,
   Inject,
+  Input,
   LOCALE_ID,
   Renderer2,
 } from '@angular/core';
@@ -20,6 +21,8 @@ export class DateInputDirective implements AfterViewInit {
   onInput() {
     this.updateMask(this.elementRef.nativeElement.value);
   }
+
+  @Input() prefillYear = false;
 
   private maskingElement: HTMLElement;
 
@@ -47,6 +50,7 @@ export class DateInputDirective implements AfterViewInit {
     new Inputmask('datetime', {
       inputFormat,
       placeholder,
+      prefillYear: this.prefillYear,
     }).mask(this.elementRef.nativeElement);
 
     // Append input overlay, so it's possible to style typed date differntly than the date-mask


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3080 

## What is the new behavior?

Kirby input doesn't prefill the year ;)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- ~~[ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be merged to `develop` by Team Kirby.

