### PR TITLE
Only animate transition between pages in kirby-router-outlet when running as app

### DIFF
--- a/libs/designsystem/kirby-ionic-module/src/kirby-ionic.module.ts
+++ b/libs/designsystem/kirby-ionic-module/src/kirby-ionic.module.ts
@@ -1,25 +1,21 @@
 import { NgModule } from '@angular/core';
 import { AnimationController, IonicModule, isPlatform } from '@ionic/angular';
+import { IonicConfig } from '@ionic/core';
 
-const getIonicConfig = () => {
-  let config: any = {
-    mode: 'ios',
-    inputShims: true,
-    scrollAssist: true,
-    scrollPadding: false,
-  };
-
-  if (!isPlatform('hybrid')) {
-    config = {
-      ...config,
-      navAnimation: () => new AnimationController().create(),
-    };
-  }
-
-  return config;
+const navAnimation: IonicConfig = !isPlatform('hybrid') && {
+  navAnimation: () => new AnimationController().create(),
 };
+
+const config: IonicConfig = {
+  mode: 'ios',
+  inputShims: true,
+  scrollAssist: true,
+  scrollPadding: false,
+  ...navAnimation,
+};
+
 @NgModule({
-  imports: [IonicModule.forRoot(getIonicConfig())],
+  imports: [IonicModule.forRoot(config)],
   exports: [IonicModule],
 })
 export class KirbyIonicModule {}

--- a/libs/designsystem/kirby-ionic-module/src/kirby-ionic.module.ts
+++ b/libs/designsystem/kirby-ionic-module/src/kirby-ionic.module.ts
@@ -1,15 +1,25 @@
 import { NgModule } from '@angular/core';
-import { IonicModule } from '@ionic/angular';
+import { IonicModule, isPlatform } from '@ionic/angular';
 
+const getIonicConfig = () => {
+  let config: any = {
+    mode: 'ios',
+    inputShims: true,
+    scrollAssist: true,
+    scrollPadding: false,
+  };
+
+  if (!isPlatform('hybrid')) {
+    config = {
+      ...config,
+      navAnimation: () => null,
+    };
+  }
+
+  return config;
+};
 @NgModule({
-  imports: [
-    IonicModule.forRoot({
-      mode: 'ios',
-      inputShims: true,
-      scrollAssist: true,
-      scrollPadding: false,
-    }),
-  ],
+  imports: [IonicModule.forRoot(getIonicConfig())],
   exports: [IonicModule],
 })
 export class KirbyIonicModule {}

--- a/libs/designsystem/kirby-ionic-module/src/kirby-ionic.module.ts
+++ b/libs/designsystem/kirby-ionic-module/src/kirby-ionic.module.ts
@@ -2,7 +2,9 @@ import { NgModule } from '@angular/core';
 import { AnimationController, IonicModule, isPlatform } from '@ionic/angular';
 import { IonicConfig } from '@ionic/core';
 
-const navAnimationConfig: IonicConfig = !isPlatform('hybrid') && {
+const shouldHaveNoopAnimation = !isPlatform('hybrid');
+
+const navAnimationConfig: IonicConfig = shouldHaveNoopAnimation && {
   navAnimation: () => new AnimationController().create(),
 };
 

--- a/libs/designsystem/kirby-ionic-module/src/kirby-ionic.module.ts
+++ b/libs/designsystem/kirby-ionic-module/src/kirby-ionic.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { AnimationController, IonicModule, isPlatform } from '@ionic/angular';
 import { IonicConfig } from '@ionic/core';
 
-const navAnimation: IonicConfig = !isPlatform('hybrid') && {
+const navAnimationConfig: IonicConfig = !isPlatform('hybrid') && {
   navAnimation: () => new AnimationController().create(),
 };
 
@@ -11,7 +11,7 @@ const config: IonicConfig = {
   inputShims: true,
   scrollAssist: true,
   scrollPadding: false,
-  ...navAnimation,
+  ...navAnimationConfig,
 };
 
 @NgModule({

--- a/libs/designsystem/kirby-ionic-module/src/kirby-ionic.module.ts
+++ b/libs/designsystem/kirby-ionic-module/src/kirby-ionic.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { IonicModule, isPlatform } from '@ionic/angular';
+import { AnimationController, IonicModule, isPlatform } from '@ionic/angular';
 
 const getIonicConfig = () => {
   let config: any = {
@@ -12,7 +12,7 @@ const getIonicConfig = () => {
   if (!isPlatform('hybrid')) {
     config = {
       ...config,
-      navAnimation: () => null,
+      navAnimation: () => new AnimationController().create(),
     };
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3083 

## What is the new behavior?
Pages (components) inside `kirby-router-outlet` will only animate when Kirby is running inside Capacitor (e.g. in an app context). This is done by checking for the [ionic platform services 'hybrid' option](https://ionicframework.com/docs/angular/platform#platforms).

The config checks for the hybrid flag because we do not wish to animate pages when running in a browser on devices - in that case, we still want the web-like experience. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

