### PR TITLE
Page: add option to subscribe to toolbar title click

### DIFF
--- a/libs/designsystem/header/src/header.component.html
+++ b/libs/designsystem/header/src/header.component.html
@@ -8,7 +8,7 @@
 
 <div class="container">
     <!-- Title and value - title: -->
-  <h1 *ngIf="!!title && !!value" #titleElement class="title kirby-text-medium" [class.clickable]="titleClick.observed" [class.has-icon]="!!titleActionIconTemplate" (click)="onTitleClick($event)">
+  <h1 *ngIf="!!title && !!value" #titleElement class="title kirby-text-medium" [class.clickable]="hasInteractiveTitle !== false && titleClick.observed" [class.has-icon]="!!titleActionIconTemplate" (click)="onTitleClick($event)">
     {{ title }}
     <ng-container *ngTemplateOutlet="titleActionIconTemplate"></ng-container>
   </h1>

--- a/libs/designsystem/header/src/header.component.ts
+++ b/libs/designsystem/header/src/header.component.ts
@@ -81,6 +81,7 @@ export class HeaderComponent implements AfterContentInit, OnInit {
   @Input() valueUnit: string = null;
   @Input() subtitle1: string = null;
   @Input() subtitle2: string = null;
+  @Input() hasInteractiveTitle?: boolean;
 
   @Output() titleClick = new EventEmitter<PointerEvent>();
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3075 

## What is the new behavior?

It's already possible to subscribe to `Header.onTitleClick()` which also is emitted on toolbar title click, but in virtual scrolling scenarios the header gets removed from the DOM and the component instance destroyed, which prevents the event handler from being triggered.

This PR adds a `toolbarTitleClick` event/output property.
It also adds a `hasInteractiveTitle` prop to support overriding when the toolbar should be styled as clickable (i.e. `cursor: pointer)` 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?
No.

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- ~~[ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be merged to `develop` by Team Kirby.

