### PR TITLE
Fix slides navigation buttons showing above sticky tab navigation

### DIFF
--- a/libs/core/src/scss/base/_variables.scss
+++ b/libs/core/src/scss/base/_variables.scss
@@ -75,7 +75,7 @@ $z-layers: (
   default: 1,
   segment-badge: 2,
   avatar-badge: 2,
-  sticky-content: 2,
+  sticky-content: 10,
   dropdown: 800,
   popover: 850,
   modal-overlay: 900,

--- a/libs/designsystem/slide/src/slides.component.scss
+++ b/libs/designsystem/slide/src/slides.component.scss
@@ -43,6 +43,7 @@ $bullet-inactive-opacity: 0.2;
 
   .buttons {
     display: none;
+    z-index: utils.z('default');
 
     @include utils.media('>=medium') {
       display: block;
@@ -51,13 +52,11 @@ $bullet-inactive-opacity: 0.2;
     .swiper-button-prev {
       margin-block: 0;
       margin-inline-start: 0;
-      z-index: utils.z('default');
     }
 
     .swiper-button-next {
       margin-block: 0;
       margin-inline-end: 0;
-      z-index: utils.z('default');
     }
 
     @include utils.slotted('button[kirby-button]') {

--- a/libs/designsystem/slide/src/slides.component.scss
+++ b/libs/designsystem/slide/src/slides.component.scss
@@ -51,11 +51,13 @@ $bullet-inactive-opacity: 0.2;
     .swiper-button-prev {
       margin-block: 0;
       margin-inline-start: 0;
+      z-index: utils.z('default');
     }
 
     .swiper-button-next {
       margin-block: 0;
       margin-inline-end: 0;
+      z-index: utils.z('default');
     }
 
     @include utils.slotted('button[kirby-button]') {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3113 

## What is the new behavior?
We reset the z-index of the `next` and `prev` button, so they match the rest of the page content. At the same time, we make sure the sticky content actually has the same z-index as ionics header/toolbar, which is 10. 

The reason we can comfortably do this is because the navigation buttons are visually moved onto canvas instead of on top of the slides which is the case for the default swiper.js setup. Because they are placed in the top right corner, they will never be occluded by slides.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

