### PR TITLE
Disable animations on desktop

### DIFF
--- a/libs/designsystem/router-outlet/src/router-outlet.component.html
+++ b/libs/designsystem/router-outlet/src/router-outlet.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="main">
-  <ion-router-outlet main></ion-router-outlet>
+  <ion-router-outlet main [animated]="_animated"></ion-router-outlet>
 </ng-container>
 <ng-container *ngIf="!main">
-  <ion-router-outlet></ion-router-outlet>
+  <ion-router-outlet [animated]="_animated"></ion-router-outlet>
 </ng-container>

--- a/libs/designsystem/router-outlet/src/router-outlet.component.ts
+++ b/libs/designsystem/router-outlet/src/router-outlet.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { isPlatform } from '@ionic/angular';
 
 @Component({
   selector: 'kirby-router-outlet',
@@ -8,4 +9,6 @@ import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 })
 export class RouterOutletComponent {
   @Input() main: boolean;
+
+  _animated = isPlatform('hybrid');
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3114

## What is the new behavior?

Disables animations on `ion-router-outlet` when platform is not hybrid.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

No.

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- ~~[ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- ~~[ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

