### PR TITLE
Fix kirby-slides breaking when slides input is updated 

### DIFF
--- a/libs/designsystem/slide/src/slides.component.ts
+++ b/libs/designsystem/slide/src/slides.component.ts
@@ -97,7 +97,7 @@ export class SlidesComponent implements OnInit, AfterViewInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes?.slides.firstChange === false) {
+    if (changes.slides?.firstChange === false) {
       this.cdr.detectChanges();
       this.swiperContainer.nativeElement.swiper.updateSlides();
     }

--- a/libs/designsystem/slide/src/slides.component.ts
+++ b/libs/designsystem/slide/src/slides.component.ts
@@ -45,13 +45,6 @@ type SwiperContainer = HTMLElement & { initialize: () => void; swiper: Swiper };
 export class SlidesComponent implements OnInit, AfterViewInit, OnChanges {
   constructor(private platform: PlatformService, private cdr: ChangeDetectorRef) {}
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes?.slides.firstChange === false) {
-      this.cdr.detectChanges();
-      this.swiperContainer.nativeElement.swiper.updateSlides();
-    }
-  }
-
   @ViewChild('swiperContainer') swiperContainer: ElementRef<SwiperContainer>;
   @ContentChild(SlideDirective, { static: true, read: TemplateRef })
   public slideTemplate: TemplateRef<SlideDirective>;
@@ -101,6 +94,13 @@ export class SlidesComponent implements OnInit, AfterViewInit, OnChanges {
 
   public slideTo(index: number) {
     this.swiperContainer.nativeElement.swiper.slideTo(index);
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes?.slides.firstChange === false) {
+      this.cdr.detectChanges();
+      this.swiperContainer.nativeElement.swiper.updateSlides();
+    }
   }
 
   private getDefaultConfig(): KirbySwiperOptions {

--- a/libs/designsystem/slide/src/slides.component.ts
+++ b/libs/designsystem/slide/src/slides.component.ts
@@ -1,13 +1,16 @@
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ContentChild,
   ElementRef,
   EventEmitter,
   Input,
+  OnChanges,
   OnInit,
   Output,
+  SimpleChanges,
   TemplateRef,
   ViewChild,
 } from '@angular/core';
@@ -39,8 +42,15 @@ type SwiperContainer = HTMLElement & { initialize: () => void; swiper: Swiper };
   styleUrls: ['./slides.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SlidesComponent implements OnInit, AfterViewInit {
-  constructor(private platform: PlatformService) {}
+export class SlidesComponent implements OnInit, AfterViewInit, OnChanges {
+  constructor(private platform: PlatformService, private cdr: ChangeDetectorRef) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes?.slides.firstChange === false) {
+      this.cdr.detectChanges();
+      this.swiperContainer.nativeElement.swiper.updateSlides();
+    }
+  }
 
   @ViewChild('swiperContainer') swiperContainer: ElementRef<SwiperContainer>;
   @ContentChild(SlideDirective, { static: true, read: TemplateRef })


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3112

## What is the new behavior?
When kirby-slides slides input is updated asynchronosly, but with a new object that causes us to re-render the individual slides without re-rendering the slides template itself, swiper.js no longer has the correct slide element references to apply its styles/calculations to, causing the slides to lose all config like slides per view, gap etc. 
![image](https://github.com/kirbydesign/designsystem/assets/42470636/3018f86a-8c5e-49ba-a4f4-40906d0405e1)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

