### PR TITLE
Only warn once about table deprecations

### DIFF
--- a/libs/designsystem/data-table/src/table-row/table-row.component.ts
+++ b/libs/designsystem/data-table/src/table-row/table-row.component.ts
@@ -22,7 +22,12 @@ const KIRBY_TABLE_ROW_SELECTABLE_DEPRECATION_WARNING =
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TableRowComponent {
+  static hasWarnedAboutTableRowDeprecation: boolean = false;
+  static hasWarnedAboutSelectableDeprecation: boolean = false;
+
   constructor() {
+    if (TableRowComponent.hasWarnedAboutTableRowDeprecation) return;
+    TableRowComponent.hasWarnedAboutTableRowDeprecation = true;
     console.warn(KIRBY_TABLE_ROW_DEPRECATION_WARNING);
   }
 
@@ -35,6 +40,9 @@ export class TableRowComponent {
 
   @Input() set selectable(selectable: boolean) {
     this._selectable = selectable;
+
+    if (TableRowComponent.hasWarnedAboutSelectableDeprecation) return;
+    TableRowComponent.hasWarnedAboutSelectableDeprecation = true;
     console.warn(KIRBY_TABLE_ROW_SELECTABLE_DEPRECATION_WARNING);
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?
We accidentally warn about table row and selectable deprecations for each instance of the table row component, which is of course not ideal for a component such as table with many individual rows: 
![image](https://github.com/kirbydesign/designsystem/assets/42470636/116ce2fd-e751-4dd4-bbf6-163e5b605e40)

A drawback of this solution is that we only warn for the first table that is instantiated in an application, but I believe it is a significant improvement as opposed to warning over and over again.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

