### PR TITLE
Remove obsolete Ionic shims

### DIFF
--- a/libs/designsystem/kirby-ionic-module/src/kirby-ionic.module.ts
+++ b/libs/designsystem/kirby-ionic-module/src/kirby-ionic.module.ts
@@ -10,9 +10,6 @@ const navAnimationConfig: IonicConfig = shouldHaveNoopAnimation && {
 
 const config: IonicConfig = {
   mode: 'ios',
-  inputShims: true,
-  scrollAssist: true,
-  scrollPadding: false,
   ...navAnimationConfig,
 };
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3060 

## What is the new behavior?

Ionic 6.0 changed the configuration API and moved shims for input, scroll etc. to internal and now sets them based on platform and device.

This PR removes those shims from Kirby's Ionic config accordingly.   

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

It seems this also solves the bug _on Android_ regarding input shifting position when scrolling in a modal (#2652)


## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- ~~[ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- ~~[ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

