### PR TITLE
Revert sass.math removal

### DIFF
--- a/libs/designsystem/tabs/src/tab-button/tab-button.component.scss
+++ b/libs/designsystem/tabs/src/tab-button/tab-button.component.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 @use '@kirbydesign/core/src/scss/interaction-state';
 @use '@kirbydesign/core/src/scss/utils';
 
@@ -67,7 +69,11 @@ ion-tab-button {
         --kirby-badge-left: 0;
 
         margin-left: utils.size('xxxxs');
-        margin-bottom: utils.size('xxxxs') / 2;
+
+        // Using / for division outside of calc() is deprecated
+        // and will be removed in Dart Sass 2.0.0. Use math.div() instead.
+        // See: https://sass-lang.com/documentation/breaking-changes/slash-div/
+        margin-bottom: math.div(utils.size('xxxxs'), 2);
       }
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3130

## What is the new behavior?

None. Reverts `sass.math` removal as using `/` for division outside of `calc()` is deprecated.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

No.

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- ~~[ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- ~~[ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] ~~Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be merged to `develop` by Team Kirby.

