### PR TITLE
Tabs: only apply animation to background-color

### DIFF
--- a/libs/designsystem/tabs/src/tab-button/tab-button.component.scss
+++ b/libs/designsystem/tabs/src/tab-button/tab-button.component.scss
@@ -19,7 +19,7 @@ ion-tab-button {
     --background: #{interaction-state.get-state-color('white', 'xxs')};
   }
 
-  transition: interaction-state.transition();
+  transition: interaction-state.transition(background-color);
   height: 100%;
   flex: 1 1 0%;
   max-width: 168px;

--- a/libs/designsystem/tabs/src/tab-button/tab-button.component.spec.ts
+++ b/libs/designsystem/tabs/src/tab-button/tab-button.component.spec.ts
@@ -26,7 +26,6 @@ describe('TabsComponent', () => {
       spectator = createHost();
       ionTabButton = spectator.query('ion-tab-button');
       await TestHelper.whenReady(ionTabButton);
-      ionTabButton.style.transition = 'none';
       innerButton = ionTabButton.shadowRoot.querySelector('[part=native]');
     });
 
@@ -46,6 +45,12 @@ describe('TabsComponent', () => {
 
       expect(ionTabButton).toHaveComputedStyle({
         color: getTextColor('black'),
+      });
+    });
+
+    it('should only apply css transition to background-color', () => {
+      expect(ionTabButton).toHaveComputedStyle({
+        'transition-property': 'background-color',
       });
     });
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3136 

## What is the new behavior?

Only background-color of tab in hover/active state is animated, text and icon color changes instantly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

No.

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- ~~[ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

