### PR TITLE
Close sliding item when clicking swipeAction

### DIFF
--- a/libs/designsystem/item-sliding/src/item-sliding.component.html
+++ b/libs/designsystem/item-sliding/src/item-sliding.component.html
@@ -6,7 +6,7 @@
       <ion-item-option
         *ngIf="!swipeAction.isDisabled"
         [ngClass]="swipeAction.type"
-        (click)="swipeAction.onSelected()"
+        (click)="onSwipeActionClick(swipeAction)"
       >
         <kirby-icon
           *ngIf="swipeAction.icon !== undefined"

--- a/libs/designsystem/item-sliding/src/item-sliding.component.spec.ts
+++ b/libs/designsystem/item-sliding/src/item-sliding.component.spec.ts
@@ -145,8 +145,8 @@ describe('ItemSlidingComponent', () => {
         const idx = 0;
         const closeSpy = spyOn(spectator.component.itemSliding, 'close');
         ionItemOptionElements[idx].click();
-     expect(closeSpy).toHaveBeenCalled(); 
-     expect(closeSpy).toHaveBeenCalledTimes(1);
+        expect(closeSpy).toHaveBeenCalled();
+        expect(closeSpy).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/libs/designsystem/item-sliding/src/item-sliding.component.spec.ts
+++ b/libs/designsystem/item-sliding/src/item-sliding.component.spec.ts
@@ -143,7 +143,7 @@ describe('ItemSlidingComponent', () => {
 
       it('should call close', () => {
         const idx = 0;
-        const onSelectedSpy = spyOn(spectator.component.itemSliding, 'close');
+        const closeSpy = spyOn(spectator.component.itemSliding, 'close');
         ionItemOptionElements[idx].click();
      expect(closeSpy).toHaveBeenCalled(); 
      expect(closeSpy).toHaveBeenCalledTimes(1);

--- a/libs/designsystem/item-sliding/src/item-sliding.component.spec.ts
+++ b/libs/designsystem/item-sliding/src/item-sliding.component.spec.ts
@@ -138,7 +138,6 @@ describe('ItemSlidingComponent', () => {
         const idx = 0;
         const onSelectedSpy = spyOn(spectator.component.swipeActions[idx], 'onSelected');
         ionItemOptionElements[idx].click();
-
         expect(onSelectedSpy).toHaveBeenCalled();
       });
 
@@ -146,7 +145,6 @@ describe('ItemSlidingComponent', () => {
         const idx = 0;
         const onSelectedSpy = spyOn(spectator.component.itemSliding, 'close');
         ionItemOptionElements[idx].click();
-
         expect(onSelectedSpy).toHaveBeenCalled();
       });
     });

--- a/libs/designsystem/item-sliding/src/item-sliding.component.spec.ts
+++ b/libs/designsystem/item-sliding/src/item-sliding.component.spec.ts
@@ -145,7 +145,8 @@ describe('ItemSlidingComponent', () => {
         const idx = 0;
         const onSelectedSpy = spyOn(spectator.component.itemSliding, 'close');
         ionItemOptionElements[idx].click();
-        expect(onSelectedSpy).toHaveBeenCalled();
+     expect(closeSpy).toHaveBeenCalled(); 
+     expect(closeSpy).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/libs/designsystem/item-sliding/src/item-sliding.component.spec.ts
+++ b/libs/designsystem/item-sliding/src/item-sliding.component.spec.ts
@@ -140,6 +140,13 @@ describe('ItemSlidingComponent', () => {
         ionItemOptionElements[idx].click();
         expect(onSelectedSpy).toHaveBeenCalled();
       });
+
+      it('should call close', () => {
+        const idx = 0;
+        const onSelectedSpy = spyOn(spectator.component.itemSliding, 'close');
+        ionItemOptionElements[idx].click();
+        expect(onSelectedSpy).toHaveBeenCalled();
+      });
     });
 
     describe('when a swipeAction has an icon', () => {

--- a/libs/designsystem/item-sliding/src/item-sliding.component.spec.ts
+++ b/libs/designsystem/item-sliding/src/item-sliding.component.spec.ts
@@ -138,6 +138,7 @@ describe('ItemSlidingComponent', () => {
         const idx = 0;
         const onSelectedSpy = spyOn(spectator.component.swipeActions[idx], 'onSelected');
         ionItemOptionElements[idx].click();
+
         expect(onSelectedSpy).toHaveBeenCalled();
       });
 
@@ -145,6 +146,7 @@ describe('ItemSlidingComponent', () => {
         const idx = 0;
         const onSelectedSpy = spyOn(spectator.component.itemSliding, 'close');
         ionItemOptionElements[idx].click();
+
         expect(onSelectedSpy).toHaveBeenCalled();
       });
     });

--- a/libs/designsystem/item-sliding/src/item-sliding.component.ts
+++ b/libs/designsystem/item-sliding/src/item-sliding.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input } from '@angular/core';
-import { IonicModule } from '@ionic/angular';
+import { Component, Input, ViewChild } from '@angular/core';
+import { IonicModule, IonItemSliding } from '@ionic/angular';
 import { IconModule } from '@kirbydesign/designsystem/icon';
 
 import { ItemSlidingSide, ItemSwipeAction } from './item-sliding.types';
@@ -13,6 +13,7 @@ import { ItemSlidingSide, ItemSwipeAction } from './item-sliding.types';
   styleUrls: ['./item-sliding.component.scss'],
 })
 export class ItemSlidingComponent {
+  @ViewChild(IonItemSliding, { static: true }) itemSliding: IonItemSliding;
   @Input() swipeActions: ItemSwipeAction[];
 
   _side: 'start' | 'end' = 'start';
@@ -24,5 +25,10 @@ export class ItemSlidingComponent {
     // Using '>' instead of '!==';
     // will only return true when swipeActions is an array
     return this.swipeActions?.length > 0;
+  }
+
+  onSwipeActionClick(swipeAction: ItemSwipeAction): void {
+    swipeAction.onSelected();
+    this.itemSliding.close();
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2894 

## What is the new behavior?

When using kirby sliding item now autocloses on click

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

