### PR TITLE
Remove the old implementation of alertBeforeClose

### DIFF
--- a/libs/designsystem/modal/src/modal-navigation.service.ts
+++ b/libs/designsystem/modal/src/modal-navigation.service.ts
@@ -4,7 +4,7 @@ import { EMPTY, firstValueFrom, Observable } from 'rxjs';
 import { filter, map, pairwise, startWith } from 'rxjs/operators';
 
 import { Location } from '@angular/common';
-import { ModalRouteActivation, NavigationData } from './modal.interfaces';
+import { ModalRouteActivation } from './modal.interfaces';
 import { AlertConfig } from './public_api';
 
 @Injectable({ providedIn: 'root' })
@@ -217,10 +217,8 @@ export class ModalNavigationService {
         this.modalRouteSetContainsPath(modalRouteSet, navigationEnd, modalRoutesContainsUrlParams)
       ),
       map((navigationEnd) => {
-        const locationState = this.location.getState() as NavigationData;
         return {
           route: this.getCurrentActivatedRoute(),
-          modalData: locationState.navigationData,
           isNewModal: this.isNewModalWindow(navigationEnd),
         };
       })
@@ -298,18 +296,12 @@ export class ModalNavigationService {
     return { activated$: EMPTY, deactivated$: EMPTY };
   }
 
-  async navigateToModal(
-    path: string | string[],
-    queryParams?: Params,
-    alertConfig?: AlertConfig
-  ): Promise<boolean> {
+  async navigateToModal(path: string | string[], queryParams?: Params): Promise<boolean> {
     const commands = Array.isArray(path) ? path : path.split('/');
     const childPath = commands.pop();
-    const navigationData: NavigationData = { navigationData: { alertConfig } };
     const result = await this.router.navigate([...commands, { outlets: { modal: [childPath] } }], {
       queryParams,
       relativeTo: this.getCurrentActivatedRoute(),
-      state: navigationData,
     });
     return result;
   }

--- a/libs/designsystem/modal/src/modal.interfaces.ts
+++ b/libs/designsystem/modal/src/modal.interfaces.ts
@@ -14,17 +14,8 @@ export interface Overlay {
   onDidDismiss: Promise<OverlayEventDetail>;
 }
 
-export interface ModalData {
-  alertConfig: AlertConfig;
-}
-
-export interface NavigationData {
-  navigationData: ModalData;
-}
-
 export interface ModalRouteActivation {
   route: ActivatedRoute;
-  modalData: ModalData;
   isNewModal: boolean;
 }
 

--- a/libs/designsystem/modal/src/modal/services/modal.controller.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.controller.ts
@@ -4,7 +4,7 @@ import { Observable, Subject } from 'rxjs';
 import { filter, map, takeUntil } from 'rxjs/operators';
 
 import { KirbyAnimation } from '@kirbydesign/designsystem/helpers';
-import { ModalData, ModalRouteActivation, Overlay } from '../../modal.interfaces';
+import { ModalRouteActivation, Overlay } from '../../modal.interfaces';
 import { ActionSheetConfig } from '../action-sheet/config/action-sheet-config';
 import { AlertConfig } from '../alert/config/alert-config';
 
@@ -57,7 +57,6 @@ export class ModalController implements OnDestroy {
           await this.showModalRoute(
             modalRouteActivation.route,
             siblingModalRouteActivated$,
-            modalRouteActivation.modalData,
             navigateOnWillClose
           );
         }
@@ -75,23 +74,12 @@ export class ModalController implements OnDestroy {
       });
   }
 
-  public async showModal(
-    config: ModalConfig,
-    onClose?: (data?: any) => void,
-    alertConfig?: AlertConfig
-  ): Promise<void> {
-    await this.showAndRegisterOverlay(
-      () => this.modalHelper.showModalWindow(config, alertConfig),
-      onClose
-    );
+  public async showModal(config: ModalConfig, onClose?: (data?: any) => void): Promise<void> {
+    await this.showAndRegisterOverlay(() => this.modalHelper.showModalWindow(config), onClose);
   }
 
-  public async navigateToModal(
-    path: string | string[],
-    queryParams?: Params,
-    alertConfig?: AlertConfig
-  ): Promise<boolean> {
-    return this.modalNavigationService.navigateToModal(path, queryParams, alertConfig);
+  public async navigateToModal(path: string | string[], queryParams?: Params): Promise<boolean> {
+    return this.modalNavigationService.navigateToModal(path, queryParams);
   }
 
   public async navigateWithinModal(relativePath: string, queryParams?: Params): Promise<boolean> {
@@ -101,7 +89,6 @@ export class ModalController implements OnDestroy {
   private async showModalRoute(
     modalRoute: ActivatedRoute,
     siblingModalRouteActivated$: Observable<ActivatedRoute>,
-    modalData: ModalData,
     onWillClose: (data?: any) => void
   ): Promise<void> {
     const config: ModalConfig = {
@@ -111,7 +98,7 @@ export class ModalController implements OnDestroy {
       siblingModalRouteActivated$: siblingModalRouteActivated$,
     };
     await this.showAndRegisterOverlay(
-      () => this.modalHelper.showModalWindow(config, modalData?.alertConfig),
+      () => this.modalHelper.showModalWindow(config),
       null,
       onWillClose
     );

--- a/libs/designsystem/modal/src/modal/services/modal.helper.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.helper.ts
@@ -12,10 +12,8 @@ import {
   ModalWrapperComponent,
 } from '../../modal-wrapper';
 
-import { AlertConfig } from '../alert/config/alert-config';
 import { ModalAnimationBuilderService } from './modal-animation-builder.service';
 import { CanDismissHelper } from './can-dismiss.helper';
-import { AlertHelper } from './alert.helper';
 
 @Injectable()
 export class ModalHelper {
@@ -23,8 +21,7 @@ export class ModalHelper {
     private ionicModalController: ModalController,
     private modalAnimationBuilder: ModalAnimationBuilderService,
     private windowRef: WindowRef,
-    private canDismissHelper: CanDismissHelper,
-    private alertHelper: AlertHelper
+    private canDismissHelper: CanDismissHelper
   ) {}
 
   /* 
@@ -35,7 +32,7 @@ export class ModalHelper {
   */
   private isModalOpening = false;
 
-  public async showModalWindow(config: ModalConfig, alertConfig?: AlertConfig): Promise<Overlay> {
+  public async showModalWindow(config: ModalConfig): Promise<Overlay> {
     if (this.isModalOpening) return;
 
     config.flavor = config.flavor || 'modal';
@@ -68,25 +65,6 @@ export class ModalHelper {
 
     if (config.canDismiss) {
       canDismiss = this.canDismissHelper.getCanDismissCallback(config.canDismiss);
-    }
-
-    // This functionality is kept to prevent breaking changes, but should be depracated in the next major.
-    // It will be replaced by the new 'config.canDismiss' callback
-    if (alertConfig) {
-      console.warn(
-        "This way of passing an alertConfig to the modal will be deprecated in the next major version. We recommend using the 'config.canDismiss' callback instead."
-      );
-
-      // Remembers the modal dismissal response from user to prevent multiple alerts on
-      // approval since the callback is invoked more than once when closing.
-      let canBeDismissed = false;
-      canDismiss = async () => {
-        if (!canBeDismissed) {
-          canBeDismissed = await this.canDismissHelper.showAlert(alertConfig);
-        }
-
-        return canBeDismissed;
-      };
     }
 
     this.isModalOpening = true;
@@ -126,7 +104,7 @@ export class ModalHelper {
 
     // Back button should only be handled manually
     // if the modal is not instantiated through a route.
-    if (!config.modalRoute && !config.canDismiss && !alertConfig) {
+    if (!config.modalRoute && !config.canDismiss) {
       this.handleBrowserBackButton(ionModal);
     }
 

--- a/libs/designsystem/src/lib/directives/modal-router-link/modal-router-link.directive.ts
+++ b/libs/designsystem/src/lib/directives/modal-router-link/modal-router-link.directive.ts
@@ -25,8 +25,7 @@ export class ModalRouterLinkDirective implements OnInit {
   onClick(): boolean {
     this.modalNavigationService.navigateToModal(
       this.path,
-      typeof this.queryParams !== 'string' ? this.queryParams : null,
-      this.alertConfig || null
+      typeof this.queryParams !== 'string' ? this.queryParams : null
     );
     return false;
   }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3120

## What is the new behavior?
The old implementation of alertBeforeClose has been removed

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?
This PR is created as a draft, so the breaking change is not merged before we are ready with Kirby v10.

**For migrations notes:**
It is no longer possible to pass ann `AlertConfig` as an optional third argument to `modalController.showModal` or as an optional third argument to `modalController.navigateToModal`. Instead a callback that returns either a boolean or an `AlertConfig` can passed to the `ModalConfig` as `canDismiss` as described in the documentation.

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

