### PR TITLE
Avatar: remove shadow input binding

### DIFF
--- a/libs/designsystem/avatar/src/avatar.component.ts
+++ b/libs/designsystem/avatar/src/avatar.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular/core';
 
 import { BrandColor, NotificationColor } from '@kirbydesign/core';
 import { ThemeColorDirective } from '@kirbydesign/designsystem/shared';
@@ -19,10 +19,9 @@ export enum AvatarSize {
   styleUrls: ['./avatar.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AvatarComponent implements OnInit {
+export class AvatarComponent {
   @Input() imageSrc: string;
   @Input() altText: string;
-  @Input() shadow: boolean;
   @Input() stroke: boolean;
   @Input() text: string;
   @Input() overlay: boolean;
@@ -33,16 +32,5 @@ export class AvatarComponent implements OnInit {
   @HostBinding('class')
   get _cssClass() {
     return [this.themeColor, this.size].filter((cssClass) => !!cssClass);
-  }
-
-  ngOnInit(): void {
-    if (!this.shadow) {
-      return;
-    }
-
-    this.stroke = true;
-    console.warn(
-      'Shadow input binding on avatar will be deprecated next major. Use stroke instead'
-    );
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3185 

## What is the new behavior?

Removed shadow input binding on Avatar component

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

