### PR TITLE
Add canDismiss description to the ModalConfig API table

### DIFF
--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
@@ -372,8 +372,8 @@
 <p>
   It is possible to provide a
   <code>canDismiss</code>
-  callback to the modal that returns either
-  <code>true</code>
+  callback to the modal that returns either a
+  <code>boolean</code>
   or an
   <code>AlertConfig</code>
   . If an

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
@@ -96,9 +96,11 @@ export class ModalShowcaseComponent {
     },
     {
       name: 'canDismiss',
-      description: `(Optional) A callback that returns either a boolean or an AlertConfig. If an AlertConfig is being returned, an alert will appear, when the user tries to dismiss the modal.`,
+      description: `(Optional) Determines whether or not a modal can be dismissed.
+ 
+      The canDismiss option takes a callback function that returns either a boolean or an AlertConfig. If an AlertConfig is returned an alert will appear when the user tries to dismiss the modal. If false is returned the modal cannot be dismissed by user-interaction or with ModalController.hideTopMost(). `,
       defaultValue: 'undefined',
-      type: ['boolean | AlertConfig'],
+      type: ['boolean | AlertConfig | Promise<boolean | AlertConfig>'],
     },
   ];
 

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
@@ -94,6 +94,12 @@ export class ModalShowcaseComponent {
       defaultValue: '',
       type: ['string | string[]'],
     },
+    {
+      name: 'canDismiss',
+      description: `(Optional) A callback that returns either a boolean or an AlertConfig. If an AlertConfig is being returned, an alert will appear, when the user tries to dismiss the modal.`,
+      defaultValue: 'undefined',
+      type: ['boolean | AlertConfig'],
+    },
   ];
 
   properties: ApiDescriptionProperty[] = [

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
@@ -99,7 +99,7 @@ export class ModalShowcaseComponent {
       description: `(Optional) Determines whether or not a modal can be dismissed.
  
       The canDismiss option takes a callback function that returns either a boolean or an AlertConfig. If an AlertConfig is returned an alert will appear when the user tries to dismiss the modal. If false is returned the modal cannot be dismissed by user-interaction or with ModalController.hideTopMost(). `,
-      defaultValue: 'undefined',
+      defaultValue: 'true',
       type: ['boolean | AlertConfig | Promise<boolean | AlertConfig>'],
     },
   ];


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3187

## What is the new behavior?
The API table for ModalConfig now contains a description of `canDismiss`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

