### PR TITLE
Tab Button: properly remove active state when icon is click target 

### DIFF
--- a/libs/designsystem/icon/src/icon.component.scss
+++ b/libs/designsystem/icon/src/icon.component.scss
@@ -45,3 +45,10 @@
     margin-inline-start: utils.size('xxs');
   }
 }
+
+// Clicking a kirby-icon inside ion-tab-button on Android in Chrome WebView (Capacitor)
+// sometimes causes the tab-button to persist its :active pseudo-class
+// until clicked again. Therefore, disable pointer-events when inside tab button.
+:host-context(ion-tab-button) {
+  pointer-events: none;
+}


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3199 

## What is the new behavior?
This PR fixes an issue when using tab buttons on Android when running the app in a Chrome WebView inside Capacitor. 
For reasons not entirely known, the :active pseudo element is not properly removed if it is the icon within the tab button that receives the click.

This only happens when using the functionality for showing a different icon on the selected tab.

As far as @jakobe and I can deduct, the issue occurs because the icon is removed and another is added under the hood immediately when clicked. So maybe the browser is not able to handle that one target element receives the pointer-event for initializing the active state but another element is the target once the mouse is released and it should be de-activated?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [ ] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] ~~Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be merged to `develop` by Team Kirby.

