### PR TITLE
Menu: make trigger button float when button with isFloating is slotted

### DIFF
--- a/apps/cookbook/src/app/examples/menu-example/examples/customButton.ts
+++ b/apps/cookbook/src/app/examples/menu-example/examples/customButton.ts
@@ -2,17 +2,33 @@ import { Component } from '@angular/core';
 
 const config = {
   selector: 'cookbook-menu-custom-button-example',
-  template: `<kirby-menu>
+  template: `<kirby-menu [title]="'Title'" [subtitle]="'This is a message where we can put absolutely anything we want.'">
   <button
     kirby-button
     type="button"
-    [attentionLevel]="'3'"
+    [isFloating]="true"
   >
-    <kirby-icon [name]="'menu-outline'"></kirby-icon>
+    <kirby-icon [name]="'add'"></kirby-icon>
   </button>
-  <kirby-item>
-    <h3>Action 1</h3>
-  </kirby-item>
+  <kirby-item [selectable]="true">
+  <h3>Action 1</h3>
+</kirby-item>
+<kirby-divider></kirby-divider>
+<kirby-item [selectable]="true">
+  <h3>Action 2</h3>
+</kirby-item>
+<kirby-divider></kirby-divider>
+<kirby-item [selectable]="true">
+  <h3>Action 3 lorem ipsum something wow yes</h3>
+</kirby-item>
+<kirby-divider></kirby-divider>
+<kirby-item [selectable]="true">
+  <h3>Action 4</h3>
+</kirby-item>
+<kirby-divider></kirby-divider>
+<kirby-item [selectable]="true">
+  <h3>Action 5</h3>
+</kirby-item>
 </kirby-menu>`,
 };
 

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -374,6 +374,7 @@ $button-margin: utils.size('xxxs');
 
 :host-context(kirby-page-actions),
 :host-context(kirby-action-group),
+:host-context(kirby-menu),
 :host-context(.kirby-modal ion-header ion-toolbar ion-buttons) {
   margin: 0;
 }

--- a/libs/designsystem/menu/src/menu.component.html
+++ b/libs/designsystem/menu/src/menu.component.html
@@ -27,10 +27,19 @@
   [closeOnSelect]="closeOnSelect"
   [autoPlacement]="autoPlacement"
   [shift]="shift"
+  [offset]="_offset"
   [ngStyle]="{
     minWidth: minWidth ? minWidth + 'px' : null
   }"
   class="menu-popover"
 >
-  <ng-content select="kirby-item"></ng-content>
+  <kirby-card-header
+    *ngIf="title || subtitle"
+    [title]="title"
+    [subtitle]="subtitle"
+    [isTitleBold]="true"
+  >
+    <ng-content></ng-content>
+  </kirby-card-header>
+  <ng-content select="kirby-item,kirby-divider"></ng-content>
 </kirby-card>

--- a/libs/designsystem/menu/src/menu.component.scss
+++ b/libs/designsystem/menu/src/menu.component.scss
@@ -7,6 +7,12 @@ $max-screen-width-small: 460px;
 
 :host {
   position: relative;
+
+  &.floating-action-button {
+    position: fixed;
+    bottom: utils.size('s');
+    right: utils.size('s');
+  }
 }
 
 .button-container {

--- a/libs/designsystem/menu/src/menu.component.ts
+++ b/libs/designsystem/menu/src/menu.component.ts
@@ -1,11 +1,13 @@
 import { CommonModule } from '@angular/common';
 import {
+  AfterContentInit,
   AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
   ContentChild,
   ElementRef,
+  HostBinding,
   Input,
   NgZone,
   OnDestroy,
@@ -34,7 +36,7 @@ import { EventListenerDisposeFn } from '@kirbydesign/designsystem/types';
   styleUrls: ['./menu.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MenuComponent implements AfterViewInit, OnDestroy {
+export class MenuComponent implements AfterViewInit, OnDestroy, AfterContentInit {
   constructor(
     private cdf: ChangeDetectorRef,
     private elementRef: ElementRef<HTMLElement>,
@@ -66,10 +68,16 @@ export class MenuComponent implements AfterViewInit, OnDestroy {
 
   @Input() public shift: boolean = true;
 
+  @Input() public title: string;
+
+  @Input() public subtitle: string;
+
   /**
    * The minimum width of the menu. If not set, the default width is 240px
    */
   @Input() public minWidth: number;
+
+  @HostBinding('class.floating-action-button') private isFloatingActionButton;
 
   @ViewChild('buttonContainer', { read: ElementRef })
   public buttonContainerElement: ElementRef<HTMLElement> | undefined;
@@ -77,14 +85,14 @@ export class MenuComponent implements AfterViewInit, OnDestroy {
   @ViewChild('defaultButton', { read: ElementRef })
   public defaultButtonElement: ElementRef<HTMLElement> | undefined;
 
-  @ContentChild(ButtonComponent, { read: ElementRef }) public userProvidedButton:
-    | ElementRef<HTMLElement>
-    | undefined;
+  @ContentChild(ButtonComponent) public userProvidedButton: ButtonComponent | undefined;
 
   @ViewChild(FloatingDirective)
   private floatingDirective: FloatingDirective;
 
   public FloatingOffset: typeof FloatingOffset = FloatingOffset;
+
+  public _offset = FloatingOffset.small;
 
   private scrollListenerDisposeFn: EventListenerDisposeFn;
 
@@ -100,6 +108,10 @@ export class MenuComponent implements AfterViewInit, OnDestroy {
         this.floatingDirective.hide();
       });
     });
+  }
+
+  public ngAfterContentInit(): void {
+    this.isFloatingActionButton = this.userProvidedButton?.isFloating;
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes # (insert issue number here)

## What is the new behavior?
This is a proposal for a migration path for FAB-sheet-like behavior in Kirby now that Action Sheet (and therefore FAB-sheet) is deprecated in v9 and removed in v10.

With this addition kirby-menu will recognize whenever a button with `isFloating` set to true is slotted as a custom button, and position itself in the bottom right side of its containing element. 

This could be extended with css props to enable custom placement.  

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

