### PR TITLE
Github: fix broken links in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -57,7 +57,7 @@ To make sure the bug is not intended behaviour; it should be verified by a membe
 ### Implementation 
 The contributor who wants to implement this issue should: 
 
-- [ ] Make sure you have read: "[Before you get coding](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#before-you-get-coding)".
+- [ ] Make sure you have read: "[Before you get coding](../CONTRIBUTING.md/#before-you-get-coding)".
 - [ ] Signal to others you are working on the issue by assigning yourself.
 - [ ] Create a branch from the [develop branch](https://github.com/kirbydesign/designsystem/tree/develop) following our [branch naming convention](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Branch). 
 - [ ] Create a test that reproduces the bug following guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)". 

--- a/.github/ISSUE_TEMPLATE/component-request.md
+++ b/.github/ISSUE_TEMPLATE/component-request.md
@@ -38,7 +38,7 @@ The following tasks should be carried out in sequence in order to follow [the pr
 ### Implementation 
 The contributor who wants to implement this issue should: 
 
-- [ ] Make sure you have read: "[Before you get coding](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#before-you-get-coding)".
+- [ ] Make sure you have read: "[Before you get coding](../CONTRIBUTING.md/#before-you-get-coding)".
 - [ ] Signal to others you are working on the issue by assigning yourself.
 - [ ] Create a branch from the [develop branch](https://github.com/kirbydesign/designsystem/tree/develop) following our [branch naming convention](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Branch). 
 - [ ] Publish a WIP implementation to Github as a draft PR and ask for feedback. 

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -41,7 +41,7 @@ The following tasks should be carried out in sequence in order to follow [the pr
 ### Implementation 
 The contributor who wants to implement this issue should: 
 
-- [ ] Make sure you have read: "[Before you get coding](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#before-you-get-coding)".
+- [ ] Make sure you have read: "[Before you get coding](../CONTRIBUTING.md/#before-you-get-coding)".
 - [ ] Signal to others you are working on the issue by assigning yourself.
 - [ ] Create a branch from the [develop branch](https://github.com/kirbydesign/designsystem/tree/develop) following our [branch naming convention](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Branch). 
 - [ ] Publish a WIP implementation to Github as a draft PR and ask for feedback. 


### PR DESCRIPTION
## Which issue does this PR close?
No issue, small fix for issue templates.

## What is the new behavior?

Fix broken links in issue templates.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- ~~[ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be merged to `develop` by Team Kirby.

