### PR TITLE
Input: fix layout shift when hasError is changed from false to true 

### DIFF
--- a/libs/designsystem/form-field/src/input/input.component.scss
+++ b/libs/designsystem/form-field/src/input/input.component.scss
@@ -32,6 +32,12 @@ $padding-block-size-md: shared.$form-field-input-padding * 0.5;
 :host(.md) {
   border-radius: utils.size('m');
   padding-block: $padding-block-size-md;
+
+  &.error {
+    padding-block: calc(
+      #{$padding-block-size-md} - 1px
+    ); // subtract border width from padding to maintain overall height
+  }
 }
 
 /* clean-css ignore:start */

--- a/libs/designsystem/form-field/src/input/input.component.spec.ts
+++ b/libs/designsystem/form-field/src/input/input.component.spec.ts
@@ -142,18 +142,22 @@ describe('InputComponent', () => {
       });
     });
   });
-});
 
-describe('when configured with size medium', () => {
-  const createHost = createHostFactory({
-    component: InputComponent,
-  });
-  it('should render with correct height', () => {
-    const spectator = createHost(`
-    <input kirby-input size="md"/>
-    `);
-    expect(spectator.element).toHaveComputedStyle({
-      height: size('xl'),
+  describe('when configured with size medium', () => {
+    beforeEach(() => {
+      spectator.setInput('size', 'md');
+    });
+
+    it('should render with correct height', () => {
+      expect(spectator.element).toHaveComputedStyle({
+        height: size('xl'),
+      });
+    });
+
+    it('should render with correct height when hasError is true', () => {
+      spectator.setInput('hasError', true);
+
+      expect(spectator.element).toHaveComputedStyle({ height: size('xl') });
     });
   });
 });


### PR DESCRIPTION
## Which issue does this PR close?
This PR closes #3223

## What is the new behavior?
The 1px border added when `hasError` is true is now subtracted from the input-fields padding similar to how we do it for the large input. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- ~~[ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be merged to `develop` by Team Kirby.

