### PR TITLE
Build: remove legacy webpack css import notation 

### DIFF
--- a/libs/core/src/scss/base/_ionic.scss
+++ b/libs/core/src/scss/base/_ionic.scss
@@ -2,7 +2,7 @@
 @use '../themes/colors';
 
 /* Core CSS required for Ionic components to work properly */
-@import '~@ionic/angular/css/core.css';
+@import '@ionic/angular/css/core';
 
 @mixin ionic-color-map($ionic-variant, $kirby-variant: $ionic-variant) {
   --ion-color-#{$ionic-variant}: var(--kirby-#{$kirby-variant});

--- a/libs/core/src/scss/base/_typography.scss
+++ b/libs/core/src/scss/base/_typography.scss
@@ -1,10 +1,10 @@
 @use 'functions';
 
-@import '~@fontsource/roboto/300.css';
-@import '~@fontsource/roboto/400.css';
-@import '~@fontsource/roboto/500.css';
-@import '~@fontsource/roboto/700.css';
-@import '~@fontsource/roboto/900.css';
+@import '@fontsource/roboto/300';
+@import '@fontsource/roboto/400';
+@import '@fontsource/roboto/500';
+@import '@fontsource/roboto/700';
+@import '@fontsource/roboto/900';
 
 h1,
 .h1,

--- a/libs/core/stencil.config.ts
+++ b/libs/core/stencil.config.ts
@@ -6,7 +6,6 @@ export const config: Config = {
   namespace: 'kirby',
   srcDir: './src/',
   plugins: [sass()],
-  globalStyle: './src/scss/_global-styles.scss',
   outputTargets: [
     angularOutputTarget({
       componentCorePackage: '@kirbydesign/core',


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3092

## What is the new behavior?
Using tilde for instructing webpack to resolve paths starting in node_modules is deprecated, as per https://github.com/webpack-contrib/sass-loader#resolving-import-at-rules

Previously, we have removed all ~ from our scss included via Angular, but were not able to properly resolve the paths with stencil, so we never removed the tidle imports from the scss files placed in the core project. 

However the use of tilde becomes a problem when moving away from webpack to e.g. esbuild, as it does not support that type of imports. 

To work around the stencil issues, we simply remove the reference to the global_styles scss file. We can do this because the core package is never installed on its own, always alongside the designsystem package that exposes the global styles to projects. 

This allows us to remove the tilde imports without compiler errors. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

