### PR TITLE
Calendar: Remove hover effect on disabled days

### DIFF
--- a/libs/designsystem/calendar/src/calendar.component.scss
+++ b/libs/designsystem/calendar/src/calendar.component.scss
@@ -96,7 +96,6 @@ td {
 .day.disabled,
 .day:not(.selectable) {
   --color: #{utils.get-text-color('semi-dark')};
-
   pointer-events: none;
 }
 

--- a/libs/designsystem/calendar/src/calendar.component.scss
+++ b/libs/designsystem/calendar/src/calendar.component.scss
@@ -96,6 +96,8 @@ td {
 .day.disabled,
 .day:not(.selectable) {
   --color: #{utils.get-text-color('semi-dark')};
+
+  pointer-events: none;
 }
 
 .day.today {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3184 

## What is the new behavior?

When disabledWeekends is enabled, hover effect will now not be shown on disabled days.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

