### PR TITLE
Cookbook: Fix visual bug in form field color example

### DIFF
--- a/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.scss
+++ b/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.scss
@@ -9,7 +9,7 @@ kirby-page-content > * + *:not(cookbook-example-configuration-wrapper) {
 }
 
 kirby-card {
-  min-width: 500px;
+  --kirby-card-width: min(500px, 100%);
 }
 
 .card-option-button-group {

--- a/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.scss
+++ b/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.scss
@@ -10,6 +10,8 @@ kirby-page-content > * + *:not(cookbook-example-configuration-wrapper) {
 
 kirby-card {
   --kirby-card-width: min(500px, 100%);
+
+  margin: 1rem auto;
 }
 
 .card-option-button-group {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes NO_ISSUE

## What is the new behavior?

`kirby-card` in form field color example will have a maximum width of 500px (as apposed to a _minimum_ width)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

