### PR TITLE
Calendar: Do not submit form when navigating months

### DIFF
--- a/libs/designsystem/calendar/src/calendar.component.html
+++ b/libs/designsystem/calendar/src/calendar.component.html
@@ -1,6 +1,7 @@
 <div class="header">
   <div class="month-navigator">
     <button
+      type="button"
       [disabled]="!_canNavigateBack"
       (click)="_changeMonth(-1)"
       kirby-button
@@ -16,6 +17,7 @@
     </div>
 
     <button
+      type="button"
       [disabled]="!_canNavigateForward"
       (click)="_changeMonth(1)"
       kirby-button


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3267

## What is the new behavior?
The buttons in the calendar are now type="button" instead of type="submit" (the default)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

