### PR TITLE
Progress Circle: Rotate whole svg to avoid safari zoom level issues

### DIFF
--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
@@ -1,7 +1,7 @@
 @use '@kirbydesign/core/src/scss/utils';
 
 svg {
-  transform: rotate(-90deg);
+  rotate: -90deg;
 }
 
 .circle {

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
@@ -1,5 +1,9 @@
 @use '@kirbydesign/core/src/scss/utils';
 
+svg {
+  transform: rotate(-90deg);
+}
+
 .circle {
   stroke: utils.get-color('semi-light');
 }
@@ -8,7 +12,6 @@
   transition-property: stroke-dashoffset, stroke;
   transition-duration: utils.get-transition-duration('extra-long');
   transition-timing-function: utils.get-transition-easing('enter-exit');
-  transform: rotate(-90deg);
   transform-origin: 50% 50%;
   stroke: var(--kirby-progress-circle-stroke-color, #{utils.get-color('success')});
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3256

## What is the new behavior?
Instead of only rotating the value indicator circle, the whole svg including the progress "track" is now rotated to avoid issues with the transform origin differing between the two elements. This would somehow cause them to rotate out of sync for different zoom level _in Safari_ as seen on the linked issue. 

This fixes the issue in Safari, and still works in Chrome and Firefox.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?
See issue

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

