### PR TITLE
Docs: Fix github example link in cookbook showcases

### DIFF
--- a/apps/cookbook/src/app/showcase/showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/showcase.component.ts
@@ -15,7 +15,7 @@ export class ShowcaseComponent implements OnDestroy {
   propertiesTable: Element;
   private routerEventsSubscription: Subscription;
   private gitUrl =
-    'https://github.com/kirbydesign/designsystem/tree/main/apps/cookbook/src/app/examples/';
+    'https://github.com/kirbydesign/designsystem/tree/develop/apps/cookbook/src/app/examples/';
   showCallToActionLinks = true;
 
   constructor(private router: Router, private elementRef: ElementRef<HTMLElement>) {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3272

## What is the new behavior?
Link points to develop instead of the deleted main branch. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

