### PR TITLE
Core: Add fields to ensure interpretation as ES Module

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -2,6 +2,8 @@
   "name": "@kirbydesign/core",
   "version": "0.0.52",
   "description": "Core styles and helpers for the Kirby Design System.",
+  "type": "module",
+  "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/types/index.d.ts",
   "license": "MIT"


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue, but fixes a problem with importing `KirbyTestingModule` in jest-tests. 

## What is the new behavior?
I added back the `main` field that was removed by mistake in #3263 so node knows the correct entry point for the package, and a `type` field that ensures that it is interpreted as an ES Module instead of CommonJS.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

