### PR TITLE
Slides: Remove 16px on top of title

### DIFF
--- a/libs/designsystem/slide/src/slides.component.scss
+++ b/libs/designsystem/slide/src/slides.component.scss
@@ -19,8 +19,7 @@ $bullet-inactive-opacity: 0.2;
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-block: utils.size('s');
-    margin-block-start: 0;
+    margin-block: 0 utils.size('s');
     margin-inline: utils.size('s');
 
     &-inner {

--- a/libs/designsystem/slide/src/slides.component.scss
+++ b/libs/designsystem/slide/src/slides.component.scss
@@ -20,6 +20,7 @@ $bullet-inactive-opacity: 0.2;
     justify-content: space-between;
     align-items: center;
     margin-block: utils.size('s');
+    margin-block-start: 0;
     margin-inline: utils.size('s');
 
     &-inner {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3279 

## What is the new behavior?

Remove 16 px on top from title which shouldn't be there by design. This now matches with the kirby standard spacing.

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

