### PR TITLE
Range: add pinFormatter and `move` event emitter

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -10,6 +10,7 @@ This document provides information about breaking changes and their migrations f
   - [Experimental Alert](#experimental-alert-v9)
   - [Grid](#grid-v9)
   - [Modal](#modal-v9)
+  - [Range](#range-v9)
   - [Slides](#slides-v9)
 - [Styles](#styles-v9)
 - [Dependencies](#dependencies-v9)
@@ -35,6 +36,13 @@ The grid **component** has been removed in favor of using the much more flexible
 <h4 id="modal-v9">Modal</h4>
 
 The following methods have been removed from the `modalController` and all usages of these methods should be removed: `registerPresentingElement`, `scrollToTop`, `scrollToBottom`.
+
+<h4 id="range-v9">Range</h4>
+
+The `change` event no longer emits for each value change, but instead only when the user releases the knob after dragging or when the user moves the knob with keyboard arrows.
+This prevents excessively emitting _a lot_ of events especially for large ranges, and removes the need for debouncing measures in applications.
+
+If the previous functionality of reacting to each value change is needed consider binding to the `move` event instead.
 
 <h4 id="slides-v9">Slides</h4>
 

--- a/apps/cookbook/src/app/examples/range-example/examples/pin.component.ts
+++ b/apps/cookbook/src/app/examples/range-example/examples/pin.component.ts
@@ -4,10 +4,20 @@ const config = {
   selector: 'cookbook-range-pin-example',
   template: `<kirby-range pin="true" minLabel="Min value" maxLabel="Max value" max="15" min="1"></kirby-range>`,
 };
+
+const pinFormatterExample = {
+  template: `<kirby-range pin="true" [pinFormatter]="pinFormatter" minLabel="Min value" maxLabel="Max value" max="15" min="1"></kirby-range>`,
+  function: `pinFormatter(value: number) {
+    return \`\${value}%\`;
+  }`,
+};
+
 @Component({
   selector: config.selector,
   template: config.template,
 })
 export class RangePinExampleComponent {
   template: string = config.template;
+  pinFormatterFunction: string = pinFormatterExample.function;
+  pinFormatterTemplate: string = pinFormatterExample.template;
 }

--- a/apps/cookbook/src/app/examples/range-example/examples/pin.component.ts
+++ b/apps/cookbook/src/app/examples/range-example/examples/pin.component.ts
@@ -8,8 +8,8 @@ const config = {
 const pinFormatterExample = {
   template: `<kirby-range pin="true" [pinFormatter]="pinFormatter" minLabel="Min value" maxLabel="Max value" max="15" min="1"></kirby-range>`,
   function: `pinFormatter(value: number) {
-    return \`\${value}%\`;
-  }`,
+  return \`\${value}%\`;
+}`,
 };
 
 @Component({

--- a/apps/cookbook/src/app/showcase/range-showcase/range-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/range-showcase/range-showcase.component.html
@@ -25,6 +25,15 @@
     <cookbook-range-pin-example #pinExample></cookbook-range-pin-example>
   </cookbook-example-viewer>
 
+  <p>
+    Additionally, the
+    <code>pinFormatter</code>
+    function can be supplied to customize the formatting of the range value shown to the user in the
+    pin. It defaults to the range sliders integer-value.
+  </p>
+  <cookbook-code-viewer [html]="pinExample.pinFormatterTemplate"></cookbook-code-viewer>
+  <cookbook-code-viewer [ts]="pinExample.pinFormatterFunction"></cookbook-code-viewer>
+
   <h2>Disabled</h2>
   <cookbook-example-viewer [html]="disabledFormExample.template">
     <cookbook-range-disabled-form-example

--- a/apps/cookbook/src/app/showcase/range-showcase/range-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/range-showcase/range-showcase.component.html
@@ -29,7 +29,7 @@
     Additionally, the
     <code>pinFormatter</code>
     function can be supplied to customize the formatting of the range value shown to the user in the
-    pin. It defaults to the range sliders integer-value.
+    pin. It defaults to the range slider's integer-value.
   </p>
   <cookbook-code-viewer [html]="pinExample.pinFormatterTemplate"></cookbook-code-viewer>
   <cookbook-code-viewer [ts]="pinExample.pinFormatterFunction"></cookbook-code-viewer>

--- a/apps/cookbook/src/app/showcase/range-showcase/range-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/range-showcase/range-showcase.component.ts
@@ -48,6 +48,11 @@ export class RangeShowcaseComponent {
       defaultValue: 'false',
     },
     {
+      name: 'pinFormatter',
+      description: '(Optional) A callback used to format the pin text.',
+      type: ['(value: number) => string | number'],
+    },
+    {
       name: 'debounce',
       description: '(Optional) How long, in milliseconds, to wait to trigger the change event',
       type: ['number'],
@@ -65,7 +70,8 @@ export class RangeShowcaseComponent {
   rangeEvents: ApiDescriptionMethod[] = [
     {
       name: 'change',
-      description: 'Emits events when the value changes.',
+      description:
+        'Emitted when the user modifies the value by releasing the knob or moving the knob with the keyboard',
       signature: '() => EventEmitter<number>',
     },
   ];

--- a/apps/cookbook/src/app/showcase/range-showcase/range-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/range-showcase/range-showcase.component.ts
@@ -74,5 +74,11 @@ export class RangeShowcaseComponent {
         'Emitted when the user modifies the value by releasing the knob or moving the knob with the keyboard',
       signature: '() => EventEmitter<number>',
     },
+    {
+      name: 'move',
+      description:
+        'Emitted for each distinct change whenever the knob is moved by the user. Unlike the change event it fires continuously while the user is dragging the knob.',
+      signature: '() => EventEmitter<number>',
+    },
   ];
 }

--- a/apps/cookbook/src/app/showcase/range-showcase/range-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/range-showcase/range-showcase.component.ts
@@ -77,7 +77,7 @@ export class RangeShowcaseComponent {
     {
       name: 'move',
       description:
-        'Emitted for each distinct change whenever the knob is moved by the user. Unlike the change event it fires continuously while the user is dragging the knob.',
+        'Emitted for each distinct change whenever the knob is moved by the user. Unlike the `change` event it fires continuously while the user is dragging the knob.',
       signature: '() => EventEmitter<number>',
     },
   ];

--- a/libs/designsystem/range/src/range.component.html
+++ b/libs/designsystem/range/src/range.component.html
@@ -5,6 +5,7 @@
   [step]="step"
   [value]="value"
   [pin]="pin"
+  [pinFormatter]="pinFormatter"
   [snaps]="ticks"
   [ticks]="ticks"
   [debounce]="debounce"

--- a/libs/designsystem/range/src/range.component.ts
+++ b/libs/designsystem/range/src/range.component.ts
@@ -37,6 +37,7 @@ export class RangeComponent implements OnChanges, ControlValueAccessor {
   @Input() step = 1;
   @Input() ticks: boolean;
   @Input() disabled = false;
+  @Input() pinFormatter: (value: number) => string | number;
   @Input()
   set value(value: number) {
     if (value !== this.currentValue) {

--- a/libs/designsystem/range/src/range.component.ts
+++ b/libs/designsystem/range/src/range.component.ts
@@ -6,11 +6,13 @@ import {
   forwardRef,
   Input,
   OnChanges,
+  OnInit,
   Output,
   SimpleChanges,
+  ViewChild,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { IonicModule } from '@ionic/angular';
+import { IonicModule, IonRange } from '@ionic/angular';
 
 @Component({
   standalone: true,
@@ -27,7 +29,7 @@ import { IonicModule } from '@ionic/angular';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RangeComponent implements OnChanges, ControlValueAccessor {
+export class RangeComponent implements OnChanges, OnInit, ControlValueAccessor {
   @Input() minLabel: string;
   @Input() maxLabel: string;
   @Input() debounce: number;
@@ -51,8 +53,15 @@ export class RangeComponent implements OnChanges, ControlValueAccessor {
   }
 
   @Output() change: EventEmitter<number> = new EventEmitter<number>();
+  @Output() move: EventEmitter<number> = new EventEmitter<number>();
+
+  @ViewChild(IonRange, { static: true }) private ionRange: IonRange;
 
   private currentValue: number;
+
+  ngOnInit() {
+    this.initializeMoveEventEmitter();
+  }
 
   ngOnChanges(_: SimpleChanges) {
     if (!this.ticks) return;
@@ -81,6 +90,16 @@ export class RangeComponent implements OnChanges, ControlValueAccessor {
     return ticks;
   }
 
+  private initializeMoveEventEmitter() {
+    // We subscribe to ionRange's ionInput imperatively instead of in markup
+    // to avoid doing work when no-one is listening to the move event.
+    if (this.move.observed) {
+      this.ionRange.ionInput.subscribe((rangeEvent) => {
+        this._onRangeKnobMove(rangeEvent);
+      });
+    }
+  }
+
   public setDisabledState?(isDisabled: boolean): void {
     this.disabled = isDisabled;
   }
@@ -88,6 +107,11 @@ export class RangeComponent implements OnChanges, ControlValueAccessor {
   public _onRangeValueChange($event: any): void {
     this.writeValue($event.detail.value);
     this.change.emit(this.currentValue);
+  }
+
+  public _onRangeKnobMove($event: any): void {
+    this.writeValue($event.detail.value);
+    this.move.emit(this.currentValue);
   }
 
   public onTouched = () => {};


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3296 closes #3295

## What is the new behavior?
See issues. 

TL;DR: To preserve Ionics performance enhancements to the range's change event, but still allow applications to react on each value change if they really need it, the `ionInput` event is now proxied by range as `move` so applications can get notified whenever the knob is moved to a new value.

At the same time we also add the `pinFormatter` function as another, and in most cases better, migration path for use-cases that need to show the currently "selected" value in the range before the user lets go of the knob.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

