### PR TITLE
Form Field: cannot focus input programmatically immediately after disabled state is removed

### DIFF
--- a/apps/cookbook/src/app/examples/form-field-example/examples/input/focus.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/examples/input/focus.ts
@@ -52,6 +52,6 @@ export class FormFieldFocusExampleComponent {
   onToggleInput(enable: boolean) {
     this.inputEnabled = enable;
     if (!enable) return;
-    setTimeout(() => this.formfield.focus());
+    this.formfield.focus();
   }
 }

--- a/libs/designsystem/form-field/src/form-field.component.spec.ts
+++ b/libs/designsystem/form-field/src/form-field.component.spec.ts
@@ -8,6 +8,7 @@ import { TestHelper } from '@kirbydesign/designsystem/testing';
 import { ItemComponent } from '@kirbydesign/designsystem/item';
 import { RadioComponent, RadioGroupComponent } from '@kirbydesign/designsystem/radio';
 
+import { fakeAsync, tick } from '@angular/core/testing';
 import { FormFieldMessageComponent } from './form-field-message/form-field-message.component';
 import { FormFieldComponent } from './form-field.component';
 import { InputCounterComponent } from './input-counter/input-counter.component';
@@ -502,7 +503,7 @@ describe('FormFieldComponent', () => {
       platformServiceSpy = spectator.inject(PlatformService);
     });
 
-    it('should focus input element if not touch', () => {
+    it('should focus input element if not touch', fakeAsync(() => {
       platformServiceSpy.isTouch.and.returnValue(false);
       // Call detectChanges() twice - see: https://angular.io/guide/testing-components-scenarios#detectchanges
       spectator.detectChanges(); //ngOnInit() + 1st ngAfterContentChecked()
@@ -511,11 +512,12 @@ describe('FormFieldComponent', () => {
       const focusSpy = spyOn(formFieldElement, 'focus');
 
       spectator.component.focus();
+      tick();
 
       expect(focusSpy).toHaveBeenCalled();
-    });
+    }));
 
-    it('should dispatch touch events if touch', () => {
+    it('should dispatch touch events if touch', fakeAsync(() => {
       platformServiceSpy.isTouch.and.returnValue(true);
       // Call detectChanges() twice - see: https://angular.io/guide/testing-components-scenarios#detectchanges
       spectator.detectChanges(); //ngOnInit() + 1st ngAfterContentChecked()
@@ -524,6 +526,7 @@ describe('FormFieldComponent', () => {
       const dispatchEventSpy = spyOn(inputElement, 'dispatchEvent');
 
       spectator.component.focus();
+      tick();
 
       expect(dispatchEventSpy).toHaveBeenCalledTimes(2);
       const firstEvent: Event = dispatchEventSpy.calls.argsFor(0)[0];
@@ -532,7 +535,7 @@ describe('FormFieldComponent', () => {
       const secondEvent: Event = dispatchEventSpy.calls.argsFor(1)[0];
       expect(secondEvent).toBeInstanceOf(TouchEvent);
       expect(secondEvent.type).toBe('touchend');
-    });
+    }));
   });
 
   describe('affix', () => {

--- a/libs/designsystem/form-field/src/form-field.component.ts
+++ b/libs/designsystem/form-field/src/form-field.component.ts
@@ -89,18 +89,24 @@ export class FormFieldComponent
   }
 
   public focus() {
-    if (!this.inputElement) return;
+    /*
+     * This timeout ensures that any previous manipulation of inputElement
+     * (e.g. setting disabled state) has been synced to the DOM before trying to focus.
+     */
+    setTimeout(() => {
+      if (!this.inputElement) return;
 
-    if (this.isTouch) {
-      // Trigger Ionic's input shims to ensure input is scrolled into view.
-      // See: https://github.com/ionic-team/ionic-framework/blob/master/core/src/utils/input-shims/hacks/scroll-assist.ts
-      const touchStart = new TouchEvent('touchstart');
-      const touchEnd = new TouchEvent('touchend');
-      this.inputElement.dispatchEvent(touchStart);
-      this.inputElement.dispatchEvent(touchEnd);
-    } else {
-      this.inputElement.focus();
-    }
+      if (this.isTouch) {
+        // Trigger Ionic's input shims to ensure input is scrolled into view.
+        // See: https://github.com/ionic-team/ionic-framework/blob/master/core/src/utils/input-shims/hacks/scroll-assist.ts
+        const touchStart = new TouchEvent('touchstart');
+        const touchEnd = new TouchEvent('touchend');
+        this.inputElement.dispatchEvent(touchStart);
+        this.inputElement.dispatchEvent(touchEnd);
+      } else {
+        this.inputElement.focus();
+      }
+    });
   }
 
   ngOnInit() {

--- a/libs/designsystem/form-field/src/form-field.component.ts
+++ b/libs/designsystem/form-field/src/form-field.component.ts
@@ -89,13 +89,13 @@ export class FormFieldComponent
   }
 
   public focus() {
+    if (!this.inputElement) return;
+
     /*
      * This timeout ensures that any previous manipulation of inputElement
      * (e.g. setting disabled state) has been synced to the DOM before trying to focus.
      */
     setTimeout(() => {
-      if (!this.inputElement) return;
-
       if (this.isTouch) {
         // Trigger Ionic's input shims to ensure input is scrolled into view.
         // See: https://github.com/ionic-team/ionic-framework/blob/master/core/src/utils/input-shims/hacks/scroll-assist.ts


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3302 

## What is the new behavior?
We take care of the `setTimeout` when focussing nested input element in form field, instead of relying on consumers to do so.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

