### PR TITLE
Segmented Control: fix chip sizing when overflowing horizontally

### DIFF
--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -80,7 +80,7 @@
 
 ion-segment {
   border-radius: utils.$border-radius-round;
-  grid-auto-columns: initial;
+  grid-auto-columns: max-content;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR is a follow-up to #3293 

## What is the new behavior?
As a result of the change in #3294, any chip content that grows beyond the initial min width will result in overlap between the chips: 

<img width="457" alt="image" src="https://github.com/kirbydesign/designsystem/assets/42470636/b199145b-a917-477f-b32a-5c762d8fdf5a">

But only in **_chromium_**, safari and firefox works as expected.
My initial hunch of just falling back to the default grid-auto-columns value set by ionic is not an option, as each chip then grows to fill 1 fraction whenever width allows it: 

<img width="936" alt="image" src="https://github.com/kirbydesign/designsystem/assets/42470636/c3151a4d-407b-4cac-81ee-4c5909d6458b">

Setting `grid-auto-columns: max-content;` works as expected in firefox, safari and chrome.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] ~~Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".~~
- [ ] ~~Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).~~

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

