### PR TITLE
config: lock date-fns peer dependencies version

### DIFF
--- a/libs/designsystem/package.json
+++ b/libs/designsystem/package.json
@@ -18,8 +18,8 @@
     "chartjs-adapter-date-fns": ">=2.0.0",
     "chartjs-plugin-annotation": ">=1.0.2",
     "chartjs-plugin-datalabels": ">=2.0.0",
-    "date-fns": ">=2.21.1",
-    "date-fns-tz": ">=1.1.4",
+    "date-fns": "^2.30.0",
+    "date-fns-tz": "^1.3.8",
     "rxjs": ">=7.0.0",
     "swiper": "^9.2.0",
     "zone.js": ">=0.10.2"


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3309 

## What is the new behavior?

Locks the version of date-fns peer dependencies.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

