### PR TITLE
Fix floating-ui compile error

### DIFF
--- a/libs/designsystem/shared/floating/src/floating.directive.spec.ts
+++ b/libs/designsystem/shared/floating/src/floating.directive.spec.ts
@@ -3,8 +3,7 @@ import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectat
 import { PortalDirective } from '@kirbydesign/designsystem/shared/portal';
 import { PortalOutletConfig, TriggerEvent } from '@kirbydesign/designsystem/shared/floating';
 
-import { Strategy } from '@floating-ui/dom';
-import { Placement } from '@floating-ui/core/src/types';
+import { Placement, Strategy } from '@floating-ui/dom';
 import { DesignTokenHelper } from '@kirbydesign/core';
 import { FloatingDirective, OutletSelector } from './floating.directive';
 

--- a/libs/designsystem/shared/floating/src/floating.directive.ts
+++ b/libs/designsystem/shared/floating/src/floating.directive.ts
@@ -18,7 +18,7 @@ import {
   shift,
   Strategy,
 } from '@floating-ui/dom';
-import { ComputePositionConfig, Middleware, Placement } from '@floating-ui/core/src/types';
+import { ComputePositionConfig, Middleware, Placement } from '@floating-ui/dom';
 import { DesignTokenHelper } from '@kirbydesign/core';
 import { from } from 'rxjs';
 import { PortalDirective } from '@kirbydesign/designsystem/shared/portal';

--- a/libs/designsystem/shared/floating/src/floating.directive.ts
+++ b/libs/designsystem/shared/floating/src/floating.directive.ts
@@ -13,12 +13,14 @@ import {
   autoPlacement,
   autoUpdate,
   computePosition,
+  ComputePositionConfig,
   flip,
+  Middleware,
   offset,
+  Placement,
   shift,
   Strategy,
 } from '@floating-ui/dom';
-import { ComputePositionConfig, Middleware, Placement } from '@floating-ui/dom';
 import { DesignTokenHelper } from '@kirbydesign/core';
 import { from } from 'rxjs';
 import { PortalDirective } from '@kirbydesign/designsystem/shared/portal';


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes NO ISSUE

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

Could not compile project due to error importing types from `@floating-ui/core`. Importing from `@floating-ui/dom` instead fixes the error (inspired by https://github.com/floating-ui/floating-ui/pull/2513)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

