### PR TITLE
Fonts: New heading style h4

### DIFF
--- a/apps/cookbook/src/app/showcase/fonts-showcase/fonts-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/fonts-showcase/fonts-showcase.component.html
@@ -55,6 +55,13 @@
       <code class="highlight">CLASS: h3 or kirby-text-medium</code>
     </div>
 
+    <h4 class="sample-header-4 h4">h4 - Section header</h4>
+    <div class="info-box">
+      <code>font-size: font-size("n");</code>
+      <code>font-weight: font-weight("bold");</code>
+      <code class="highlight">CLASS: h4</code>
+    </div>
+
     <p class="sample-body kirby-text-normal">p - Paragraph (Default body font)</p>
     <div class="info-box">
       <code>font-size: font-size("n");</code>

--- a/apps/cookbook/src/app/showcase/fonts-showcase/fonts-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/fonts-showcase/fonts-showcase.component.html
@@ -38,28 +38,28 @@
     <div class="info-box">
       <code>font-size: font-size("xl");</code>
       <code>font-weight: font-weight("black");</code>
-      <code class="highlight">CLASS: h1 or .kirby-text-xlarge</code>
+      <code class="highlight">CLASS: kirby-text-xlarge</code>
     </div>
 
     <h2 class="sample-header-2 kirby-text-large">h2 - Heading 2</h2>
     <div class="info-box">
       <code>font-size: font-size("l");</code>
       <code>font-weight: font-weight("bold");</code>
-      <code class="highlight">CLASS: h2 or kirby-text-large</code>
+      <code class="highlight">CLASS: kirby-text-large</code>
     </div>
 
     <h3 class="sample-header-3 kirby-text-medium">h3 - Heading 3</h3>
     <div class="info-box">
       <code>font-size: font-size("m");</code>
       <code>font-weight: font-weight("bold");</code>
-      <code class="highlight">CLASS: h3 or kirby-text-medium</code>
+      <code class="highlight">CLASS: kirby-text-medium</code>
     </div>
 
-    <h4 class="sample-header-4 h4">h4 - Section header</h4>
+    <h4 class="sample-header-4 kirby-text-normal-bold">h4 - Section header</h4>
     <div class="info-box">
       <code>font-size: font-size("n");</code>
       <code>font-weight: font-weight("bold");</code>
-      <code class="highlight">CLASS: h4</code>
+      <code class="highlight">CLASS: kirby-text-normal-bold</code>
     </div>
 
     <p class="sample-body kirby-text-normal">p - Paragraph (Default body font)</p>

--- a/apps/cookbook/src/app/showcase/fonts-showcase/fonts-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/fonts-showcase/fonts-showcase.component.scss
@@ -34,6 +34,7 @@ code {
   &-header-1,
   &-header-2,
   &-header-3,
+  &-header-4,
   &-body,
   &-body-small,
   &-body-small-light,
@@ -58,6 +59,12 @@ code {
   &-header-3 {
     &::after {
       content: '(#{utils.font-size('m')})';
+    }
+  }
+
+  &-header-4 {
+    &::after {
+      content: '(#{utils.font-size('n')})';
     }
   }
 

--- a/libs/core/src/scss/base/_typography.scss
+++ b/libs/core/src/scss/base/_typography.scss
@@ -73,6 +73,13 @@ h3,
   line-height: functions.line-height('m');
 }
 
+h4,
+.h4 {
+  font-size: functions.font-size('n');
+  font-weight: functions.font-weight('bold');
+  line-height: functions.line-height('n');
+}
+
 p,
 .p,
 .kirby-text-normal {

--- a/libs/core/src/scss/base/_typography.scss
+++ b/libs/core/src/scss/base/_typography.scss
@@ -74,7 +74,8 @@ h3,
 }
 
 h4,
-.h4 {
+.h4,
+.kirby-text-normal-bold {
   font-size: functions.font-size('n');
   font-weight: functions.font-weight('bold');
   line-height: functions.line-height('n');

--- a/libs/designsystem/helpers/scss/src/typography.spec.ts
+++ b/libs/designsystem/helpers/scss/src/typography.spec.ts
@@ -112,6 +112,13 @@ describe('Typography', () => {
         fontWeight: '700',
         lineHeight: '24px',
       },
+      'heading 4': {
+        tag: 'h4',
+        cssClasses: ['h4', 'kirby-text-normal-bold'],
+        fontSize: '16px',
+        fontWeight: '700',
+        lineHeight: '24px',
+      },
     };
 
     for (const headingName in headings) {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3332 

## What is the new behavior?

Added new heading style for "H4". Showcase for "H4 - section header" added in cookbook under Fonts.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

