### PR TITLE
Input: fix initial value not shown in Chrome

### DIFF
--- a/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
@@ -128,7 +128,7 @@
     <code>LOCALE_ID</code>
     . E.g. when
     <code>DA</code>
-    the date-mask will be
+    the placeholder will be
     <code>dd.mm.åååå</code>
   </em>
 </p>

--- a/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
@@ -109,12 +109,24 @@
     #inputDateExample
   ></cookbook-form-field-input-date-example>
 </cookbook-example-viewer>
+
+<p>
+  By default (or when
+  <code>[useNativeDatePicker]="false"</code>
+  is set explicitly) the value supplied to the input should be formatted according to the current
+  locale. When opting into the native datepicker, the value should be in the
+  <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#date_strings">
+    Date strings format
+  </a>
+  .
+</p>
+
 <p>
   <em>
     <strong>*Please note:</strong>
-    Date-mask is based on
+    The placeholder is based on
     <code>LOCALE_ID</code>
-    . When
+    . E.g. when
     <code>DA</code>
     the date-mask will be
     <code>dd.mm.åååå</code>

--- a/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
@@ -111,9 +111,7 @@
 </cookbook-example-viewer>
 
 <p>
-  By default (or when
-  <code>[useNativeDatePicker]="false"</code>
-  is set explicitly) the value supplied to the input should be formatted according to the current
+  By default (i.e. when not using the native datepicker) the value supplied to the input should be formatted according to the current
   locale. When opting into the native datepicker, the value should be in the
   <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#date_strings">
     Date strings format

--- a/libs/designsystem/form-field/src/directives/date/date-input.directive.spec.ts
+++ b/libs/designsystem/form-field/src/directives/date/date-input.directive.spec.ts
@@ -28,7 +28,7 @@ describe('DateInputDirective', () => {
 
   describe('by default', () => {
     beforeEach(() => {
-      spectator = createDirective(`<input kirby-input type="date"/>`);
+      spectator = createDirective(`<input kirby-input type="date" />`);
     });
 
     it('should get the instance', () => {
@@ -139,7 +139,7 @@ describe('DateInputDirective', () => {
 
   describe('when configured with value', () => {
     beforeEach(() => {
-      spectator = createDirective(`<input kirby-input type="date" value="01-01-2024"/>`);
+      spectator = createDirective(`<input kirby-input type="date" value="01-01-2024" />`);
     });
 
     it('should have date-mask placeholder', () => {

--- a/libs/designsystem/form-field/src/directives/date/date-input.directive.spec.ts
+++ b/libs/designsystem/form-field/src/directives/date/date-input.directive.spec.ts
@@ -28,7 +28,7 @@ describe('DateInputDirective', () => {
 
   describe('by default', () => {
     beforeEach(() => {
-      spectator = createDirective(`<input kirby-input type="date" />`);
+      spectator = createDirective(`<input kirby-input type="date"/>`);
     });
 
     it('should get the instance', () => {
@@ -36,9 +36,14 @@ describe('DateInputDirective', () => {
       expect(instance).toBeDefined();
     });
 
-    it('should have initial date-mask value', () => {
+    it('should have initial date-mask placeholder', () => {
       // @ts-ignore
       expect(spectator.element.placeholder).toEqual('mm/dd/yyyy');
+    });
+
+    it('should not have initial date-mask value', () => {
+      // @ts-ignore
+      expect(spectator.element.value).toEqual('');
     });
 
     it('should keep date-mask when typing', () => {
@@ -129,6 +134,22 @@ describe('DateInputDirective', () => {
 
         expect(datemaskPadding).toEqual(inputPadding);
       });
+    });
+  });
+
+  describe('when configured with value', () => {
+    beforeEach(() => {
+      spectator = createDirective(`<input kirby-input type="date" value="01-01-2024"/>`);
+    });
+
+    it('should have date-mask placeholder', () => {
+      // @ts-ignore
+      expect(spectator.element.placeholder).toEqual('mm/dd/yyyy');
+    });
+
+    it('should have initial date-mask value', () => {
+      // @ts-ignore
+      expect(spectator.element.value).toEqual('01/01/2024');
     });
   });
 

--- a/libs/designsystem/form-field/src/directives/date/date-input.directive.ts
+++ b/libs/designsystem/form-field/src/directives/date/date-input.directive.ts
@@ -61,6 +61,11 @@ export class DateInputDirective implements AfterViewInit {
     @Inject(LOCALE_ID) private locale: string
   ) {
     this.isDateInput = this.elementRef.nativeElement.type === 'date';
+    if (this.isDateInput) {
+      // Remove type to avoid user-agent specific behaviour for [type="date"]
+      // Has to be done in constructor to avoid browser behavior kicking in
+      this.elementRef.nativeElement.removeAttribute('type');
+    }
   }
 
   ngAfterViewInit(): void {
@@ -71,9 +76,11 @@ export class DateInputDirective implements AfterViewInit {
     // This case is identical to date input fields _before_ native date picker
     // option was introduced
     if (this.enableInputMask) {
-      // Remove type to avoid user-agent specific behaviour for [type="date"]
-      this.elementRef.nativeElement.removeAttribute('type');
       this.initMask();
+    }
+
+    if (this.useNativeDatePicker) {
+      this.elementRef.nativeElement.setAttribute('type', 'date');
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3337 

## What is the new behavior?
This is a hotfix where we make sure to remove the type="date" attribute no matter what, and re-add it back when we want to use the native date picker.

This is to ensure that the default browser behavior does not kick in for the inputs default date behavior, where the inputmask library is used instead.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

