### PR TITLE
Menu: Fix floating directive performance issues

### DIFF
--- a/libs/designsystem/shared/floating/src/floating.directive.spec.ts
+++ b/libs/designsystem/shared/floating/src/floating.directive.spec.ts
@@ -92,7 +92,7 @@ describe('FloatingDirective', () => {
         const spy = spyOn(directive, <never>'updateHostElementPosition');
         directive.reference = component.floatingElementRef;
         spectator.detectChanges();
-        directive.show(); // Spy must be injected before show is called since show enables autoUpdate
+        directive.show(); // Spy must be injected before show is called
         spy.calls.reset();
 
         spectator.dispatchFakeEvent(window, 'scroll');
@@ -187,7 +187,7 @@ describe('FloatingDirective', () => {
         directive.reference = component.floatingElementRef;
         directive['isShown'] = false;
         spectator.detectChanges();
-        spy.calls.reset(); // Not actually needed, but may limit error scope
+        spy.calls.reset();
 
         directive.strategy = 'absolute';
         spectator.detectChanges();

--- a/libs/designsystem/shared/floating/src/floating.directive.spec.ts
+++ b/libs/designsystem/shared/floating/src/floating.directive.spec.ts
@@ -73,8 +73,8 @@ describe('FloatingDirective', () => {
 
   describe('automatic host position update behaviour', () => {
     describe('floating element is not shown', () => {
-      it('should NOT peform position updates', fakeAsync(() => {
-        spyOn(directive, <never>'updateHostElementPosition');
+      it('should NOT perform position updates', fakeAsync(() => {
+        const updateHostElementPositionSpy = spyOn<any>(directive, 'updateHostElementPosition');
         directive.reference = component.floatingElementRef;
         directive['isShown'] = false;
 
@@ -84,12 +84,13 @@ describe('FloatingDirective', () => {
         spectator.dispatchFakeEvent(window, 'resize');
 
         expect(directive['updateHostElementPosition']).toHaveBeenCalledTimes(0);
+        expect(updateHostElementPositionSpy.calls.count()).toEqual(0);
       }));
     });
 
     describe('floating element is shown', () => {
       it('should update host element position on scroll', fakeAsync(() => {
-        const spy = spyOn(directive, <never>'updateHostElementPosition');
+        const spy = spyOn<any>(directive, 'updateHostElementPosition');
         directive.reference = component.floatingElementRef;
         spectator.detectChanges();
         directive.show(); // Spy must be injected before show is called
@@ -101,11 +102,11 @@ describe('FloatingDirective', () => {
       }));
 
       it('should update host element position on window resize', fakeAsync(() => {
-        const spy = spyOn(directive, <never>'updateHostElementPosition');
+        const updateHostElementPositionSpy = spyOn<any>(directive, 'updateHostElementPosition');
         directive.reference = component.floatingElementRef;
         spectator.detectChanges();
         directive.show();
-        spy.calls.reset();
+        updateHostElementPositionSpy.calls.reset();
 
         spectator.dispatchFakeEvent(window, 'resize');
 
@@ -136,11 +137,11 @@ describe('FloatingDirective', () => {
       });
 
       it('should update host position if shown', fakeAsync(() => {
-        const spy = spyOn(directive, <never>'updateHostElementPosition');
+        const updateHostElementPositionSpy = spyOn<any>(directive, 'updateHostElementPosition');
         directive.reference = component.floatingElementRef;
         directive['isShown'] = true;
         spectator.detectChanges();
-        spy.calls.reset();
+        updateHostElementPositionSpy.calls.reset();
 
         directive.placement = 'top-start';
         spectator.detectChanges();
@@ -149,11 +150,11 @@ describe('FloatingDirective', () => {
       }));
 
       it('should NOT update host position if hidden', fakeAsync(() => {
-        const spy = spyOn(directive, <never>'updateHostElementPosition');
+        const updateHostElementPositionSpy = spyOn<any>(directive, 'updateHostElementPosition');
         directive.reference = component.floatingElementRef;
         directive['isShown'] = false;
         spectator.detectChanges();
-        spy.calls.reset();
+        updateHostElementPositionSpy.calls.reset();
 
         directive.placement = 'top-start';
         spectator.detectChanges();
@@ -170,11 +171,11 @@ describe('FloatingDirective', () => {
       });
 
       it('should update host position if shown', fakeAsync(() => {
-        const spy = spyOn(directive, <never>'updateHostElementPosition');
+        const updateHostElementPositionSpy = spyOn<any>(directive, 'updateHostElementPosition');
         directive.reference = component.floatingElementRef;
         directive['isShown'] = true;
         spectator.detectChanges();
-        spy.calls.reset();
+        updateHostElementPositionSpy.calls.reset();
 
         directive.strategy = 'absolute';
         spectator.detectChanges();
@@ -183,11 +184,11 @@ describe('FloatingDirective', () => {
       }));
 
       it('should NOT update host position if hidden', fakeAsync(() => {
-        const spy = spyOn(directive, <never>'updateHostElementPosition');
+        const updateHostElementPositionSpy = spyOn<any>(directive, 'updateHostElementPosition');
         directive.reference = component.floatingElementRef;
         directive['isShown'] = false;
         spectator.detectChanges();
-        spy.calls.reset();
+        updateHostElementPositionSpy.calls.reset();
 
         directive.strategy = 'absolute';
         spectator.detectChanges();
@@ -466,10 +467,10 @@ describe('FloatingDirective', () => {
       });
 
       it('should update host position when shown', fakeAsync(() => {
-        const spy = spyOn(directive, <never>'updateHostElementPosition');
+        const updateHostElementPositionSpy = spyOn<any>(directive, 'updateHostElementPosition');
         directive.reference = component.floatingElementRef;
         spectator.detectChanges();
-        spy.calls.reset();
+        updateHostElementPositionSpy.calls.reset();
 
         directive.show();
         spectator.detectChanges();
@@ -478,10 +479,10 @@ describe('FloatingDirective', () => {
       }));
 
       it('should update host position when shown and scrolled', fakeAsync(() => {
-        const spy = spyOn(directive, <never>'updateHostElementPosition');
+        const updateHostElementPositionSpy = spyOn<any>(directive, 'updateHostElementPosition');
         directive.reference = component.floatingElementRef;
         spectator.detectChanges();
-        spy.calls.reset();
+        updateHostElementPositionSpy.calls.reset();
 
         directive.show();
         spectator.dispatchFakeEvent(window, 'scroll');
@@ -490,10 +491,10 @@ describe('FloatingDirective', () => {
       }));
 
       it('should update host position when shown, scrolled, and resized', fakeAsync(() => {
-        const spy = spyOn(directive, <never>'updateHostElementPosition');
+        const updateHostElementPositionSpy = spyOn<any>(directive, 'updateHostElementPosition');
         directive.reference = component.floatingElementRef;
         spectator.detectChanges();
-        spy.calls.reset();
+        updateHostElementPositionSpy.calls.reset();
 
         directive.show();
         spectator.dispatchFakeEvent(window, 'scroll');
@@ -548,12 +549,12 @@ describe('FloatingDirective', () => {
       });
 
       it('should NOT auto updating positions after hiding', fakeAsync(() => {
-        const spy = spyOn(directive, <never>'updateHostElementPosition');
+        const updateHostElementPositionSpy = spyOn<any>(directive, 'updateHostElementPosition');
         directive.reference = component.floatingElementRef;
         spectator.detectChanges();
         directive.show();
         directive.hide();
-        spy.calls.reset();
+        updateHostElementPositionSpy.calls.reset();
 
         spectator.dispatchFakeEvent(window, 'scroll');
         spectator.dispatchFakeEvent(window, 'resize');

--- a/libs/designsystem/shared/floating/src/floating.directive.spec.ts
+++ b/libs/designsystem/shared/floating/src/floating.directive.spec.ts
@@ -97,9 +97,7 @@ describe('FloatingDirective', () => {
 
         spectator.dispatchFakeEvent(window, 'scroll');
 
-        spectator.fixture.whenStable().then(() => {
-          expect(directive['updateHostElementPosition']).toHaveBeenCalledTimes(1);
-        });
+        expect(directive['updateHostElementPosition']).toHaveBeenCalledTimes(1);
       }));
 
       it('should update host element position on window resize', fakeAsync(() => {

--- a/libs/designsystem/shared/floating/src/floating.directive.spec.ts
+++ b/libs/designsystem/shared/floating/src/floating.directive.spec.ts
@@ -431,7 +431,7 @@ describe('FloatingDirective', () => {
     });
 
     describe('show', () => {
-      it('should set isShown to false by default', () => {
+      it('should set isShown to true by default', () => {
         directive['isShown'] = false;
         spectator.setInput('isDisabled', false);
         directive.show();

--- a/libs/designsystem/shared/floating/src/floating.directive.spec.ts
+++ b/libs/designsystem/shared/floating/src/floating.directive.spec.ts
@@ -5,6 +5,7 @@ import { PortalOutletConfig, TriggerEvent } from '@kirbydesign/designsystem/shar
 
 import { Placement, Strategy } from '@floating-ui/dom';
 import { DesignTokenHelper } from '@kirbydesign/core';
+import { fakeAsync } from '@angular/core/testing';
 import { FloatingDirective, OutletSelector } from './floating.directive';
 
 @Component({
@@ -90,6 +91,9 @@ describe('FloatingDirective', () => {
         directive.placement = placement;
         expect(directive['_placement']).toEqual(placement);
       });
+
+      it('should update host position if shown', fakeAsync(() => {}));
+      it('should NOT update host position if hidden', fakeAsync(() => {}));
     });
 
     describe('strategy', () => {
@@ -98,6 +102,9 @@ describe('FloatingDirective', () => {
         directive.strategy = strategy;
         expect(directive['_strategy']).toEqual(strategy);
       });
+
+      it('should update host position if shown', fakeAsync(() => {}));
+      it('should NOT update host position if hidden', fakeAsync(() => {}));
     });
 
     describe('triggers', () => {
@@ -335,7 +342,7 @@ describe('FloatingDirective', () => {
     });
 
     describe('show', () => {
-      it('should set isShown to true by default', () => {
+      it('should set isShown to false by default', () => {
         directive['isShown'] = false;
         spectator.setInput('isDisabled', false);
         directive.show();
@@ -368,6 +375,47 @@ describe('FloatingDirective', () => {
         directive.show();
         expect(directive.displayChanged.emit).toHaveBeenCalledWith(true);
       });
+
+      it('should NOT peform position updates when floating element is hidden', fakeAsync(() => {
+        directive.reference = component.floatingElementRef;
+
+        spyOn<any>(directive, 'updateHostElementPosition');
+        spectator.detectChanges();
+        spectator.tick(10000);
+        spectator.dispatchFakeEvent(window, 'scroll');
+        expect(directive['updateHostElementPosition']).toHaveBeenCalledTimes(0);
+      }));
+
+      it('should perform position updates when shown', fakeAsync(() => {
+        directive.reference = component.floatingElementRef;
+        spectator.detectChanges();
+
+        spyOn<any>(directive, 'updateHostElementPosition');
+        directive.show();
+        spectator.tick(1000);
+        return expect(directive['updateHostElementPosition']).toHaveBeenCalledTimes(1);
+      }));
+
+      it('should perform position updates when shown and scrolled', fakeAsync(() => {
+        directive.reference = component.floatingElementRef;
+        spectator.detectChanges();
+
+        spyOn<any>(directive, 'updateHostElementPosition');
+        directive.show();
+        spectator.dispatchFakeEvent(window, 'scroll');
+        return expect(directive['updateHostElementPosition']).toHaveBeenCalledTimes(2);
+      }));
+
+      it('should perform position updates when shown and scrolled multiple times', fakeAsync(() => {
+        directive.reference = component.floatingElementRef;
+        spectator.detectChanges();
+
+        spyOn<any>(directive, 'updateHostElementPosition');
+        directive.show();
+        spectator.dispatchFakeEvent(window, 'scroll');
+        spectator.dispatchFakeEvent(window, 'scroll');
+        return expect(directive['updateHostElementPosition']).toHaveBeenCalledTimes(3);
+      }));
     });
 
     describe('hide', () => {
@@ -413,6 +461,17 @@ describe('FloatingDirective', () => {
         directive.hide();
         expect(directive.displayChanged.emit).not.toHaveBeenCalled();
       });
+
+      it('should stop auto updating positions after hiding', fakeAsync(() => {
+        directive.reference = component.floatingElementRef;
+        spectator.detectChanges();
+
+        directive.show();
+        directive.hide();
+        spyOn<any>(directive, 'updateHostElementPosition');
+        spectator.dispatchFakeEvent(window, 'scroll');
+        expect(directive['updateHostElementPosition']).toHaveBeenCalledTimes(0);
+      }));
     });
 
     describe('toggleShow', () => {

--- a/libs/designsystem/shared/floating/src/floating.directive.ts
+++ b/libs/designsystem/shared/floating/src/floating.directive.ts
@@ -74,6 +74,9 @@ export class FloatingDirective implements OnInit, OnDestroy {
     this.tearDownReferenceElementEventHandling();
     this._reference = ref;
     this.setupEventHandling();
+    if (this.isShown) {
+      this.autoUpdatePosition();
+    }
   }
 
   public get reference(): ElementRef<HTMLElement> | undefined {

--- a/libs/designsystem/shared/floating/src/floating.directive.ts
+++ b/libs/designsystem/shared/floating/src/floating.directive.ts
@@ -74,7 +74,6 @@ export class FloatingDirective implements OnInit, OnDestroy {
     this.tearDownReferenceElementEventHandling();
     this._reference = ref;
     this.setupEventHandling();
-    this.autoUpdatePosition();
   }
 
   public get reference(): ElementRef<HTMLElement> | undefined {
@@ -86,7 +85,9 @@ export class FloatingDirective implements OnInit, OnDestroy {
    * */
   @Input() public set placement(placement: Placement) {
     this._placement = placement;
-    this.updateHostElementPosition();
+    if (this.isShown) {
+      this.updateHostElementPosition();
+    }
   }
 
   public get placement() {
@@ -98,7 +99,9 @@ export class FloatingDirective implements OnInit, OnDestroy {
    * */
   @Input() public set strategy(strategy: Strategy) {
     this._strategy = strategy;
-    this.updateHostElementPosition();
+    if (this.isShown) {
+      this.updateHostElementPosition();
+    }
   }
 
   public get strategy(): Strategy {
@@ -244,7 +247,6 @@ export class FloatingDirective implements OnInit, OnDestroy {
 
   public ngOnInit(): void {
     this.addFloatStylingToHostElement();
-    this.updateHostElementPosition();
   }
 
   /* Should be accessible for programmatically setting display */
@@ -253,12 +255,11 @@ export class FloatingDirective implements OnInit, OnDestroy {
       return;
     }
 
-    this.autoUpdatePosition();
-
     this.attachDocumentClickEventHandler();
     this.attachHostClickEventHandler();
     this.renderer.setStyle(this.elementRef.nativeElement, 'display', 'block');
     this.isShown = true;
+    this.autoUpdatePosition();
     this.displayChanged.emit(this.isShown);
   }
 
@@ -269,7 +270,6 @@ export class FloatingDirective implements OnInit, OnDestroy {
     }
 
     this.removeAutoUpdaterRef();
-
     this.tearDownDocumentClickEventHandling();
     this.renderer.setStyle(this.elementRef.nativeElement, 'display', 'none');
     this.isShown = false;
@@ -306,7 +306,7 @@ export class FloatingDirective implements OnInit, OnDestroy {
   }
 
   private updateHostElementPosition(): void {
-    if (!this.reference || !this.isShown) {
+    if (!this.reference) {
       return;
     }
 

--- a/libs/designsystem/shared/floating/src/floating.directive.ts
+++ b/libs/designsystem/shared/floating/src/floating.directive.ts
@@ -253,6 +253,8 @@ export class FloatingDirective implements OnInit, OnDestroy {
       return;
     }
 
+    this.autoUpdatePosition();
+
     this.attachDocumentClickEventHandler();
     this.attachHostClickEventHandler();
     this.renderer.setStyle(this.elementRef.nativeElement, 'display', 'block');
@@ -265,6 +267,8 @@ export class FloatingDirective implements OnInit, OnDestroy {
     if (this.isDisabled || !this.isShown) {
       return;
     }
+
+    this.removeAutoUpdaterRef();
 
     this.tearDownDocumentClickEventHandling();
     this.renderer.setStyle(this.elementRef.nativeElement, 'display', 'none');
@@ -302,7 +306,7 @@ export class FloatingDirective implements OnInit, OnDestroy {
   }
 
   private updateHostElementPosition(): void {
-    if (!this.reference) {
+    if (!this.reference || !this.isShown) {
       return;
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3351 

## What is the new behavior?

Floating directive now only updates host element position manually when:
* Setting strategy when floating element is shown
* Setting placement when floating element is shown

Additionally, autoUpdate is enabled only on show, and disabled on hide / destroy.

For now, autoUpdate (from floating-ui) also performs an initial update.
If this is changed in the future, tests are added to catch it.

Update:
Now also re-enables autoUpdate if reference changes while floating element is shown.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

No breaking changes unless users hacked into private functions / fields somehow.

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

Performance profiling from cookbook menu page.

### Before changes:

[video] https://github.com/kirbydesign/designsystem/assets/5255948/118ecc7c-8239-4c45-8764-36f31a7716d4
![before](https://github.com/kirbydesign/designsystem/assets/5255948/255924f3-7c3c-40bf-b975-c85a6d0f1d91)

### After changes:

[video] https://github.com/kirbydesign/designsystem/assets/5255948/4cebc73e-acc0-4bfd-83db-0f4f0b62bb8e
![after](https://github.com/kirbydesign/designsystem/assets/5255948/f772fca8-c21d-455c-ac27-a14f9163b079)


## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/main/.github/CONTRIBUTING.md/#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

