### PR TITLE
Range: Fix undefined pinFormatter on initialization

### DIFF
--- a/libs/designsystem/range/src/range.component.spec.ts
+++ b/libs/designsystem/range/src/range.component.spec.ts
@@ -1,0 +1,25 @@
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
+import { TestHelper } from '@kirbydesign/designsystem/testing';
+import { RangeComponent } from './range.component';
+
+describe('RangeComponent', () => {
+  let spectator: SpectatorHost<RangeComponent>;
+
+  const createHost = createHostFactory({
+    component: RangeComponent,
+    imports: [TestHelper.ionicModuleForTest],
+  });
+
+  beforeEach(() => {
+    spectator = createHost('<kirby-range></kirby-range>');
+  });
+
+  it('should create', () => {
+    expect(spectator.component).toBeTruthy();
+  });
+
+  it('should always have a pinFormatter function when pin is set', () => {
+    spectator.setInput('pin', true);
+    expect(spectator.component.pinFormatter).toBeDefined();
+  });
+});

--- a/libs/designsystem/range/src/range.component.ts
+++ b/libs/designsystem/range/src/range.component.ts
@@ -99,7 +99,7 @@ export class RangeComponent implements OnChanges, OnInit, ControlValueAccessor {
     }
   }
 
-  private defaultPinFormatter(value: number): string | number {
+  private defaultPinFormatter(value: number): number {
     return value;
   }
 

--- a/libs/designsystem/range/src/range.component.ts
+++ b/libs/designsystem/range/src/range.component.ts
@@ -38,7 +38,7 @@ export class RangeComponent implements OnChanges, OnInit, ControlValueAccessor {
   @Input() step = 1;
   @Input() ticks: boolean;
   @Input() disabled = false;
-  @Input() pinFormatter: (value: number) => string | number;
+  @Input() pinFormatter: (value: number) => string | number = this.defaultPinFormatter;
   @Input()
   set value(value: number) {
     if (value !== this.currentValue) {
@@ -97,6 +97,10 @@ export class RangeComponent implements OnChanges, OnInit, ControlValueAccessor {
         this._onRangeKnobMove(rangeEvent);
       });
     }
+  }
+
+  private defaultPinFormatter(value: number): string | number {
+    return value;
   }
 
   public setDisabledState?(isDisabled: boolean): void {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3366

## What is the new behavior?
We always define a pinFormatter so we avoid initialization issues where the pinFormatter is undefined when forwarded to `ion-range`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] ~~Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)~~

When the pull request has been approved it will be merged to `develop` by Team Kirby.

