### PR TITLE
Enhancement: allow color overrides

### DIFF
--- a/apps/cookbook/src/app/showcase/colors-showcase/colors-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/colors-showcase/colors-showcase.component.html
@@ -37,7 +37,7 @@
   *ngTemplateOutlet="colorPalette; context: { $implicit: notificationColors }"
 ></ng-container>
 
-<h2>Decoration colors</h2>
+<h2>Decoration colors (click to copy)</h2>
 <ng-container
   *ngTemplateOutlet="decorationColorPalette; context: { $implicit: decorationColors }"
 ></ng-container>
@@ -92,7 +92,8 @@
           <dd>{{ ramp.step }}</dd>
           <dt
             class="color-ramp-sample {{ color.name }}-{{ ramp.step }}"
-            title="var(--kirby-decoration-color-{{ color.name }}-{{ ramp.step }})"
+            title="{{ getDecorationColorVariable(color.name, ramp.step) }}"
+            (click)="onDecorationColorClick($event, color.name, ramp.step)"
           ></dt>
         </ng-container>
       </dl>

--- a/apps/cookbook/src/app/showcase/colors-showcase/colors-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/colors-showcase/colors-showcase.component.scss
@@ -213,6 +213,55 @@
       min-height: 2.5rem;
       min-width: 2.5rem;
       border-radius: utils.size('xxxs');
+      position: relative;
+      transition: transform utils.get-transition-duration('quick');
+      cursor: pointer;
+
+      &:hover {
+        transform: scale(120%);
+      }
+
+      &::before {
+        display: block;
+        position: absolute;
+        content: 'Copied!';
+        background-color: utils.get-color('semi-light');
+        color: utils.get-color('semi-dark-contrast');
+        font-size: utils.font-size('xxs');
+        padding: utils.size('xxxxs') utils.size('xxxs');
+        border-radius: utils.size('xxxs');
+        opacity: 0;
+        transform: translateY(-50%);
+      }
+
+      &.copied::before {
+        opacity: 1;
+        animation-name: slide-in-out;
+        animation-duration: 1.5s;
+        animation-fill-mode: forwards;
+      }
     }
+  }
+}
+
+@keyframes slide-in-out {
+  0% {
+    opacity: 0;
+    transform: translateY(-50%);
+  }
+
+  10% {
+    opacity: 1;
+    transform: translateY(-125%);
+  }
+
+  90% {
+    opacity: 1;
+    transform: translateY(-125%);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateY(-200%);
   }
 }

--- a/apps/cookbook/src/app/showcase/colors-showcase/colors-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/colors-showcase/colors-showcase.component.ts
@@ -20,4 +20,18 @@ export class ColorsShowcaseComponent {
     this.selectedColor = color.name;
     this.selectedOnColor = color.name + '-contrast';
   }
+
+  async onDecorationColorClick(event: UIEvent, name: string, step: number) {
+    const colorVariable = this.getDecorationColorVariable(name, step);
+    await navigator.clipboard.writeText(colorVariable);
+    const stepElement = event.target as HTMLElement;
+    stepElement.classList.add('copied');
+    window.setTimeout(() => {
+      stepElement.classList.remove('copied');
+    }, 1500);
+  }
+
+  getDecorationColorVariable(name: string, step: number) {
+    return `var(--kirby-decoration-color-${name}-${step})`;
+  }
 }

--- a/libs/core/src/helpers/color-helper.ts
+++ b/libs/core/src/helpers/color-helper.ts
@@ -51,7 +51,7 @@ export class ColorHelper {
     return colorArray;
   }
 
-  private static mapToKirbyColorRampArray(colors: KirbyColorRamp): any[] {
+  private static mapToKirbyColorRampArray(colors: KirbyColorRamp): KirbyDecorationColor[] {
     const colorArray = Object.entries(colors).map(([name, value]) => ({
       name: camelToKebabCase(name),
       ramp: Object.entries(value).map(([step, rampValue]) => ({
@@ -191,6 +191,11 @@ export interface KirbyColor extends Color {
   tint: Color;
   shade: Color;
   contrast: Color;
+}
+
+export interface KirbyDecorationColor {
+  name: string;
+  ramp: KirbyColorRamp[];
 }
 
 export type NotificationColor = keyof typeof styles.notificationColors;

--- a/libs/core/src/helpers/color-helper.ts
+++ b/libs/core/src/helpers/color-helper.ts
@@ -150,7 +150,10 @@ export class ColorHelper {
   private static getColor(name: string): string {
     const camelCaseKey = kebabToCamelCase(name);
     const found = styles.kirbyColors[camelCaseKey];
-    return found || null;
+    const runTimeColor = window
+      .getComputedStyle(document.documentElement)
+      .getPropertyValue(`--kirby-${name}`);
+    return runTimeColor || found || null;
   }
 
   private static getDecorationColor(name: string, step: number): string {

--- a/libs/core/src/scss/themes/_colors.scss
+++ b/libs/core/src/scss/themes/_colors.scss
@@ -6,68 +6,73 @@ $brand-colors: (
   'secondary': #005c3c,
   'tertiary': #01352c,
 ) !default;
+$decoration-colors-blue: (
+  10: #abe3f2,
+  20: #88d7ec,
+  30: #66cbe7,
+  40: #43c0e1,
+  50: #21b4dc,
+  60: #1c98ba,
+  70: #177c98,
+  80: #126076,
+  90: #0d4454,
+) !default;
+$decoration-colors-green: (
+  10: #b9efd2,
+  20: #9de8c0,
+  30: #80e1ae,
+  40: #64db9b,
+  50: #47d489,
+  60: #3cb374,
+  70: #31925f,
+  80: #267149,
+  90: #1b5134,
+) !default;
+$decoration-colors-purple: (
+  10: #e4d4e7,
+  20: #d9c3de,
+  30: #ceb1d4,
+  40: #c3a0cb,
+  50: #b88ec1,
+  60: #9b78a3,
+  70: #7f6285,
+  80: #624c67,
+  90: #463649,
+) !default;
+$decoration-colors-red: (
+  10: #f7bec0,
+  20: #f3a4a6,
+  30: #f0898c,
+  40: #ec6f72,
+  50: #e95458,
+  60: #c5474a,
+  70: #a13a3d,
+  80: #7d2d2f,
+  90: #592021,
+) !default;
+$decoration-colors-yellow: (
+  10: #fde8ae,
+  20: #fddf8d,
+  30: #fcd66c,
+  40: #fccc4b,
+  50: #fbc32a,
+  60: #d4a523,
+  70: #ad871d,
+  80: #866816,
+  90: #5f4a10,
+) !default;
 $decoration-colors: (
-  'blue': (
-    10: #abe3f2,
-    20: #88d7ec,
-    30: #66cbe7,
-    40: #43c0e1,
-    50: #21b4dc,
-    60: #1c98ba,
-    70: #177c98,
-    80: #126076,
-    90: #0d4454,
-  ),
-  'green': (
-    10: #b9efd2,
-    20: #9de8c0,
-    30: #80e1ae,
-    40: #64db9b,
-    50: #47d489,
-    60: #3cb374,
-    70: #31925f,
-    80: #267149,
-    90: #1b5134,
-  ),
-  'purple': (
-    10: #e4d4e7,
-    20: #d9c3de,
-    30: #ceb1d4,
-    40: #c3a0cb,
-    50: #b88ec1,
-    60: #9b78a3,
-    70: #7f6285,
-    80: #624c67,
-    90: #463649,
-  ),
-  'red': (
-    10: #f7bec0,
-    20: #f3a4a6,
-    30: #f0898c,
-    40: #ec6f72,
-    50: #e95458,
-    60: #c5474a,
-    70: #a13a3d,
-    80: #7d2d2f,
-    90: #592021,
-  ),
-  'yellow': (
-    10: #fde8ae,
-    20: #fddf8d,
-    30: #fcd66c,
-    40: #fccc4b,
-    50: #fbc32a,
-    60: #d4a523,
-    70: #ad871d,
-    80: #866816,
-    90: #5f4a10,
-  ),
-);
+  'blue': $decoration-colors-blue,
+  'green': $decoration-colors-green,
+  'purple': $decoration-colors-purple,
+  'red': $decoration-colors-red,
+  'yellow': $decoration-colors-yellow,
+) !default;
 $notification-colors: (
   'success': map.get($decoration-colors, 'green', 50),
   'warning': map.get($decoration-colors, 'yellow', 50),
   'danger': map.get($decoration-colors, 'red', 50),
-);
+) !default;
 $system-colors: (
   'background-color': #f6f6f6,
   'white': #fff,
@@ -79,7 +84,7 @@ $system-colors: (
   'dark': #353535,
   'dark-overlay': rgb(28 28 28 / 6%),
   'black': #1c1c1c,
-);
+) !default;
 $text-colors: (
   'white': #fff,
   'semi-dark': #707070,
@@ -87,7 +92,7 @@ $text-colors: (
   'danger': #ee0d0d,
   'positive': map.get($decoration-colors, 'green', 80),
   'negative': map.get($decoration-colors, 'red', 70),
-);
+) !default;
 $focus-ring-color: rgb(77 144 254);
 
 @function get-all-colors() {


### PR DESCRIPTION
## Which issue does this PR close?

No issue.

## What is the new behavior?

- Allows for easier overrides of decoration colors in consuming app:

  ```scss
  @use '@kirbydesign/core/src/scss/themes/colors' with (
    $decoration-colors-green: (
      10: #caeade,
      20: #b4e2cf,
      30: #9cd9c2,
      40: #85d1b3,
      50: #6cc8a6,
      60: #5ca98c,
      70: #4b8a72,
      80: #3a6b59,
      90: #2b4c3f,
    ),
  );
  ```
- Adds support for getting runtime color values incl. overrides in `ColorHelper`
- Enhances docs with copy util for decoration colors

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

