### PR TITLE
test: run css transitions immediately

### DIFF
--- a/libs/designsystem/progress-circle/src/progress-circle.component.spec.ts
+++ b/libs/designsystem/progress-circle/src/progress-circle.component.spec.ts
@@ -347,6 +347,8 @@ describe('ProgressCircleComponent', () => {
       spectator = createHost({
         props: { value: 50 },
       });
+      //Ensure css transitions run immediately:
+      spectator.query<SVGCircleElement>('circle.progress').style.transitionDuration = '0ms';
     });
 
     it('should render progress stroke with themeColor `success`, when themeColor is not set', () => {


### PR DESCRIPTION
## Which issue does this PR close?

None.

## What is the new behavior?

Fixes some failing tests due to css transitions.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

