### PR TITLE
ColorHelper: Get runtime decoration and text colors

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kirbydesign/core",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "description": "Core styles and helpers for the Kirby Design System.",
   "type": "module",
   "main": "dist/index.js",

--- a/libs/core/src/helpers/color-helper.ts
+++ b/libs/core/src/helpers/color-helper.ts
@@ -159,13 +159,19 @@ export class ColorHelper {
   private static getDecorationColor(name: string, step: number): string {
     const camelCaseKey = kebabToCamelCase(name);
     const found = styles.decorationColors[camelCaseKey][step];
-    return found || null;
+    const runTimeColor = window
+      .getComputedStyle(document.documentElement)
+      .getPropertyValue(`--kirby-decoration-color-${name}-${step}`);
+    return runTimeColor || found || null;
   }
 
   private static getTextColor(name: string): string {
     const camelCaseKey = kebabToCamelCase(name);
     const found = styles.kirbyTextColors[camelCaseKey];
-    return found || null;
+    const runTimeColor = window
+      .getComputedStyle(document.documentElement)
+      .getPropertyValue(`--kirby-text-color-${name}`);
+    return runTimeColor || found || null;
   }
 
   private static opacityThreshold(opacity: number): number {

--- a/libs/designsystem/helpers/scss/src/link.spec.ts
+++ b/libs/designsystem/helpers/scss/src/link.spec.ts
@@ -3,24 +3,27 @@ import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
 const { getColor } = DesignTokenHelper;
 
 describe('Anchor tag', () => {
-  let element: HTMLElement;
+  let element: HTMLAnchorElement;
+
+  beforeEach(() => {
+    element = document.createElement('a');
+    element.id = 'fixture';
+    element.href = '/test/';
+    element.text = 'Text';
+    element.style.transitionDuration = '0ms';
+    document.body.appendChild(element);
+  });
 
   afterEach(() => {
     document.body.removeChild(element);
   });
-  describe(`by default`, () => {
-    beforeEach(() => {
-      const fixture = `<a href="/test/" id="fixture">Text</a>`;
-      document.body.insertAdjacentHTML('afterbegin', fixture);
-      console.log('document.body.style.color - BEFORE:', document.body.style.color);
-      document.body.style.color = getColor('black').value;
-      console.log('document.body.style.color - AFTER:', document.body.style.color);
-      element = document.body.querySelector('#fixture');
-    });
 
+  describe(`by default`, () => {
     it(`should inherit its color`, () => {
-      expect(document.body).toHaveComputedStyle({ color: getColor('black') });
+      document.body.style.color = getColor('black').value;
+
       expect(element).toHaveComputedStyle({ color: getColor('black') });
+      document.body.style.removeProperty('color');
     });
 
     it(`should be styled with an underline`, () => {
@@ -33,14 +36,9 @@ describe('Anchor tag', () => {
   });
 
   describe(`with class for link-icon applied`, () => {
-    beforeEach(() => {
-      const fixture = `<a href="/test/" class="kirby-external-icon" id="fixture">Text</a>`;
-      document.body.insertAdjacentHTML('afterbegin', fixture);
-      element = document.body.querySelector('#fixture');
-    });
-
     it(`should have a link icon`, () => {
       const baseURI = window.document.baseURI;
+      element.className = 'kirby-external-icon';
 
       expect(element).toHaveComputedStyle({
         'background-image': `url("${baseURI}assets/kirby/icons/svg/link.svg")`,

--- a/libs/designsystem/helpers/scss/src/link.spec.ts
+++ b/libs/designsystem/helpers/scss/src/link.spec.ts
@@ -12,11 +12,14 @@ describe('Anchor tag', () => {
     beforeEach(() => {
       const fixture = `<a href="/test/" id="fixture">Text</a>`;
       document.body.insertAdjacentHTML('afterbegin', fixture);
+      console.log('document.body.style.color - BEFORE:', document.body.style.color);
       document.body.style.color = getColor('black').value;
+      console.log('document.body.style.color - AFTER:', document.body.style.color);
       element = document.body.querySelector('#fixture');
     });
 
     it(`should inherit its color`, () => {
+      expect(document.body).toHaveComputedStyle({ color: getColor('black') });
       expect(element).toHaveComputedStyle({ color: getColor('black') });
     });
 

--- a/libs/designsystem/package.json
+++ b/libs/designsystem/package.json
@@ -6,7 +6,7 @@
     "@angular/cdk": "^17.0.0",
     "@fontsource/roboto": "4.2.1",
     "@ionic/angular": "7.3.3",
-    "@kirbydesign/core": "0.0.57",
+    "@kirbydesign/core": "0.0.58",
     "inputmask": "5.0.5"
   },
   "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "designsystem",
-  "version": "9.3.1",
+  "version": "9.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "designsystem",
-      "version": "9.3.1",
+      "version": "9.3.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -123,7 +123,7 @@
     },
     "libs/core": {
       "name": "@kirbydesign/core",
-      "version": "0.0.56",
+      "version": "0.0.58",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "designsystem",
-  "version": "9.3.1",
+  "version": "9.3.2",
   "description": "The Kirby Design Angular Components.",
   "engines": {
     "node": "20",


### PR DESCRIPTION
## Which issue does this PR close?

This PR is a follow-up to #3377 

## What is the new behavior?
Added runtime color functionality for text color and decoration colors so `ColorHelper.getThemeDecorationColorHexString()` and `ColorHelper.getThemeTextColorHexString` gets the runtime color if present.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

