### PR TITLE
Dropdown: items not shown when used within kirby-page

### DIFF
--- a/libs/designsystem/dropdown/src/dropdown.component.spec.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.spec.ts
@@ -5,6 +5,7 @@ import { createHostFactory, Spectator, SpectatorHost } from '@ngneat/spectator';
 import { MockComponents } from 'ng-mocks';
 
 import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
+import { TestHelper } from '@kirbydesign/designsystem/testing';
 import { CardComponent } from '@kirbydesign/designsystem/card';
 import { IconComponent } from '@kirbydesign/designsystem/icon';
 import { ItemComponent, ItemModule } from '@kirbydesign/designsystem/item';
@@ -1141,6 +1142,43 @@ describe('DropdownComponent', () => {
         expect(spectator.component['itemClickUnlisten']).toHaveLength(0);
         expect(unlistenCounter).toEqual(unlistenMockArrayLength);
       });
+    });
+  });
+
+  describe('when configured with expand=block and usePopover=true', () => {
+    const createHost = createHostFactory({
+      component: DropdownComponent,
+      imports: [ItemModule],
+      declarations: [
+        ItemComponent,
+        MockComponents(ButtonComponent, CardComponent, IconComponent, IonItem, PopoverComponent),
+      ],
+    });
+
+    let spectator: SpectatorHost<DropdownComponent>;
+
+    beforeEach(() => {
+      spectator = createHost(`<kirby-dropdown></kirby-dropdown>`, {
+        props: {
+          items: items,
+          expand: 'block',
+          usePopover: true,
+        },
+      });
+    });
+
+    it('should update popover card size when resized', async () => {
+      const initWidth = spectator.element.clientWidth;
+      const popoverCard = spectator.element.querySelector<HTMLElement>('kirby-card');
+      const initCardWidth = popoverCard.style.getPropertyValue('--kirby-card-width');
+      expect(initCardWidth).toEqual(`${initWidth}px`);
+
+      const newWidth = '200px';
+      (spectator.hostElement as HTMLElement).style.width = newWidth;
+      await TestHelper.waitForResizeObserver();
+
+      const cardWidth = popoverCard.style.getPropertyValue('--kirby-card-width');
+      expect(cardWidth).toEqual(newWidth);
     });
   });
 });

--- a/libs/designsystem/dropdown/src/dropdown.component.spec.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.spec.ts
@@ -1174,11 +1174,8 @@ describe('DropdownComponent', () => {
       expect(initCardWidth).toEqual(`${initWidth}px`);
 
       const newWidth = '200px';
-      console.log('Setting new width...');
       (spectator.hostElement as HTMLElement).style.width = newWidth;
-      console.log('Waiting for resize observer...');
       await TestHelper.waitForResizeObserver();
-      console.log('Assert...');
       const cardWidth = popoverCard.style.getPropertyValue('--kirby-card-width');
       expect(cardWidth).toEqual(newWidth);
     });

--- a/libs/designsystem/dropdown/src/dropdown.component.spec.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.spec.ts
@@ -1176,6 +1176,11 @@ describe('DropdownComponent', () => {
       const newWidth = '200px';
       (spectator.hostElement as HTMLElement).style.width = newWidth;
       await TestHelper.waitForResizeObserver();
+      // Resize observe callback can be flaky in test, so ensure width has changed before asserting:
+      await TestHelper.whenTrue(
+        () => popoverCard.style.getPropertyValue('--kirby-card-width') !== `${initWidth}px`
+      );
+
       const cardWidth = popoverCard.style.getPropertyValue('--kirby-card-width');
       expect(cardWidth).toEqual(newWidth);
     });

--- a/libs/designsystem/dropdown/src/dropdown.component.spec.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.spec.ts
@@ -1177,9 +1177,7 @@ describe('DropdownComponent', () => {
       (spectator.hostElement as HTMLElement).style.width = newWidth;
       await TestHelper.waitForResizeObserver();
       // Resize observe callback can be flaky in test, so ensure width has changed before asserting:
-      await TestHelper.whenTrue(
-        () => popoverCard.style.getPropertyValue('--kirby-card-width') !== `${initWidth}px`
-      );
+      await TestHelper.whenTrue(() => spectator.element.clientWidth !== initWidth);
 
       const cardWidth = popoverCard.style.getPropertyValue('--kirby-card-width');
       expect(cardWidth).toEqual(newWidth);

--- a/libs/designsystem/dropdown/src/dropdown.component.spec.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.spec.ts
@@ -1174,9 +1174,11 @@ describe('DropdownComponent', () => {
       expect(initCardWidth).toEqual(`${initWidth}px`);
 
       const newWidth = '200px';
+      console.log('Setting new width...');
       (spectator.hostElement as HTMLElement).style.width = newWidth;
+      console.log('Waiting for resize observer...');
       await TestHelper.waitForResizeObserver();
-
+      console.log('Assert...');
       const cardWidth = popoverCard.style.getPropertyValue('--kirby-card-width');
       expect(cardWidth).toEqual(newWidth);
     });

--- a/libs/designsystem/dropdown/src/dropdown.component.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.ts
@@ -288,13 +288,17 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
 
   ngAfterViewInit() {
     if (this.usePopover && this.expand === 'block') {
-      const { width } = this.elementRef.nativeElement.getBoundingClientRect();
-      this.setPopoverCardStyle('--kirby-card-width', `${width}px`);
+      const { width: initialWidth } = this.elementRef.nativeElement.getBoundingClientRect();
       this.setPopoverCardStyle('max-width', 'initial');
       this.setPopoverCardStyle('min-width', 'initial');
+      console.log('initial width:', initialWidth);
+      // Ensure initial width is set even if the resize observer callback also fires initially:
+      this.setPopoverCardStyle('--kirby-card-width', `${initialWidth}px`);
       this.resizeObserverService.observe(this.elementRef, (entry) => {
-        if (entry.contentRect.width > 0) {
-          this.setPopoverCardStyle('--kirby-card-width', `${entry.contentRect.width}px`);
+        const newWidth = entry.contentRect.width;
+        console.log('resizeObserverService callback... width:', newWidth);
+        if (newWidth > 0) {
+          this.setPopoverCardStyle('--kirby-card-width', `${newWidth}px`);
         }
       });
     }

--- a/libs/designsystem/dropdown/src/dropdown.component.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.ts
@@ -26,8 +26,9 @@ import { ItemComponent } from '@kirbydesign/designsystem/item';
 import { ListItemTemplateDirective } from '@kirbydesign/designsystem/list';
 import { HorizontalDirection, PopoverComponent } from '@kirbydesign/designsystem/popover';
 import { ButtonComponent } from '@kirbydesign/designsystem/button';
-
 import { EventListenerDisposeFn } from '@kirbydesign/designsystem/types';
+import { ResizeObserverService } from '@kirbydesign/designsystem/shared';
+
 import { OpenState, VerticalDirection } from './dropdown.types';
 import { KeyboardHandlerService } from './keyboard-handler.service';
 
@@ -245,7 +246,8 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
     private renderer: Renderer2,
     private elementRef: ElementRef<HTMLElement>,
     private changeDetectorRef: ChangeDetectorRef,
-    private keyboardHandlerService: KeyboardHandlerService
+    private keyboardHandlerService: KeyboardHandlerService,
+    private resizeObserverService: ResizeObserverService
   ) {}
 
   onToggle(event: MouseEvent) {
@@ -290,6 +292,11 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
       this.setPopoverCardStyle('--kirby-card-width', `${width}px`);
       this.setPopoverCardStyle('max-width', 'initial');
       this.setPopoverCardStyle('min-width', 'initial');
+      this.resizeObserverService.observe(this.elementRef, (entry) => {
+        if (entry.contentRect.width > 0) {
+          this.setPopoverCardStyle('--kirby-card-width', `${entry.contentRect.width}px`);
+        }
+      });
     }
     this.initializeAlignment();
   }
@@ -629,6 +636,7 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
 
   ngOnDestroy(): void {
     this.unlistenAllSlottedItems();
+    this.resizeObserverService.unobserve(this.elementRef);
     if (this.intersectionObserverRef) {
       this.intersectionObserverRef.disconnect();
     }

--- a/libs/designsystem/dropdown/src/dropdown.component.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.ts
@@ -291,12 +291,11 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
       const { width: initialWidth } = this.elementRef.nativeElement.getBoundingClientRect();
       this.setPopoverCardStyle('max-width', 'initial');
       this.setPopoverCardStyle('min-width', 'initial');
-      console.log('initial width:', initialWidth);
       // Ensure initial width is set even if the resize observer callback also fires initially:
       this.setPopoverCardStyle('--kirby-card-width', `${initialWidth}px`);
+
       this.resizeObserverService.observe(this.elementRef, (entry) => {
         const newWidth = entry.contentRect.width;
-        console.log('resizeObserverService callback... width:', newWidth);
         if (newWidth > 0) {
           this.setPopoverCardStyle('--kirby-card-width', `${newWidth}px`);
         }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3391 

## What is the new behavior?
Ensures the popover card width is reflected on resize when dropdown is configured with `expand="block" [usePopover]="true"`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

