### PR TITLE
Decimal Mask: Add alignment to decimal mask directive

### DIFF
--- a/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
@@ -87,12 +87,12 @@
   <code>[disableGroupSeperator]</code>
   .
 </p>
-
 <p>
   By default the inputted numbers are right-aligned, but can be left-aligned by setting
   <code>alignment="left"</code>
   .
 </p>
+
 <cookbook-example-viewer [html]="inputDecimalMaskExample.template">
   <cookbook-form-field-input-decimal-mask-example
     [size]="size"
@@ -116,15 +116,7 @@
   ></cookbook-form-field-input-date-example>
 </cookbook-example-viewer>
 
-<p>
-  By default (i.e. when not using the native datepicker) the value supplied to the input should be
-  formatted according to the current locale. When opting into the native datepicker, the value
-  should be in the
-  <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#date_strings">
-    Date strings format
-  </a>
-  .
-</p>
+<p>The value supplied to the input should be formatted according to the current locale.</p>
 
 <p>
   <em>
@@ -138,6 +130,36 @@
   </em>
 </p>
 
+<h4>🧪 Experimental: Standard HTML date input (native date picker)</h4>
+<p>
+  <strong>Please note:</strong>
+  The input UI generally varies between browsers and between devices (
+  <a
+    href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date"
+    target="_blank"
+    rel="noopener"
+  >
+    MDN
+  </a>
+  ). This may not adhere to the visual preferences for your project.
+</p>
+<p>
+  However, a platform native date picker has several advantages out of the box, such as being
+  accessible and having built-in localization.
+</p>
+<cookbook-example-viewer [html]="inputDateNativeExample.template">
+  <cookbook-form-field-input-date-native-example
+    [size]="size"
+    #inputDateNativeExample
+  ></cookbook-form-field-input-date-native-example>
+</cookbook-example-viewer>
+<p>
+  When opting into the native datepicker, the value should be in the
+  <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#date_strings">
+    Date strings format
+  </a>
+  .
+</p>
 <h3>Disabled</h3>
 <cookbook-example-viewer [html]="inputDisabledExample.template">
   <cookbook-form-field-input-disabled-example

--- a/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
@@ -87,6 +87,12 @@
   <code>[disableGroupSeperator]</code>
   .
 </p>
+
+<p>
+  By default the inputted numbers are right-aligned, but can be left-aligned by setting
+  <code>alignment="left"</code>
+  .
+</p>
 <cookbook-example-viewer [html]="inputDecimalMaskExample.template">
   <cookbook-form-field-input-decimal-mask-example
     [size]="size"
@@ -110,7 +116,15 @@
   ></cookbook-form-field-input-date-example>
 </cookbook-example-viewer>
 
-<p>The value supplied to the input should be formatted according to the current locale.</p>
+<p>
+  By default (i.e. when not using the native datepicker) the value supplied to the input should be
+  formatted according to the current locale. When opting into the native datepicker, the value
+  should be in the
+  <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#date_strings">
+    Date strings format
+  </a>
+  .
+</p>
 
 <p>
   <em>
@@ -124,36 +138,6 @@
   </em>
 </p>
 
-<h4>🧪 Experimental: Standard HTML date input (native date picker)</h4>
-<p>
-  <strong>Please note:</strong>
-  The input UI generally varies between browsers and between devices (
-  <a
-    href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date"
-    target="_blank"
-    rel="noopener"
-  >
-    MDN
-  </a>
-  ). This may not adhere to the visual preferences for your project.
-</p>
-<p>
-  However, a platform native date picker has several advantages out of the box, such as being
-  accessible and having built-in localization.
-</p>
-<cookbook-example-viewer [html]="inputDateNativeExample.template">
-  <cookbook-form-field-input-date-native-example
-    [size]="size"
-    #inputDateNativeExample
-  ></cookbook-form-field-input-date-native-example>
-</cookbook-example-viewer>
-<p>
-  When opting into the native datepicker, the value should be in the
-  <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#date_strings">
-    Date strings format
-  </a>
-  .
-</p>
 <h3>Disabled</h3>
 <cookbook-example-viewer [html]="inputDisabledExample.template">
   <cookbook-form-field-input-disabled-example

--- a/libs/designsystem/form-field/src/directives/decimal-mask/decimal-mask.directive.ts
+++ b/libs/designsystem/form-field/src/directives/decimal-mask/decimal-mask.directive.ts
@@ -26,6 +26,7 @@ export class DecimalMaskDirective implements ControlValueAccessor, OnInit {
   @Input() max: number;
   @Input() precision = 2;
   @Input() setMaxOnOverflow = false;
+  @Input() alignment: 'left' | 'right' = 'right';
 
   @Input() set allowMinus(allowMinus: boolean) {
     this._allowMinus = allowMinus || (this.min || 0) < 0;
@@ -99,6 +100,7 @@ export class DecimalMaskDirective implements ControlValueAccessor, OnInit {
       showMaskOnFocus: false,
       showMaskOnHover: false,
       placeholder: '',
+      rightAlign: this.alignment === 'right',
       onBeforeWrite: () => {
         if (!this.inputmask) return;
         const unmaskedValue = this.inputmask.unmaskedvalue();


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue.

## What is the new behavior?

We add the option to left-align text in a decimal-mask-enabled input, so it matches the rest of the input variants.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

