### PR TITLE
Modal: ensure footer content doesn't exceed footer width

### DIFF
--- a/libs/designsystem/modal/src/modal/footer/modal-footer.component.scss
+++ b/libs/designsystem/modal/src/modal/footer/modal-footer.component.scss
@@ -5,6 +5,7 @@ ion-footer {
   @include themes.apply-white-theme;
 
   box-shadow: utils.get-elevation(8);
+  box-sizing: inherit;
   display: flex;
   justify-content: var(--kirby-modal-footer-justify-content, center);
   align-items: center;

--- a/libs/designsystem/modal/src/modal/footer/modal-footer.component.spec.ts
+++ b/libs/designsystem/modal/src/modal/footer/modal-footer.component.spec.ts
@@ -32,6 +32,7 @@ describe('ModalFooterComponent', () => {
   const createHost = createHostFactory({
     component: ModalFooterComponent,
     host: TestHostComponent,
+    imports: [TestHelper.ionicModuleForTest],
   });
 
   beforeEach(() => {});
@@ -43,7 +44,6 @@ describe('ModalFooterComponent', () => {
 
   it('should set correct padding', () => {
     spectator = createHost(`<kirby-modal-footer></kirby-modal-footer>`);
-    expect(spectator.component).toBeTruthy();
     ionFooterElement = spectator.query('ion-footer');
     expect(ionFooterElement).toHaveComputedStyle({
       'padding-left': BASE_PADDING_PX,
@@ -51,6 +51,12 @@ describe('ModalFooterComponent', () => {
       'padding-top': BASE_PADDING_PX,
       'padding-bottom': BASE_PADDING_PX,
     });
+  });
+
+  it('should ensure ion-footer width is same as kirby-modal-footer width', () => {
+    spectator = createHost(`<kirby-modal-footer></kirby-modal-footer>`);
+    ionFooterElement = spectator.query('ion-footer');
+    expect(ionFooterElement.offsetWidth).toEqual(spectator.element.offsetWidth);
   });
 
   describe('Set bottom padding', () => {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #2425 

## What is the new behavior?

Ensures the footer content doesn't exceed the width of the modal footer.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

