### PR TITLE
Alert: ensure buttons don't overflow the alert

### DIFF
--- a/libs/designsystem/modal/src/modal/alert/alert.component.scss
+++ b/libs/designsystem/modal/src/modal/alert/alert.component.scss
@@ -11,11 +11,15 @@ article {
 
 .buttongroup {
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
+  column-gap: utils.size('xxs');
 
   button {
-    width: 50%;
-    margin-left: 6px;
-    margin-right: 6px;
+    flex: 1 1 50%;
+    margin-inline: 0;
+
+    &:only-child {
+      flex-grow: 0;
+    }
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3434 

## What is the new behavior?

Correct spacing of buttons in the alert without overflowing it's container.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

