### PR TITLE
Progress circle: fix wrong animation direction

### DIFF
--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.html
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.html
@@ -13,7 +13,7 @@
     class="progress"
     fill="transparent"
     stroke-linecap="round"
-    [attr.stroke-width]="strokeWidth"
+    [attr.stroke-width]="_progressStrokeWidth"
     [attr.r]="_centerRadius"
     [attr.cx]="radius"
     [attr.cy]="radius"

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.html
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.html
@@ -17,7 +17,6 @@
     [attr.r]="_centerRadius"
     [attr.cx]="radius"
     [attr.cy]="radius"
-    [attr.stroke-dashoffset]="_offset"
-    [attr.stroke-dasharray]="_centerCircumference"
+    [attr.stroke-dasharray]="[_progress, _remainder]"
   />
 </svg>

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
@@ -8,19 +8,6 @@ svg {
   stroke: utils.get-color('semi-light');
 }
 
-.progress {
-  // Avoid flash of full progress circle if attribute binding in template has not yet been evaluated.
-  &:not([stroke-dasharray]) {
-    stroke-dasharray: 0 999;
-  }
-
-  transition-property: stroke-dasharray;
-  transition-duration: utils.get-transition-duration('extra-long');
-  transition-timing-function: utils.get-transition-easing('enter-exit');
-  transform-origin: 50% 50%;
-  stroke: var(--kirby-progress-circle-stroke-color, #{utils.get-color('success')});
-}
-
 :host {
   @each $color-name, $color-value in utils.$notification-colors {
     &.#{$color-name} {
@@ -31,6 +18,10 @@ svg {
   &.view-initialized {
     .progress {
       transition-property: stroke-dasharray, stroke;
+      transition-duration: utils.get-transition-duration('extra-long');
+      transition-timing-function: utils.get-transition-easing('enter-exit');
+      transform-origin: 50% 50%;
+      stroke: var(--kirby-progress-circle-stroke-color, #{utils.get-color('success')});
     }
   }
 }

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
@@ -9,20 +9,23 @@ svg {
 }
 
 .progress {
-  transition-property: stroke-dasharray, stroke;
+  transition-property: stroke-dasharray;
   transition-duration: utils.get-transition-duration('extra-long');
   transition-timing-function: utils.get-transition-easing('enter-exit');
   transform-origin: 50% 50%;
   stroke: var(--kirby-progress-circle-stroke-color, #{utils.get-color('success')});
-  // Avoid flash of full progress circle if attribute binding in template has not yet been evaluated.
-  &:not([stroke-dasharray]) {
-    stroke-dasharray: 0 999;
-  }
 }
+
 :host {
   @each $color-name, $color-value in utils.$notification-colors {
     &.#{$color-name} {
       --kirby-progress-circle-stroke-color: #{utils.get-color($color-name)};
+    }
+  }
+
+  &.view-initialized {
+    .progress {
+      transition-property: stroke-dasharray, stroke;
     }
   }
 }

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
@@ -9,7 +9,7 @@ svg {
 }
 
 .progress {
-  transition-property: stroke-dasharray;
+  transition-property: stroke-dasharray, stroke;
   transition-duration: utils.get-transition-duration('extra-long');
   transition-timing-function: utils.get-transition-easing('enter-exit');
   transform-origin: 50% 50%;

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
@@ -14,13 +14,11 @@ svg {
   transition-timing-function: utils.get-transition-easing('enter-exit');
   transform-origin: 50% 50%;
   stroke: var(--kirby-progress-circle-stroke-color, #{utils.get-color('success')});
+  // Avoid flash of full progress circle if attribute binding in template has not yet been evaluated.
+  &:not([stroke-dasharray]) {
+    stroke-dasharray: 0 999;
+  }
 }
-
-// Avoid flash of full progress circle if attribute binding in template has not yet been evaluated.
-.progress:not([stroke-dasharray]) {
-  stroke-dasharray: 0 999;
-}
-
 :host {
   @each $color-name, $color-value in utils.$notification-colors {
     &.#{$color-name} {

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
@@ -9,6 +9,11 @@ svg {
 }
 
 .progress {
+  // Avoid flash of full progress circle if attribute binding in template has not yet been evaluated.
+  &:not([stroke-dasharray]) {
+    stroke-dasharray: 0 999;
+  }
+
   transition-property: stroke-dasharray;
   transition-duration: utils.get-transition-duration('extra-long');
   transition-timing-function: utils.get-transition-easing('enter-exit');

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
@@ -16,6 +16,11 @@ svg {
   stroke: var(--kirby-progress-circle-stroke-color, #{utils.get-color('success')});
 }
 
+// Avoid flash of full progress circle if attribute binding in template has not yet been evaluated.
+.progress:not([stroke-dasharray]) {
+  stroke-dasharray: 0 999;
+}
+
 :host {
   @each $color-name, $color-value in utils.$notification-colors {
     &.#{$color-name} {

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
@@ -9,7 +9,7 @@ svg {
 }
 
 .progress {
-  transition-property: stroke-dashoffset, stroke;
+  transition-property: stroke-dasharray;
   transition-duration: utils.get-transition-duration('extra-long');
   transition-timing-function: utils.get-transition-easing('enter-exit');
   transform-origin: 50% 50%;

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.spec.ts
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.spec.ts
@@ -44,8 +44,8 @@ describe('ProgressCircleRingComponent', () => {
     });
   });
 
-  describe('offset (progress) within upperBound', () => {
-    it('should return the non-progress circumference (1 - progress) as offset', () => {
+  describe('progress within upperBound', () => {
+    it('should return the non-progress circumference (1 - progress) as remainder', () => {
       const value = 33;
       const upperBound = 96;
       spectator.setInput({
@@ -53,15 +53,15 @@ describe('ProgressCircleRingComponent', () => {
         upperBound,
       });
 
-      expect(spectator.component._offset).toBe(
+      expect(spectator.component._remainder).toBe(
         spectator.component._centerCircumference -
           spectator.component._centerCircumference * (value / 100)
       );
     });
   });
 
-  describe('offset (progress) larger than upperBound', () => {
-    it('should return the non-progress circumference (1 - upperBound) as offset', () => {
+  describe('progress larger than upperBound', () => {
+    it('should return the non-progress circumference (1 - upperBound) as remainder', () => {
       const value = 99;
       const upperBound = 96;
       spectator.setInput({
@@ -69,7 +69,7 @@ describe('ProgressCircleRingComponent', () => {
         upperBound,
       });
 
-      expect(spectator.component._offset).toBe(
+      expect(spectator.component._remainder).toBe(
         spectator.component._centerCircumference -
           spectator.component._centerCircumference * (upperBound / 100)
       );

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.ts
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.ts
@@ -1,5 +1,11 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  HostBinding,
+  Input,
+} from '@angular/core';
 
 @Component({
   standalone: true,
@@ -9,7 +15,7 @@ import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular
   styleUrls: ['./progress-circle-ring.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ProgressCircleRingComponent {
+export class ProgressCircleRingComponent implements AfterViewInit {
   @Input() radius: number; // The desired outer radius of the SVG circle
   @Input() value: number = 0;
   @Input() themeColor: 'success' | 'warning' | 'danger' = 'success';
@@ -33,7 +39,6 @@ export class ProgressCircleRingComponent {
   get _progress(): number {
     const valueWithinBounds = this.value < this.upperBound || this.value > 99;
     const _value = valueWithinBounds ? this.value : this.upperBound;
-
     const progressPercentage = _value / 100;
     return this._centerCircumference * progressPercentage;
   }
@@ -43,8 +48,9 @@ export class ProgressCircleRingComponent {
   }
 
   get _progressStrokeWidth(): number {
-    // Don't render stroke if value is 0, otherwise it will show as a dot:
-    if (this.value === 0) return 0;
+    // Do not render stroke if progress is 0, otherwise it will show as a dot
+    if (this._progress === 0) return 0;
+
     return this.strokeWidth;
   }
 }

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.ts
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.ts
@@ -22,6 +22,13 @@ export class ProgressCircleRingComponent implements AfterViewInit {
   @Input() strokeWidth: number;
   @Input() upperBound: number;
 
+  @HostBinding('class.view-initialized')
+  viewInitialized;
+
+  ngAfterViewInit(): void {
+    this.viewInitialized = true;
+  }
+
   @HostBinding('style.width.px')
   @HostBinding('style.height.px')
   get _diameter(): number {

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.ts
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.ts
@@ -40,4 +40,8 @@ export class ProgressCircleRingComponent {
   get _remainder(): number {
     return this._centerCircumference - this._progress;
   }
+
+  get _progressStrokeWidth(): number {
+    return this.value == 0 ? 0 : this.strokeWidth;
+  }
 }

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.ts
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.ts
@@ -16,15 +16,6 @@ export class ProgressCircleRingComponent {
   @Input() strokeWidth: number;
   @Input() upperBound: number;
 
-  get _offset(): number {
-    const valueWithinBounds = this.value < this.upperBound || this.value > 99;
-    if (valueWithinBounds) {
-      return this.calculateOffset(this.value);
-    } else {
-      return this.calculateOffset(this.upperBound);
-    }
-  }
-
   @HostBinding('style.width.px')
   @HostBinding('style.height.px')
   get _diameter(): number {
@@ -39,7 +30,14 @@ export class ProgressCircleRingComponent {
     return this._centerRadius * 2 * Math.PI;
   }
 
-  private calculateOffset(value: number): number {
-    return this._centerCircumference - this._centerCircumference * (value / 100);
+  get _progress(): number {
+    const valueWithinBounds = this.value < this.upperBound || this.value > 99;
+    const _value = valueWithinBounds ? this.value : this.upperBound;
+
+    return (_value * this._centerCircumference) / 100;
+  }
+
+  get _remainder(): number {
+    return this._centerCircumference - this._progress;
   }
 }

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.ts
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.ts
@@ -34,7 +34,8 @@ export class ProgressCircleRingComponent {
     const valueWithinBounds = this.value < this.upperBound || this.value > 99;
     const _value = valueWithinBounds ? this.value : this.upperBound;
 
-    return (_value * this._centerCircumference) / 100;
+    const progressPercentage = _value / 100;
+    return this._centerCircumference * progressPercentage;
   }
 
   get _remainder(): number {
@@ -42,6 +43,8 @@ export class ProgressCircleRingComponent {
   }
 
   get _progressStrokeWidth(): number {
-    return this.value == 0 ? 0 : this.strokeWidth;
+    // Don't render stroke if value is 0, otherwise it will show as a dot:
+    if (this.value === 0) return 0;
+    return this.strokeWidth;
   }
 }

--- a/libs/designsystem/progress-circle/src/progress-circle.component.spec.ts
+++ b/libs/designsystem/progress-circle/src/progress-circle.component.spec.ts
@@ -349,6 +349,7 @@ describe('ProgressCircleComponent', () => {
       });
       //Ensure css transitions run immediately:
       spectator.query<SVGCircleElement>('circle.progress').style.transitionDuration = '0ms';
+      spectator.detectComponentChanges();
     });
 
     it('should render progress stroke with themeColor `success`, when themeColor is not set', () => {


### PR DESCRIPTION
## Which issue does this PR close?
This PR closes #3441

## What is the new behavior?
The issue described here https://github.com/kirbydesign/designsystem/issues/3441#issuecomment-2056620529 happens because the colored part of the circle is rendered before the attribute bindings for `stroke-dashoffset` and `stroke-dasharray` have been evaluated, so the full circle is shown.

A view-initialized class is now added when the components view is rendered, and we then wait until this class is added before we apply the transition.

Additionally, instead of using stroke-dashoffset I have refactored the stroke to use only the dasharray attribute to set a stroke and gap length. 
One downside of this approach is that even with a stroke of length 0, we end up applying a stroke width, so we always draw a little dot when the value is 0. 
<img width="92" alt="image" src="https://github.com/kirbydesign/designsystem/assets/42470636/4a6c866b-9475-4ba8-9cc8-c51bea79b26a">
To work around this I have added a conditional that sets the stroke width to 0, when value is 0.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

