### PR TITLE
Tab Navigation: Change item padding and gap between items

### DIFF
--- a/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.scss
+++ b/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.scss
@@ -33,7 +33,7 @@ $border-color-selected: utils.get-color('dark');
 
     color: utils.get-color('black');
     box-sizing: border-box; // Ensure border is not added to button height
-    padding: utils.size('s') utils.size('m');
+    padding: utils.size('s');
     font-size: utils.font-size('n');
     line-height: utils.line-height('m');
     gap: utils.size('xxxs');

--- a/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.scss
+++ b/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.scss
@@ -39,6 +39,7 @@ div[role='tablist'] {
   justify-content: left;
   flex-wrap: nowrap;
   overflow-x: scroll;
+  column-gap: utils.size('xs');
 
   @include utils.media('<medium') {
     padding-inline: var(--padding-start) var(--padding-end);


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3445 

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

Padding on tab navigation items and the gap between them have between changed according to issue description

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

