### PR TITLE
[Enhancement] Generic SegmentedControl

### DIFF
--- a/libs/designsystem/src/lib/components/segmented-control/segment-item.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segment-item.ts
@@ -3,16 +3,11 @@ import { ThemeColor } from '@kirbydesign/core';
 type SegmentItemBadge = {
   content?: string;
   icon?: string;
-  isCustomIcon?: boolean;
   description?: string;
   themeColor: ThemeColor;
 };
 export interface SegmentItem {
   id: string;
   text: string;
-  badge?: Omit<SegmentItemBadge, 'isCustomIcon'>; // we do not expose the isCustomIcon for the external type
-}
-
-export interface SegmentItemInternal extends SegmentItem {
   badge?: SegmentItemBadge;
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3453

## What is the new behavior?

Type passed to `items` will be passed back with `segmentSelect()`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

A custom implementation of `NoInfer` has to be introduced until TypeScript 5.4 has been upgraded to which provide built-in support for `NoInfer`

The property `isCustomIcon` on `SegmentItem` has been removed since it was seemingly unused. This eliminates the need for `SegmentItemInternal` as well.

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

