### PR TITLE
Segmented Control: looses its checked state when items are updated

### DIFF
--- a/apps/cookbook/src/app/examples/segmented-control-example/color/color.ts
+++ b/apps/cookbook/src/app/examples/segmented-control-example/color/color.ts
@@ -24,7 +24,7 @@ const config = {
     <label>
       <input
         type="radio"
-        name="mode"
+        name="example-color-mode"
         value="default"
         [checked]="mode === 'default'"
         (change)="setMode($event.target.value)"
@@ -34,7 +34,7 @@ const config = {
     <label>
       <input
         type="radio"
-        name="mode"
+        name="example-color-mode"
         value="chip"
         [checked]="mode === 'chip'"
         (change)="setMode($event.target.value)"
@@ -44,7 +44,7 @@ const config = {
     <label> 
       <input
         type="radio"
-        name="mode"
+        name="example-color-mode"
         value="compactChip"
         [checked]="mode === 'compactChip'"
         (change)="setMode($event.target.value)"

--- a/apps/cookbook/src/app/examples/segmented-control-example/default/default.ts
+++ b/apps/cookbook/src/app/examples/segmented-control-example/default/default.ts
@@ -142,7 +142,6 @@ export class SegmentedControlExampleDefaultComponent implements OnInit {
   }
 
   setMode(mode: SegmentedControlMode) {
-    console.log('setMode - mode:', mode);
     this.mode = mode;
     this.selectedSegment = this.items[0];
   }

--- a/apps/cookbook/src/app/examples/segmented-control-example/default/default.ts
+++ b/apps/cookbook/src/app/examples/segmented-control-example/default/default.ts
@@ -23,7 +23,7 @@ const config = {
     <label>
       <input
         type="radio"
-        name="mode"
+        name="example-default-mode"
         value="default"
         [checked]="mode === 'default'"
         (change)="setMode($event.target.value)"
@@ -33,7 +33,7 @@ const config = {
     <label>
       <input
         type="radio"
-        name="mode"
+        name="example-default-mode"
         value="chip"
         [checked]="mode === 'chip'"
         (change)="setMode($event.target.value)"
@@ -43,7 +43,7 @@ const config = {
     <label> 
       <input
         type="radio"
-        name="mode"
+        name="example-default-mode"
         value="compactChip"
         [checked]="mode === 'compactChip'"
         (change)="setMode($event.target.value)"
@@ -56,7 +56,7 @@ const config = {
     <label>
       <input
         type="radio"
-        name="size"
+        name="example-default-size"
         value="sm"
         [checked]="size === 'sm'"
         (change)="setSize($event.target.value)"
@@ -67,7 +67,7 @@ const config = {
     <label>
       <input
         type="radio"
-        name="size"
+        name="example-default-size"
         value="md"
         [checked]="size === 'md'"
         (change)="setSize($event.target.value)"
@@ -142,6 +142,7 @@ export class SegmentedControlExampleDefaultComponent implements OnInit {
   }
 
   setMode(mode: SegmentedControlMode) {
+    console.log('setMode - mode:', mode);
     this.mode = mode;
     this.selectedSegment = this.items[0];
   }

--- a/apps/cookbook/src/app/examples/segmented-control-example/with-badge/with-badge.ts
+++ b/apps/cookbook/src/app/examples/segmented-control-example/with-badge/with-badge.ts
@@ -15,7 +15,7 @@ const config = {
     <label>
       <input
         type="radio"
-        name="size"
+        name="example-with-badge-size"
         value="sm"
         [checked]="size === 'sm'"
         (change)="setSize($event.target.value)"
@@ -26,7 +26,7 @@ const config = {
     <label>
       <input
         type="radio"
-        name="size"
+        name="example-with-badge-size"
         value="md"
         [checked]="size === 'md'"
         (change)="setSize($event.target.value)"


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3459

## What is the new behavior?

Keeps checked state as expected.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

