### PR TITLE
Page: add new max widths for page content

### DIFF
--- a/apps/cookbook/src/app/examples/page-example/content-width/page-content-width-example.component.ts
+++ b/apps/cookbook/src/app/examples/page-example/content-width/page-content-width-example.component.ts
@@ -32,7 +32,7 @@ const fieldsetHtml = `
 `;
 
 const config = {
-  template: `<kirby-page title="Content Width" defaultBackHref="/" [maxWidth]="maxWidth">
+  template: `<kirby-page title="Content Width" [maxWidth]="maxWidth">
   <kirby-page-content>${fieldsetHtml}
     <div [innerHTML]="content"></div>
   </kirby-page-content>
@@ -50,7 +50,6 @@ const config = {
 })
 export class PageContentWidthExampleComponent extends BasePageExampleComponent {
   static readonly template = config.template
-    .replace(' defaultBackHref="/"', '')
     .replace(fieldsetHtml, '')
     .replace('<div [innerHTML]="content"></div>', '...');
 

--- a/apps/cookbook/src/app/examples/page-example/content-width/page-content-width-example.component.ts
+++ b/apps/cookbook/src/app/examples/page-example/content-width/page-content-width-example.component.ts
@@ -1,21 +1,34 @@
 import { Component } from '@angular/core';
 
+import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
+const getMaxWidth = DesignTokenHelper.pageContentMaxWidth;
+
 import { BasePageExampleComponent } from '../base-page-example.component';
 
 const fieldsetHtml = `
   <fieldset>
     <legend>Max Width</legend>
-    <select (change)="onMaxWidthChange($event.target.value)">
-      <option
-        *ngFor="let option of maxWidthOptions"
-        value="{{ option.value }}"
-        [attr.selected]="maxWidthOptions === option.value ? true : null"
+    <kirby-dropdown
+      [items]="maxWidthOptions"
+      [selectedIndex]="0"
+      size="sm"
+      (change)="onMaxWidthChange($event.value)">
+      <kirby-item
+        *kirbyListItemTemplate="let item; let selected = selected; let focused = focused"
+        selectable="true"
+        [selected]="selected"
+        [class.focused]="focused"
       >
-        {{ option.text }}
-      </option>
-    </select>
+        <kirby-label>
+          <h3>{{ item.text }}</h3>
+          <code detail *ngIf="item.value !== 'default'">maxWidth="{{item.value}}"</code>
+        </kirby-label>
+        <kirby-label slot="end">
+          <data detail>{{ item.width }}</data>
+        </kirby-label>
+      </kirby-item>
+    </kirby-dropdown>
   </fieldset>
-  <br />
 `;
 
 const config = {
@@ -27,6 +40,13 @@ const config = {
 };
 @Component({
   template: config.template,
+  styles: [
+    `
+      fieldset {
+        margin-bottom: 16px;
+      }
+    `,
+  ],
 })
 export class PageContentWidthExampleComponent extends BasePageExampleComponent {
   static readonly template = config.template
@@ -34,24 +54,32 @@ export class PageContentWidthExampleComponent extends BasePageExampleComponent {
     .replace(fieldsetHtml, '')
     .replace('<div [innerHTML]="content"></div>', '...');
 
-  maxWidth: string = '';
-
   maxWidthOptions = [
     {
-      text: 'default',
+      text: 'Default',
       value: 'default',
+      width: getMaxWidth('default'),
     },
     {
-      text: 'optimized',
-      value: 'optimized',
+      text: 'Large',
+      value: 'lg',
+      width: getMaxWidth('lg'),
     },
     {
-      text: 'full',
+      text: 'X-Large',
+      value: 'xl',
+      width: getMaxWidth('xl'),
+    },
+    {
+      text: 'Full',
       value: 'full',
+      width: getMaxWidth('full'),
     },
   ];
 
-  onMaxWidthChange(value) {
+  maxWidth: string = this.maxWidthOptions[0].value;
+
+  onMaxWidthChange(value: string) {
     this.maxWidth = value;
   }
 }

--- a/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.html
@@ -481,9 +481,21 @@
       only impact the content areas as the top bar will continue to use the available space.
     </p>
     <cookbook-code-viewer [html]="contentWidthExampleHtml"></cookbook-code-viewer>
+    <p>
+      <em>
+        <strong>Please note:</strong>
+        For this setting to take effect
+        <a class="kirby-external-icon" [href]="contentWidthExample.trustedSrc">
+          the example below should be viewed in a full browser window
+        </a>
+      </em>
+    </p>
+    <cookbook-iphone
+      viewMode="full-size"
+      src="/examples/page/content-width"
+      #contentWidthExample
+    ></cookbook-iphone>
   </div>
-
-  <cookbook-iphone src="/examples/page/content-width" showExternalLink="true"></cookbook-iphone>
 </div>
 
 <h2>Page Properties:</h2>

--- a/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.ts
@@ -83,7 +83,7 @@ export class PageShowcaseComponent {
       name: 'maxWidth',
       description: 'Sets the max width for the content',
       defaultValue: 'default',
-      type: ['default', 'optimized', 'full'],
+      type: ['default', 'lg', 'xl', 'full'],
     },
   ];
   events: ApiDescriptionEvent[] = [

--- a/libs/core/src/scss/base/_variables.scss
+++ b/libs/core/src/scss/base/_variables.scss
@@ -125,7 +125,8 @@ $avatar-badge-size: 16px;
 ****************************************************************************/
 $page-content-max-widths: (
   default: 792px,
-  optimized: 1092px,
+  lg: 1092px,
+  xl: 1392px,
   full: 100%,
 );
 $page-content-max-width-default: map.get($page-content-max-widths, 'default');

--- a/libs/designsystem/page/src/page.component.scss
+++ b/libs/designsystem/page/src/page.component.scss
@@ -267,8 +267,13 @@ ion-content {
     --padding-top: 0;
   }
 
-  &.max-width-optimized {
-    --page-content-max-width: #{utils.get-page-content-max-width('optimized')};
+  &.max-width-optimized, // TODO: Remove deprecated option 'optimized' in Kirby v10
+  &.max-width-lg {
+    --page-content-max-width: #{utils.get-page-content-max-width('lg')};
+  }
+
+  &.max-width-xl {
+    --page-content-max-width: #{utils.get-page-content-max-width('xl')};
   }
 
   &.max-width-full {

--- a/libs/designsystem/page/src/page.component.spec.ts
+++ b/libs/designsystem/page/src/page.component.spec.ts
@@ -841,7 +841,37 @@ describe('PageComponent', () => {
           await TestHelper.whenReady(ionContent);
           const contentInner = ionContent.querySelector('.content-inner');
           expect(contentInner).toHaveComputedStyle({
-            'max-width': DesignTokenHelper.pageContentMaxWidth('optimized'),
+            'max-width': DesignTokenHelper.pageContentMaxWidth('lg'),
+          });
+        });
+      });
+
+      describe('and is set to lg', () => {
+        beforeEach(() => {
+          spectator.component.maxWidth = 'lg';
+          spectator.detectChanges();
+        });
+
+        it('should apply correct content width', async () => {
+          await TestHelper.whenReady(ionContent);
+          const contentInner = ionContent.querySelector('.content-inner');
+          expect(contentInner).toHaveComputedStyle({
+            'max-width': DesignTokenHelper.pageContentMaxWidth('lg'),
+          });
+        });
+      });
+
+      describe('and is set to xl', () => {
+        beforeEach(() => {
+          spectator.component.maxWidth = 'xl';
+          spectator.detectChanges();
+        });
+
+        it('should apply correct content width', async () => {
+          await TestHelper.whenReady(ionContent);
+          const contentInner = ionContent.querySelector('.content-inner');
+          expect(contentInner).toHaveComputedStyle({
+            'max-width': DesignTokenHelper.pageContentMaxWidth('xl'),
           });
         });
       });

--- a/libs/designsystem/page/src/page.component.ts
+++ b/libs/designsystem/page/src/page.component.ts
@@ -70,10 +70,13 @@ const contentScrolledOffsetInPixels = 4;
 
 type stickyConfig = { sticky: boolean };
 type fixedConfig = { fixed: boolean };
-type MaxWidth = 'default' | 'standard' | 'optimized' | 'full';
+type MaxWidth = 'default' | 'standard' | 'optimized' | 'lg' | 'xl' | 'full'; // TODO: Remove deprecated options 'standard' and 'optimized' in Kirby v10
 
 const PAGE_WIDTH_STANDARD_DEPRECATION_WARNING =
   'Deprecation warning: The support for "standard" as a maxWidth option will be removed in Kirby version 10. After that the "standard" width will be the default width and does not need to be specified.';
+
+const PAGE_WIDTH_OPTIMIZED_DEPRECATION_WARNING =
+  'Deprecation warning: The "optimized" maxWidth option is deprecated, please use "lg" instead. The support for "optimized" as a maxWidth option will be removed in Kirby version 10.';
 
 export const PAGE_BACK_BUTTON_OVERRIDE = new InjectionToken<PageBackButtonOverride>(
   'page-back-button-override'
@@ -238,8 +241,13 @@ export class PageComponent
   @Input() hasInteractiveTitle: boolean;
 
   @Input() set maxWidth(width: MaxWidth) {
+    // TODO: Remove deprecation warning in Kirby v10
     if (width === 'standard') {
       console.warn(PAGE_WIDTH_STANDARD_DEPRECATION_WARNING);
+    }
+    // TODO: Remove deprecation warning in Kirby v10
+    if (width === 'optimized') {
+      console.warn(PAGE_WIDTH_OPTIMIZED_DEPRECATION_WARNING);
     }
 
     this._maxWidth = width;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3463 

## What is the new behavior?

Added a new `xl` page max width of `1392px`. Also renamed/deprecated `optimized` to `lg`. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

