### PR TITLE
Repo: Set up core path alias and fix publish script paths

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -35,7 +35,7 @@ const coreLibDir = `${libsRootDir}/core`;
 const coreLibSrcDir = `${coreLibDir}/src`;
 
 const dist = `dist`;
-const distDesignsystemTarget = `${dist}/${designsystemLibDir}`;
+const distDesignsystemTarget = `${designsystemLibDir}/${dist}`;
 const distDesignsystemPackageJsonPath = `${distDesignsystemTarget}/package.json`;
 const distCoreTarget = `${dist}/${coreLibDir}`;
 const distCorePackageJsonPath = `${distCoreTarget}/package.json`;


### PR DESCRIPTION
## Which issue does this PR close?
No issue, this is a quick fix. 
I forgot to change the paths for our publish script, now that we place dist files inside the individual project folders.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No