### PR TITLE
Modal footer: Apply correct theme variables for nested elements inside footer

### DIFF
--- a/libs/designsystem/modal/src/modal/footer/modal-footer.component.scss
+++ b/libs/designsystem/modal/src/modal/footer/modal-footer.component.scss
@@ -43,6 +43,7 @@ ion-footer {
 :host(.inline) ion-footer {
   background: transparent;
   box-shadow: none;
+  @include themes.apply-light-theme;
 }
 
 :host-context(.keyboard-visible) {

--- a/libs/designsystem/modal/src/modal/footer/modal-footer.component.scss
+++ b/libs/designsystem/modal/src/modal/footer/modal-footer.component.scss
@@ -37,13 +37,16 @@ ion-footer {
 }
 
 :host(.light) ion-footer {
+  @include themes.apply-light-theme;
+
   background-color: utils.get-color('background-color');
 }
 
 :host(.inline) ion-footer {
+  @include themes.apply-light-theme;
+
   background: transparent;
   box-shadow: none;
-  @include themes.apply-light-theme;
 }
 
 :host-context(.keyboard-visible) {

--- a/libs/designsystem/modal/src/modal/footer/modal-footer.component.spec.ts
+++ b/libs/designsystem/modal/src/modal/footer/modal-footer.component.spec.ts
@@ -4,6 +4,7 @@ import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
 import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
 
 import { TestHelper } from '@kirbydesign/designsystem/testing';
+import { ButtonComponent } from '@kirbydesign/designsystem/button';
 import { ModalFooterComponent } from '../footer/modal-footer.component';
 
 const { getColor, size } = DesignTokenHelper;
@@ -32,7 +33,7 @@ describe('ModalFooterComponent', () => {
   const createHost = createHostFactory({
     component: ModalFooterComponent,
     host: TestHostComponent,
-    imports: [TestHelper.ionicModuleForTest],
+    imports: [TestHelper.ionicModuleForTest, ButtonComponent],
   });
 
   beforeEach(() => {});
@@ -192,6 +193,15 @@ describe('ModalFooterComponent', () => {
       spectator = createHost(`<kirby-modal-footer type="inline"></kirby-modal-footer>`);
       expect(spectator.query('ion-footer')).toHaveComputedStyle({
         'box-shadow': 'none',
+      });
+    });
+
+    it('should apply theming to buttons within the modal footer', () => {
+      spectator = createHost(
+        `<kirby-modal-footer type="inline"><button kirby-button attentionLevel="3">Click Me</button></kirby-modal-footer>`
+      );
+      expect(spectator.query('button')).toHaveComputedStyle({
+        'background-color': getColor('white'),
       });
     });
   });


### PR DESCRIPTION
## Which issue does this PR close?

This PR fixes an issue where grey buttons (buttons with `attentionLevel="3"`) in an inline footer would not change their color to white, when modal footer has `type="inline"`
An example code snippet of the use would look like this:
```
<kirby-modal-footer type="inline">
  <button kirby-button attentionLevel="3">Click Me</button>
</kirby-modal-footer>
```
And the output of this snippet would show a grey button on a grey background when a modal footer is set as inline, which makes the button not stand out:

![image](https://github.com/kirbydesign/designsystem/assets/15999062/cf0f0a65-f5bc-4849-b161-0d88cfd57d80)


## What is the new behavior?

When the `type="inline"` is added to a modal footer, the correct theme (light-theme) will be applied causing the grey buttons within the modal footer to properly turn white. 

The output will now look like this:

![image](https://github.com/kirbydesign/designsystem/assets/15999062/2ccbb9d4-a540-4fff-860e-46a2c3fe460b)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

