### PR TITLE
Housekeeping: fix `ng-packager` version

### DIFF
--- a/libs/angular/package.json
+++ b/libs/angular/package.json
@@ -25,7 +25,7 @@
     "@angular/language-service": "^17.0.10",
     "@repo/eslint-config": "*",
     "jsonc-eslint-parser": "^2.1.0",
-    "ng-packagr": "~17.0.0",
+    "ng-packagr": "^17.0.3",
     "postcss": "^8.4.5",
     "postcss-import": "~14.1.0",
     "postcss-preset-env": "~7.5.0",

--- a/libs/extensions/angular/package.json
+++ b/libs/extensions/angular/package.json
@@ -30,7 +30,7 @@
     "jest-environment-jsdom": "^29.4.1",
     "jest-preset-angular": "~13.1.4",
     "jsonc-eslint-parser": "^2.1.0",
-    "ng-packagr": "~17.0.0",
+    "ng-packagr": "^17.0.3",
     "postcss": "^8.4.5",
     "postcss-import": "~14.1.0",
     "postcss-preset-env": "~7.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,6 +112,40 @@
         "webpack-bundle-analyzer": "^4.6.1"
       }
     },
+    "libs/angular": {
+      "name": "@kirbydesign/angular",
+      "version": "0.0.1",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "devDependencies": {
+        "@angular-devkit/build-angular": "^17.0.10",
+        "@angular-devkit/core": "^17.0.10",
+        "@angular-devkit/schematics": "^17.0.10",
+        "@angular/animations": "^17.0.10",
+        "@angular/cli": "^17.0.9",
+        "@angular/compiler-cli": "^17.0.9",
+        "@angular/language-service": "^17.0.10",
+        "@repo/eslint-config": "*",
+        "jsonc-eslint-parser": "^2.1.0",
+        "ng-packagr": "^17.0.3",
+        "postcss": "^8.4.5",
+        "postcss-import": "~14.1.0",
+        "postcss-preset-env": "~7.5.0",
+        "postcss-url": "~10.1.3"
+      },
+      "peerDependencies": {
+        "@angular/common": "^17.0.0",
+        "@angular/compiler": "^17.0.0",
+        "@angular/core": "^17.0.0",
+        "@angular/forms": "^17.0.0",
+        "@angular/platform-browser": "^17.0.0",
+        "@angular/platform-browser-dynamic": "^17.0.0",
+        "@angular/router": "^17.0.0",
+        "rxjs": "~7.8.0",
+        "zone.js": "~0.14.0"
+      }
+    },
     "libs/core": {
       "name": "@kirbydesign/core",
       "version": "0.0.61",
@@ -208,7 +242,7 @@
         "jest-environment-jsdom": "^29.4.1",
         "jest-preset-angular": "~13.1.4",
         "jsonc-eslint-parser": "^2.1.0",
-        "ng-packagr": "~17.0.0",
+        "ng-packagr": "^17.0.3",
         "postcss": "^8.4.5",
         "postcss-import": "~14.1.0",
         "postcss-preset-env": "~7.5.0",
@@ -6598,6 +6632,10 @@
       "version": "3.4.0",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@kirbydesign/angular": {
+      "resolved": "libs/angular",
+      "link": true
     },
     "node_modules/@kirbydesign/core": {
       "resolved": "libs/core",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "kirby",
+  "name": "designsystem",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "designsystem",
+  "name": "kirbydesign",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "kirbydesign",
       "hasInstallScript": true,
       "workspaces": [
         "libs/*",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "kirbydesign",
   "private": true,
   "engines": {
     "node": "20",


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issues.

## What is the new behavior?

Aligns `ng-packager` versions across libs to fix conflict when doing `npm i`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

