### PR TITLE
Page: Fix dynamic header title in toolbar

### DIFF
--- a/libs/designsystem/header/src/header.component.ts
+++ b/libs/designsystem/header/src/header.component.ts
@@ -9,11 +9,14 @@ import {
   HostBinding,
   Injector,
   Input,
+  OnChanges,
   OnInit,
   Output,
+  SimpleChanges,
   TemplateRef,
   ViewChild,
 } from '@angular/core';
+import { Subject } from 'rxjs';
 
 import { ACTIONGROUP_CONFIG, ActionGroupConfig } from '@kirbydesign/designsystem/action-group';
 import { AvatarComponent } from '@kirbydesign/designsystem/avatar';
@@ -47,7 +50,7 @@ export class HeaderCustomFlagDirective {}
   styleUrls: ['./header.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class HeaderComponent implements AfterContentInit, OnInit {
+export class HeaderComponent implements AfterContentInit, OnChanges, OnInit {
   @HostBinding('class.centered')
   @Input()
   centered?: boolean;
@@ -94,6 +97,8 @@ export class HeaderComponent implements AfterContentInit, OnInit {
   @Input() hasInteractiveTitle?: boolean;
 
   @Output() titleClick = new EventEmitter<PointerEvent>();
+
+  title$: Subject<string> = new Subject<string>();
 
   get _subtitles1() {
     return Array.isArray(this.subtitle1) ? this.subtitle1 : [this.subtitle1];
@@ -143,6 +148,12 @@ export class HeaderComponent implements AfterContentInit, OnInit {
 
     if (this.centered) {
       this.actionGroupConfig.isCondensed = true;
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.title) {
+      this.title$.next(changes.title.currentValue);
     }
   }
 }

--- a/libs/designsystem/page/src/page.component.ts
+++ b/libs/designsystem/page/src/page.component.ts
@@ -614,6 +614,9 @@ export class PageComponent
     this.hasPageSubtitle = this.subtitle !== undefined || !!this.customSubtitleTemplate;
     if (this.header?.title && !this.toolbarTitle) {
       this.toolbarTitle = this.header.title;
+      this.header.title$.pipe(takeUntil(this.ngOnDestroy$)).subscribe((title) => {
+        this.toolbarTitle = title;
+      });
     }
 
     this.observeTitle();


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3517 

## What is the new behavior?

Dynamic changes to the title of header get's reflected in the toolbar title of page.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

