### PR TITLE
Button: allow adding kirby-button directive to anchor tags

### DIFF
--- a/apps/cookbook/src/app/examples/button-example/button-example.component.html
+++ b/apps/cookbook/src/app/examples/button-example/button-example.component.html
@@ -197,6 +197,19 @@
   </label>
 </div>
 
+<h2>Link Button</h2>
+<p>
+  The kirby-button directive can also be applied to anchor-tags. This will allow use of attributes
+  such as
+  <code>href</code>
+  and
+  <code>target</code>
+  , but the link will look like a button.
+</p>
+
+<a kirby-button href="/">Link</a>
+<a kirby-button href="/" target="_blank">Link (new tab/window)</a>
+
 <h2>Button with attention level</h2>
 <kirby-card hasPadding="true" class="attention-levels" [themeColor]="themeColor">
   <button kirby-button [size]="buttonSize" attentionLevel="1" expand="block">

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -172,6 +172,7 @@ $button-margin: utils.size('xxxs');
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
+  text-decoration: none;
 
   // we default to 'md' size.
   font-size: utils.font-size('s');

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -172,7 +172,6 @@ $button-margin: utils.size('xxxs');
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
-  text-decoration: none;
 
   // we default to 'md' size.
   font-size: utils.font-size('s');
@@ -279,6 +278,10 @@ $button-margin: utils.size('xxxs');
       box-shadow: utils.get-elevation(8);
     }
   }
+}
+
+:host(a) {
+  text-decoration: none;
 }
 
 :host-context(.kirby-color-brightness-dark) {

--- a/libs/designsystem/button/src/button.component.ts
+++ b/libs/designsystem/button/src/button.component.ts
@@ -27,7 +27,7 @@ export type AttentionLevel = '1' | '2' | '3';
   standalone: true,
   imports: [CommonModule],
   // eslint-disable-next-line @angular-eslint/component-selector
-  selector: 'button[kirby-button],Button[kirby-button]',
+  selector: 'button[kirby-button],Button[kirby-button],a[kirby-button]',
   templateUrl: './button.component.html',
   styleUrls: ['./button.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3210

## What is the new behavior?
Anchor-tags can now be styled as buttons by adding the kirby-button directive to any `<a>` tag. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

