### PR TITLE
Docs: Replace custom dots in item flag examples with small badge

### DIFF
--- a/apps/cookbook/src/app/examples/item-example/examples/avatar/flagged-three-lines.ts
+++ b/apps/cookbook/src/app/examples/item-example/examples/avatar/flagged-three-lines.ts
@@ -19,9 +19,9 @@ const config = {
 </kirby-item>`,
   styles: [
     `div[slot="outside"] {
-      display: flex;
-      flex-direction: column;
-    }`,
+  display: flex;
+  flex-direction: column;
+}`,
   ],
 };
 
@@ -32,4 +32,5 @@ const config = {
 })
 export class ItemExampleAvatarFlaggedThreeLinesComponent {
   template: string = config.template;
+  styles: string = config.styles[0];
 }

--- a/apps/cookbook/src/app/examples/item-example/examples/avatar/flagged-three-lines.ts
+++ b/apps/cookbook/src/app/examples/item-example/examples/avatar/flagged-three-lines.ts
@@ -4,8 +4,8 @@ const config = {
   selector: 'cookbook-item-example-avatar-flagged-three-lines',
   template: `<kirby-item>
   <div slot="outside">
-    <div class="flag success"></div>
-    <div class="flag warning"></div>
+    <kirby-badge themeColor="success" size="sm"></kirby-badge>
+    <kirby-badge themeColor="warning" size="sm"></kirby-badge>
   </div>
   <kirby-avatar overlay="true" slot="start">
     <kirby-icon name="moneybag"></kirby-icon>
@@ -18,19 +18,9 @@ const config = {
   <data slot="end" class="kirby-text-bold" value="value">Value</data>
 </kirby-item>`,
   styles: [
-    `.flag {
-      width: 8px;
-      height: 8px;
-      border-radius:50%;
-    }`,
-    `.flag.success {
-      background: var(--kirby-success);
-    }`,
-    `.flag.warning {
-      background: var(--kirby-warning);
-    }`,
-    `.flag:not(:last-child) {
-      margin-bottom: 2px;
+    `div[slot="outside"] {
+      display: flex;
+      flex-direction: column;
     }`,
   ],
 };

--- a/apps/cookbook/src/app/examples/item-example/examples/avatar/flagged.ts
+++ b/apps/cookbook/src/app/examples/item-example/examples/avatar/flagged.ts
@@ -23,9 +23,9 @@ const config = {
 </kirby-item>`,
   styles: [
     `div[slot="outside"] {
-      display: flex;
-      flex-direction: column;
-    }`,
+  display: flex;
+  flex-direction: column;
+}`,
   ],
 };
 
@@ -36,4 +36,5 @@ const config = {
 })
 export class ItemExampleAvatarFlaggedComponent {
   template: string = config.template;
+  styles: string = config.styles[0];
 }

--- a/apps/cookbook/src/app/examples/item-example/examples/avatar/flagged.ts
+++ b/apps/cookbook/src/app/examples/item-example/examples/avatar/flagged.ts
@@ -4,8 +4,8 @@ const config = {
   selector: 'cookbook-item-example-avatar-flagged',
   template: `<kirby-item>
   <div slot="outside">
-    <div class="flag success"></div>
-    <div class="flag warning"></div>
+    <kirby-badge themeColor="success" size="sm"></kirby-badge>
+    <kirby-badge themeColor="warning" size="sm"></kirby-badge>
   </div>
   <kirby-avatar overlay="true" slot="start">
     <kirby-icon name="moneybag"></kirby-icon>
@@ -22,19 +22,9 @@ const config = {
   </kirby-flag>
 </kirby-item>`,
   styles: [
-    `.flag {
-      width: 8px;
-      height: 8px;
-      border-radius:50%;
-    }`,
-    `.flag.success {
-      background: var(--kirby-success);
-    }`,
-    `.flag.warning {
-      background: var(--kirby-warning);
-    }`,
-    `.flag:not(:last-child) {
-      margin-bottom: 2px;
+    `div[slot="outside"] {
+      display: flex;
+      flex-direction: column;
     }`,
   ],
 };

--- a/apps/cookbook/src/app/examples/item-example/examples/flagged.ts
+++ b/apps/cookbook/src/app/examples/item-example/examples/flagged.ts
@@ -4,8 +4,8 @@ const config = {
   selector: 'cookbook-item-example-flagged',
   template: `<kirby-item>
   <div slot="outside">
-    <div class="flag success"></div>
-    <div class="flag warning"></div>
+    <kirby-badge themeColor="success" size="sm"></kirby-badge>
+    <kirby-badge themeColor="warning" size="sm"></kirby-badge>
   </div>
   <kirby-label>
     <h3 class="kirby-text-bold">Title</h3>
@@ -16,19 +16,9 @@ const config = {
   </kirby-flag>
 </kirby-item>`,
   styles: [
-    `.flag {
-      width: 8px;
-      height: 8px;
-      border-radius:50%;
-    }`,
-    `.flag.success {
-      background: var(--kirby-success);
-    }`,
-    `.flag.warning {
-      background: var(--kirby-warning);
-    }`,
-    `.flag:not(:last-child) {
-      margin-bottom: 2px;
+    `div[slot="outside"] {
+      display: flex;
+      flex-direction: column;
     }`,
   ],
 };

--- a/apps/cookbook/src/app/examples/item-example/examples/flagged.ts
+++ b/apps/cookbook/src/app/examples/item-example/examples/flagged.ts
@@ -17,9 +17,9 @@ const config = {
 </kirby-item>`,
   styles: [
     `div[slot="outside"] {
-      display: flex;
-      flex-direction: column;
-    }`,
+  display: flex;
+  flex-direction: column;
+}`,
   ],
 };
 
@@ -30,4 +30,5 @@ const config = {
 })
 export class ItemExampleFlaggedComponent {
   template: string = config.template;
+  styles: string = config.styles[0];
 }

--- a/apps/cookbook/src/app/showcase/item-showcase/item-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/item-showcase/item-showcase.component.html
@@ -218,7 +218,7 @@
 </p>
 
 <h2 #flagged>Flagged</h2>
-<cookbook-example-viewer [html]="flaggedExample.template">
+<cookbook-example-viewer [html]="flaggedExample.template" [css]="flaggedExample.styles">
   <cookbook-item-example-flagged #flaggedExample></cookbook-item-example-flagged>
 </cookbook-example-viewer>
 
@@ -232,13 +232,16 @@
   <cookbook-item-example-avatar-date #avatarDateExample></cookbook-item-example-avatar-date>
 </cookbook-example-viewer>
 <h3>Avatar flagged</h3>
-<cookbook-example-viewer [html]="avatarFlaggedExample.template">
+<cookbook-example-viewer [html]="avatarFlaggedExample.template" [css]="avatarFlaggedExample.styles">
   <cookbook-item-example-avatar-flagged
     #avatarFlaggedExample
   ></cookbook-item-example-avatar-flagged>
 </cookbook-example-viewer>
 <h3>Avatar flagged, three lines</h3>
-<cookbook-example-viewer [html]="avatarFlaggedThreeLinesExample.template">
+<cookbook-example-viewer
+  [html]="avatarFlaggedThreeLinesExample.template"
+  [css]="avatarFlaggedThreeLinesExample.styles"
+>
   <cookbook-item-example-avatar-flagged-three-lines
     #avatarFlaggedThreeLinesExample
   ></cookbook-item-example-avatar-flagged-three-lines>


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?
There was a custom implementation of a small notification-dot that was introduced before the small badge was added. 
This is now replaced by the small badge instead, as it works out of the box as a replacement.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

