### PR TITLE
Docs: remove page progress from drawer examples

### DIFF
--- a/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.html
+++ b/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.html
@@ -1,4 +1,4 @@
-<kirby-page-progress *ngIf="showPageProgress">
+<kirby-page-progress *ngIf="showPageProgress && flavor === 'modal'">
   <kirby-progress-circle themeColor="warning" value="50" size="sm" class="kirby-text-xsmall">
     2/4
   </kirby-progress-circle>
@@ -13,6 +13,7 @@
   configAppearance="snap-to-viewport"
 >
   <cookbook-modal-example-configuration
+    [flavor]="flavor"
     [(showDummyContent)]="showDummyContent"
     [(showPageProgress)]="showPageProgress"
     [(showFooter)]="showFooter"

--- a/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/embedded-modal-example/embedded-modal-example.component.ts
@@ -4,6 +4,7 @@ import {
   ActionSheetConfig,
   AlertConfig,
   ModalController,
+  ModalFlavor,
   ModalSize,
 } from '@kirbydesign/designsystem';
 import { COMPONENT_PROPS, Modal, ModalConfig } from '@kirbydesign/designsystem';
@@ -19,6 +20,8 @@ import { ModalSizeOption } from '../modal-example-configuration/modal-example-si
 export class EmbeddedModalExampleComponent implements OnInit {
   title: string;
   subtitle: string;
+
+  flavor: ModalFlavor;
 
   exampleProperties: {
     stringProperty: string;
@@ -112,6 +115,7 @@ export class EmbeddedModalExampleComponent implements OnInit {
       componentProps: {
         title,
         subtitle: 'Hello from second embedded example component!',
+        flavor,
         delayLoadDummyContent: this.delayLoadDummyContent,
         loadAdditionalContent: this.loadAdditionalContent,
         showPageProgress: this.showNestedPageProgress,

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-advanced.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-advanced.component.ts
@@ -243,6 +243,7 @@ export class ModalExampleAdvancedComponent {
       componentProps: {
         title,
         subtitle: 'Hello from the first embedded example component!',
+        flavor,
         exampleProperties: {
           stringProperty: 'Value injected from parent component',
           numberProperty: 123,

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.html
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.html
@@ -8,11 +8,11 @@
 ></kirby-checkbox>
 
 <kirby-checkbox
-  *ngIf="showPageProgress !== undefined"
+  *ngIf="showPageProgress !== undefined && (flavor === undefined || flavor === 'modal')"
   [checked]="showPageProgress && !interactWithBackground"
   (checkedChange)="toggleShowPageProgress($event)"
   [disabled]="interactWithBackground || disabled"
-  text="Show page progress"
+  text="Show page progress (modal only)"
   size="xs"
 ></kirby-checkbox>
 

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-configuration.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, HostListener, Input, Output } from '@angular/core';
+import { ModalFlavor } from '@kirbydesign/designsystem/modal';
 
 import { WindowRef } from '@kirbydesign/designsystem/types';
 
@@ -9,6 +10,8 @@ import { WindowRef } from '@kirbydesign/designsystem/types';
 })
 export class ModalExampleConfigurationComponent {
   @Input() disabled: boolean;
+
+  @Input() flavor: ModalFlavor;
 
   @Input() showDummyKeyboard: boolean;
   @Output() showDummyKeyboardChange = new EventEmitter<boolean>();


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3539

## What is the new behavior?

Removes page progress in drawer examples to avoid confusion.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

