### PR TITLE
Item: move label in item to Ionic modern syntax

### DIFF
--- a/libs/designsystem/checkbox/src/checkbox.component.scss
+++ b/libs/designsystem/checkbox/src/checkbox.component.scss
@@ -146,6 +146,7 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
     // Overrides for kirby-checkbox inside kirby-item
     &.in-item:not(.legacy-checkbox) {
       &::part(label) {
+        align-items: center;
         padding-inline: 0;
       }
 

--- a/libs/designsystem/checkbox/src/checkbox.component.scss
+++ b/libs/designsystem/checkbox/src/checkbox.component.scss
@@ -180,6 +180,7 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
     }
 
     &[slot='start'] {
+      margin-block: 0; // Reset Ionic Item margin applided to slot=start
       margin-inline-end: $spacing-to-label;
     }
   }

--- a/libs/designsystem/item/src/item.component.stories.ts
+++ b/libs/designsystem/item/src/item.component.stories.ts
@@ -132,11 +132,12 @@ export const ItemWithRadioModernSyntax: Story = {
     <kirby-radio value="4">No slot</kirby-radio>
   </kirby-item>
   <kirby-item size="xs">
-    <kirby-radio value="5" slot="start"></kirby-radio>
-    <kirby-label>
-      <h3>Complex</h3>
-      <p detail>Label</p>
-    </kirby-label>
+    <kirby-radio value="5" slot="start">
+      <kirby-label>
+        <h3>Complex</h3>
+        <p detail>Label</p>
+      </kirby-label>
+    </kirby-radio>
   </kirby-item> 
 </kirby-radio-group>
 
@@ -155,11 +156,12 @@ export const ItemWithRadioModernSyntax: Story = {
     <kirby-radio value="4">No slot</kirby-radio>
   </kirby-item>
   <kirby-item size="sm">
-    <kirby-radio value="5" slot="start"></kirby-radio>
-    <kirby-label>
-      <h3>Complex</h3>
-      <p detail>Label</p>
-    </kirby-label>
+    <kirby-radio value="5" slot="start">
+      <kirby-label>
+        <h3>Complex</h3>
+        <p detail>Label</p>
+      </kirby-label>
+    </kirby-radio>
   </kirby-item> 
 </kirby-radio-group>
 
@@ -178,11 +180,12 @@ export const ItemWithRadioModernSyntax: Story = {
     <kirby-radio value="4">No slot</kirby-radio>
   </kirby-item>
   <kirby-item size="md">
-    <kirby-radio value="5" slot="start"></kirby-radio>
-    <kirby-label>
-      <h3>Complex</h3>
-      <p detail>Label</p>
-    </kirby-label>
+    <kirby-radio value="5" slot="start">
+      <kirby-label>
+        <h3>Complex</h3>
+        <p detail>Label</p>
+      </kirby-label>
+    </kirby-radio>
   </kirby-item> 
 </kirby-radio-group>`,
   }),
@@ -275,11 +278,12 @@ export const ItemWithCheckboxModernSyntax: Story = {
   <kirby-checkbox>No slot</kirby-checkbox>
 </kirby-item>
 <kirby-item size="xs">
-  <kirby-checkbox slot="start"></kirby-checkbox>
-  <kirby-label>
-    <h3>Complex</h3>
-    <p detail>Label</p>
-  </kirby-label>
+  <kirby-checkbox slot="start">
+    <kirby-label>
+      <h3>Complex</h3>
+      <p detail>Label</p>
+    </kirby-label>
+  </kirby-checkbox>
 </kirby-item>
 
 <h2>Small</h2>
@@ -296,11 +300,12 @@ export const ItemWithCheckboxModernSyntax: Story = {
   <kirby-checkbox>No slot</kirby-checkbox>
 </kirby-item>
 <kirby-item size="sm">
-  <kirby-checkbox slot="start"></kirby-checkbox>
-  <kirby-label>
-    <h3>Complex</h3>
-    <p detail>Label</p>
-  </kirby-label>
+  <kirby-checkbox slot="start">
+    <kirby-label>
+      <h3>Complex</h3>
+      <p detail>Label</p>
+    </kirby-label>
+  </kirby-checkbox>
 </kirby-item>
 
 <h2>Medium</h2>
@@ -317,11 +322,12 @@ export const ItemWithCheckboxModernSyntax: Story = {
   <kirby-checkbox>No slot</kirby-checkbox>
 </kirby-item>
 <kirby-item size="md">
-  <kirby-checkbox slot="start"></kirby-checkbox>
-  <kirby-label>
-    <h3>Complex</h3>
-    <p detail>Label</p>
-  </kirby-label>
+  <kirby-checkbox slot="start">
+    <kirby-label>
+      <h3>Complex</h3>
+      <p detail>Label</p>
+    </kirby-label>
+  </kirby-checkbox>
 </kirby-item>`,
   }),
 };

--- a/libs/designsystem/item/src/item.component.ts
+++ b/libs/designsystem/item/src/item.component.ts
@@ -1,4 +1,18 @@
-import { ChangeDetectionStrategy, Component, HostBinding, Input } from '@angular/core';
+import {
+  AfterContentInit,
+  ChangeDetectionStrategy,
+  Component,
+  ContentChild,
+  ElementRef,
+  HostBinding,
+  Input,
+  Renderer2,
+} from '@angular/core';
+
+import { CheckboxComponent } from '@kirbydesign/designsystem/checkbox';
+import { RadioComponent } from '@kirbydesign/designsystem/radio';
+
+import { LabelComponent } from './label/label.component';
 
 export enum ItemSize {
   XS = 'xs',
@@ -12,7 +26,9 @@ export enum ItemSize {
   styleUrls: ['./item.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ItemComponent {
+export class ItemComponent implements AfterContentInit {
+  constructor(private renderer: Renderer2) {}
+
   @HostBinding('class.disabled')
   @Input()
   disabled: boolean;
@@ -32,6 +48,14 @@ export class ItemComponent {
 
   @Input() rotateIcon: boolean = false;
 
+  // Only query for label as direct child of item:
+  @ContentChild(LabelComponent, { static: false, read: ElementRef, descendants: false })
+  private label: ElementRef<HTMLElement>;
+  @ContentChild(CheckboxComponent, { static: false, read: ElementRef })
+  private checkbox: ElementRef<HTMLElement>;
+  @ContentChild(RadioComponent, { static: false, read: ElementRef })
+  private radio: ElementRef<HTMLElement>;
+
   // Prevent default when inside kirby-dropdown to avoid blurring dropdown:
   onMouseDown(event: MouseEvent) {
     if (
@@ -40,5 +64,22 @@ export class ItemComponent {
     ) {
       event.preventDefault();
     }
+  }
+
+  ngAfterContentInit(): void {
+    if (this.label) {
+      if (this.checkbox) {
+        this.moveLabel(this.checkbox.nativeElement.querySelector('ion-checkbox'));
+      }
+      if (this.radio) {
+        this.moveLabel(this.radio.nativeElement.querySelector('ion-radio'));
+      }
+    }
+  }
+
+  private moveLabel(newParent: HTMLElement) {
+    const labelElement = this.label.nativeElement;
+    this.renderer.removeChild(labelElement.parentElement, labelElement);
+    this.renderer.appendChild(newParent, labelElement);
   }
 }

--- a/libs/designsystem/radio/src/radio.component.scss
+++ b/libs/designsystem/radio/src/radio.component.scss
@@ -155,6 +155,7 @@ ion-radio {
   }
 
   &[slot='start'] {
+    margin-block: 0; // Reset Ionic Item margin applided to slot=start
     margin-inline-end: $spacing-to-label;
   }
 }

--- a/libs/designsystem/radio/src/radio.component.scss
+++ b/libs/designsystem/radio/src/radio.component.scss
@@ -103,6 +103,7 @@ ion-radio {
   // Overrides for kirby-radio inside kirby-item
   &.in-item:not(.legacy-radio) {
     &::part(label) {
+      align-items: center;
       padding-inline: 0;
     }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3479 and closes #3482.

## What is the new behavior?

`Item` will check for legacy syntax when `Label` is used alongside either `Checkbox` or `Radio` and move the label inside `Checkbox` or `Radio` to comply with [Ionic modern syntax](https://ionicframework.com/docs/api/radio#using-the-modern-syntax).

**NOTE** Waiting for PRs for #3479 and #3482 to fix layout issues. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

