### PR TITLE
docs: add radio stories before Ionic upgrade

### DIFF
--- a/apps/cookbook/src/app/examples/radio-example/radio-example.component.html
+++ b/apps/cookbook/src/app/examples/radio-example/radio-example.component.html
@@ -4,6 +4,12 @@
 <h2>States</h2>
 <cookbook-radio-states-example></cookbook-radio-states-example>
 
+<h2>Sizes</h2>
+<cookbook-radio-sizes-example></cookbook-radio-sizes-example>
+
+<h2>Multiline Label</h2>
+<cookbook-radio-multiline-example></cookbook-radio-multiline-example>
+
 <h2>Custom radio template</h2>
 <cookbook-radio-custom-content-example></cookbook-radio-custom-content-example>
 

--- a/libs/designsystem/header/src/header.component.spec.ts
+++ b/libs/designsystem/header/src/header.component.spec.ts
@@ -416,6 +416,12 @@ describe('HeaderComponent', () => {
     it(`should have correct margins`, () => {
       const actionsWrapper: HTMLElement = spectator.query('.actions');
 
+      console.warn('--- HEADER ACTIONS TEST --- ');
+      console.warn('--- Window innerWidth:', window.innerWidth);
+      console.warn('--- Window outerWidth:', window.outerWidth);
+      console.warn('--- document clientWidth:', document.documentElement.clientWidth);
+      console.warn('--- HEADER ACTIONS TEST --- ');
+
       expect(actionsWrapper).toHaveComputedStyle({
         'margin-bottom': '0px',
         'margin-top': '0px',

--- a/libs/designsystem/header/src/header.component.spec.ts
+++ b/libs/designsystem/header/src/header.component.spec.ts
@@ -416,12 +416,6 @@ describe('HeaderComponent', () => {
     it(`should have correct margins`, () => {
       const actionsWrapper: HTMLElement = spectator.query('.actions');
 
-      console.warn('--- HEADER ACTIONS TEST --- ');
-      console.warn('--- Window innerWidth:', window.innerWidth);
-      console.warn('--- Window outerWidth:', window.outerWidth);
-      console.warn('--- document clientWidth:', document.documentElement.clientWidth);
-      console.warn('--- HEADER ACTIONS TEST --- ');
-
       expect(actionsWrapper).toHaveComputedStyle({
         'margin-bottom': '0px',
         'margin-top': '0px',

--- a/libs/designsystem/item/src/item.component.stories.ts
+++ b/libs/designsystem/item/src/item.component.stories.ts
@@ -37,40 +37,123 @@ export const Default: Story = {
   }),
 };
 
-export const ItemWithRadio: Story = {
+export const ItemWithRadioLegacySyntax: Story = {
+  name: 'Item With Radio - Legacy Syntax',
   render: () => ({
-    template: `<kirby-radio-group value="1">
-    <kirby-item size="xs">
-      <kirby-radio value="1" slot="start"></kirby-radio>
-      <kirby-label>Extra Small</kirby-label>
-    </kirby-item> 
-    <kirby-item size="xs">
-      <kirby-radio value="2" slot="start"></kirby-radio>
-      <kirby-label>Extra Small</kirby-label>
-    </kirby-item> 
-  </kirby-radio-group>
-  <br>
-  <kirby-radio-group value="1">
-    <kirby-item size="sm">
-      <kirby-radio value="1" slot="start"></kirby-radio>
-      <kirby-label>Small</kirby-label>
-    </kirby-item> 
-    <kirby-item size="sm">
-      <kirby-radio value="2" slot="start"></kirby-radio>
-      <kirby-label>Small</kirby-label>
-    </kirby-item> 
-  </kirby-radio-group>
-  <br>
-  <kirby-radio-group value="1">
-    <kirby-item size="md">
-      <kirby-radio value="1" slot="start"></kirby-radio>
-      <kirby-label>Medium</kirby-label>
-    </kirby-item> 
-    <kirby-item size="md">
-      <kirby-radio value="2" slot="start"></kirby-radio>
-      <kirby-label>Medium</kirby-label>
-    </kirby-item> 
-  </kirby-radio-group>`,
+    styles: [`h2 { margin-top: 32px; }`],
+    template: `<h2>Extra small</h2>
+<kirby-radio-group value="1">
+  <kirby-item size="xs">
+    <kirby-radio value="1" slot="start"></kirby-radio>
+    <kirby-label>Slot start, selected</kirby-label>
+  </kirby-item> 
+  <kirby-item size="xs">
+    <kirby-radio value="2" slot="start"></kirby-radio>
+    <kirby-label>Slot start</kirby-label>
+  </kirby-item> 
+  <kirby-item size="xs">
+    <kirby-radio value="3" slot="end"></kirby-radio>
+    <kirby-label>Slot end</kirby-label>
+  </kirby-item> 
+</kirby-radio-group>
+
+<h2>Small</h2>
+<kirby-radio-group value="1">
+  <kirby-item size="sm">
+    <kirby-radio value="1" slot="start"></kirby-radio>
+    <kirby-label>Slot start, selected</kirby-label>
+  </kirby-item> 
+  <kirby-item size="sm">
+    <kirby-radio value="2" slot="start"></kirby-radio>
+    <kirby-label>Slot start</kirby-label>
+  </kirby-item> 
+  <kirby-item size="sm">
+    <kirby-radio value="3" slot="end"></kirby-radio>
+    <kirby-label>Slot end</kirby-label>
+  </kirby-item> 
+</kirby-radio-group>
+
+<h2>Medium</h2>
+<kirby-radio-group value="1">
+  <kirby-item size="md">
+    <kirby-radio value="1" slot="start"></kirby-radio>
+    <kirby-label>Slot start, selected</kirby-label>
+  </kirby-item> 
+  <kirby-item size="md">
+    <kirby-radio value="2" slot="start"></kirby-radio>
+    <kirby-label>Slot start</kirby-label>
+  </kirby-item> 
+  <kirby-item size="md">
+    <kirby-radio value="3" slot="end"></kirby-radio>
+    <kirby-label>Slot end</kirby-label>
+  </kirby-item>  
+</kirby-radio-group>`,
+  }),
+};
+
+export const ItemWithRadioModernSyntax: Story = {
+  name: 'Item With Radio - Modern Syntax',
+  render: () => ({
+    styles: [`h2 { margin-top: 32px; }`],
+    template: `<h2>Extra small</h2>
+<kirby-radio-group value="1">
+  <kirby-item size="xs">
+    <kirby-radio value="1" slot="start"></kirby-radio>
+    <kirby-label>Slot start, selected</kirby-label>
+  </kirby-item>
+  <kirby-item size="xs">
+    <kirby-radio value="2" slot="start"></kirby-radio>
+    <kirby-label>Slot start</kirby-label>
+  </kirby-item>
+  <kirby-item size="xs">
+    <kirby-radio value="3" slot="end"></kirby-radio>
+    <kirby-label>Slot end</kirby-label>
+  </kirby-item>
+  <kirby-item size="xs">
+    <kirby-radio value="4" slot="start"></kirby-radio>
+    <kirby-label>No slot</kirby-label>
+  </kirby-item>
+</kirby-radio-group>
+
+<h2>Small</h2>
+<kirby-radio-group value="1">
+  <kirby-item size="sm">
+    <kirby-radio value="1" slot="start"></kirby-radio>
+    <kirby-label>Slot start, selected</kirby-label>
+  </kirby-item>
+  <kirby-item size="sm">
+    <kirby-radio value="2" slot="start"></kirby-radio>
+    <kirby-label>Slot start</kirby-label>
+  </kirby-item>
+  <kirby-item size="sm">
+    <kirby-radio value="3" slot="end"></kirby-radio>
+    <kirby-label>Slot end</kirby-label>
+  </kirby-item>
+  <kirby-item size="sm">
+    <kirby-radio value="4" slot="start"></kirby-radio>
+    <kirby-label>No slot</kirby-label>
+  </kirby-item>
+</kirby-radio-group>
+
+<h2>Medium</h2>
+<kirby-radio-group value="1">
+  <kirby-item size="md">
+    <kirby-radio value="1" slot="start"></kirby-radio>
+    <kirby-label>Slot start, selected</kirby-label>
+  </kirby-item>
+  <kirby-item size="md">
+    <kirby-radio value="2" slot="start"></kirby-radio>
+    <kirby-label>Slot start</kirby-label>
+  </kirby-item>
+  <kirby-item size="md">
+    <kirby-radio value="3" slot="end"></kirby-radio>
+    <kirby-label>Slot end</kirby-label>
+  </kirby-item>
+  <kirby-item size="md">
+    <kirby-radio value="4" slot="start"></kirby-radio>
+    <kirby-label>No slot</kirby-label>
+  </kirby-item>
+</kirby-radio-group>`,
   }),
 };
 


### PR DESCRIPTION
## Which issue does this PR close?

None, housekeeping.

## What is the new behavior?

Add additional `Radio` stories for visual regression tests before upgrading to new Ionic syntax.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

