### PR TITLE
docs: add checkbox stories before Ionic upgrade

### DIFF
--- a/apps/cookbook/src/app/examples/checkbox-example/checkbox-example.component.html
+++ b/apps/cookbook/src/app/examples/checkbox-example/checkbox-example.component.html
@@ -13,5 +13,8 @@
 <h2>Sizes</h2>
 <cookbook-checkbox-sizes-example></cookbook-checkbox-sizes-example>
 
+<h2>Multiline Label</h2>
+<cookbook-checkbox-multiline-example></cookbook-checkbox-multiline-example>
+
 <h2>Checked Change Event</h2>
 <cookbook-checkbox-events-example></cookbook-checkbox-events-example>

--- a/apps/cookbook/src/app/examples/checkbox-example/checkbox-example.module.ts
+++ b/apps/cookbook/src/app/examples/checkbox-example/checkbox-example.module.ts
@@ -2,7 +2,11 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
-import { KirbyModule } from '@kirbydesign/designsystem';
+import { CheckboxComponent } from '@kirbydesign/designsystem/checkbox';
+import { DividerComponent } from '@kirbydesign/designsystem/divider';
+import { ItemModule } from '@kirbydesign/designsystem/item';
+import { ListModule } from '@kirbydesign/designsystem/list';
+import { ToastController, ToastHelper } from '@kirbydesign/designsystem/toast';
 
 import { ReactiveFormStateExampleModule } from '../reactive-form-state/reactive-form.module';
 import { ExampleConfigurationWrapperComponent } from '../example-configuration-wrapper/example-configuration-wrapper.component';
@@ -14,8 +18,10 @@ import { CheckboxMultilineExampleComponent } from './examples/multiline';
 import { CheckboxSizesExampleComponent } from './examples/sizes';
 import { CheckboxStatesExampleComponent } from './examples/states';
 import { CheckboxReactiveFormsExampleComponent } from './examples/reactive-forms';
+import { CheckboxExampleComponent } from './checkbox-example.component';
 
 const COMPONENT_DECLARATIONS = [
+  CheckboxExampleComponent,
   CheckboxDefaultExampleComponent,
   CheckboxListExampleComponent,
   CheckboxConfirmExampleComponent,
@@ -29,12 +35,16 @@ const COMPONENT_DECLARATIONS = [
 @NgModule({
   imports: [
     CommonModule,
-    KirbyModule,
     FormsModule,
     ExampleConfigurationWrapperComponent,
     ReactiveFormsModule,
     ReactiveFormStateExampleModule,
+    CheckboxComponent,
+    ItemModule,
+    ListModule,
+    DividerComponent,
   ],
+  providers: [ToastController, ToastHelper],
   declarations: COMPONENT_DECLARATIONS,
   exports: COMPONENT_DECLARATIONS,
 })

--- a/apps/cookbook/src/app/examples/examples.common.ts
+++ b/apps/cookbook/src/app/examples/examples.common.ts
@@ -4,7 +4,6 @@ import { AlertExampleComponent } from './alert-example/alert-example.component';
 import { ButtonExampleComponent } from './button-example/button-example.component';
 import { CalendarCardExampleComponent } from './calendar-example/calendar-card-example.component';
 import { CalendarExampleComponent } from './calendar-example/calendar-example.component';
-import { CheckboxExampleComponent } from './checkbox-example/checkbox-example.component';
 import { DividerExampleComponent } from './divider-example/divider-example.component';
 import { EmptyStateExampleComponent } from './empty-state-example/empty-state-example.component';
 import { ExamplesComponent } from './examples.component';
@@ -70,7 +69,6 @@ export const COMPONENT_DECLARATIONS: any[] = [
   CalendarExampleComponent,
   CalendarCardExampleComponent,
   ActionSheetExampleComponent,
-  CheckboxExampleComponent,
   AlertExampleComponent,
   ToastExampleComponent,
   EmptyStateExampleComponent,

--- a/libs/designsystem/checkbox/src/checkbox.component.stories.ts
+++ b/libs/designsystem/checkbox/src/checkbox.component.stories.ts
@@ -1,10 +1,17 @@
-import { type Meta, type StoryObj } from '@storybook/angular';
+import { type Meta, moduleMetadata, type StoryObj } from '@storybook/angular';
 
 import { CheckboxComponent } from '@kirbydesign/designsystem/checkbox';
+
+import { CheckboxExampleModule } from '~/app/examples/checkbox-example/checkbox-example.module';
 
 const meta: Meta<CheckboxComponent> = {
   component: CheckboxComponent,
   title: 'Components / Checkbox',
+  decorators: [
+    moduleMetadata({
+      imports: [CheckboxExampleModule],
+    }),
+  ],
 };
 export default meta;
 type Story = StoryObj<CheckboxComponent>;
@@ -28,4 +35,10 @@ export const Checkbox: Story = {
       control: { type: 'radio' },
     },
   },
+};
+
+export const CookbookExample: Story = {
+  render: () => ({
+    template: `<cookbook-checkbox-example></cookbook-checkbox-example>`,
+  }),
 };

--- a/libs/designsystem/item/src/item.component.stories.ts
+++ b/libs/designsystem/item/src/item.component.stories.ts
@@ -2,13 +2,14 @@ import { argsToTemplate, type Meta, moduleMetadata, type StoryObj } from '@story
 import { ItemComponent, ItemModule, ItemSize } from '@kirbydesign/designsystem/item';
 
 import { RadioModule } from '@kirbydesign/designsystem/radio';
+import { CheckboxComponent } from '@kirbydesign/designsystem/checkbox';
 import { ItemExampleModule } from '~/app/examples/item-example/item-example.module';
 
 const meta: Meta<ItemComponent> = {
   component: ItemComponent,
   decorators: [
     moduleMetadata({
-      imports: [ItemModule, ItemExampleModule, RadioModule],
+      imports: [CheckboxComponent, ItemModule, ItemExampleModule, RadioModule],
     }),
   ],
   title: 'Components / Item',
@@ -142,6 +143,115 @@ export const ItemWithRadioModernSyntax: Story = {
     <kirby-radio value="4" slot="start">No slot</kirby-radio>
   </kirby-item>
 </kirby-radio-group>`,
+  }),
+};
+
+export const ItemWithCheckboxLegacySyntax: Story = {
+  name: 'Item With Checkbox - Legacy Syntax',
+  render: () => ({
+    styles: [`h2 { margin-top: 32px; }`],
+    template: `<h2>Extra small</h2>
+<kirby-item size="xs">
+  <kirby-checkbox [checked]="true" slot="start"></kirby-checkbox>
+  <kirby-label>Slot start, selected</kirby-label>
+</kirby-item> 
+<kirby-item size="xs">
+  <kirby-checkbox slot="start"></kirby-checkbox>
+  <kirby-label>Slot start</kirby-label>
+</kirby-item> 
+<kirby-item size="xs">
+  <kirby-checkbox slot="end"></kirby-checkbox>
+  <kirby-label>Slot end</kirby-label>
+</kirby-item> 
+
+<h2>Small</h2>
+<kirby-item size="sm">
+  <kirby-checkbox [checked]="true" slot="start"></kirby-checkbox>
+  <kirby-label>Slot start, selected</kirby-label>
+</kirby-item> 
+<kirby-item size="sm">
+  <kirby-checkbox slot="start"></kirby-checkbox>
+  <kirby-label>Slot start</kirby-label>
+</kirby-item> 
+<kirby-item size="sm">
+  <kirby-checkbox slot="end"></kirby-checkbox>
+  <kirby-label>Slot end</kirby-label>
+</kirby-item> 
+
+<h2>Medium</h2>
+<kirby-item size="md">
+  <kirby-checkbox [checked]="true" slot="start"></kirby-checkbox>
+  <kirby-label>Slot start, selected</kirby-label>
+</kirby-item> 
+<kirby-item size="md">
+  <kirby-checkbox slot="start"></kirby-checkbox>
+  <kirby-label>Slot start</kirby-label>
+</kirby-item> 
+<kirby-item size="md">
+  <kirby-checkbox slot="end"></kirby-checkbox>
+  <kirby-label>Slot end</kirby-label>
+</kirby-item>`,
+  }),
+};
+
+export const ItemWithCheckboxModernSyntax: Story = {
+  name: 'Item With Checkbox - Modern Syntax',
+  render: () => ({
+    styles: [`h2 { margin-top: 32px; }`],
+    template: `<h2>Extra small</h2>
+<kirby-item size="xs">
+  <kirby-checkbox [checked]="true" slot="start"></kirby-checkbox>
+  <kirby-label>Slot start, selected</kirby-label>
+</kirby-item> 
+<kirby-item size="xs">
+  <kirby-checkbox slot="start"></kirby-checkbox>
+  <kirby-label>Slot start</kirby-label>
+</kirby-item> 
+<kirby-item size="xs">
+  <kirby-checkbox slot="end"></kirby-checkbox>
+  <kirby-label>Slot end</kirby-label>
+</kirby-item> 
+<kirby-item size="xs">
+  <kirby-checkbox slot="start"></kirby-checkbox>
+  <kirby-label>No slot</kirby-label>
+</kirby-item> 
+
+<h2>Small</h2>
+<kirby-item size="sm">
+  <kirby-checkbox [checked]="true" slot="start"></kirby-checkbox>
+  <kirby-label>Slot start, selected</kirby-label>
+</kirby-item> 
+<kirby-item size="sm">
+  <kirby-checkbox slot="start"></kirby-checkbox>
+  <kirby-label>Slot start</kirby-label>
+</kirby-item> 
+<kirby-item size="sm">
+  <kirby-checkbox slot="end"></kirby-checkbox>
+  <kirby-label>Slot end</kirby-label>
+</kirby-item> 
+<kirby-item size="sm">
+  <kirby-checkbox slot="start"></kirby-checkbox>
+  <kirby-label>No slot</kirby-label>
+</kirby-item> 
+
+
+<h2>Medium</h2>
+<kirby-item size="md">
+  <kirby-checkbox [checked]="true" slot="start"></kirby-checkbox>
+  <kirby-label>Slot start, selected</kirby-label>
+</kirby-item> 
+<kirby-item size="md">
+  <kirby-checkbox slot="start"></kirby-checkbox>
+  <kirby-label>Slot start</kirby-label>
+</kirby-item> 
+<kirby-item size="md">
+  <kirby-checkbox slot="end"></kirby-checkbox>
+  <kirby-label>Slot end</kirby-label>
+</kirby-item>
+<kirby-item size="md">
+  <kirby-checkbox slot="start"></kirby-checkbox>
+  <kirby-label>No slot</kirby-label>
+</kirby-item>`,
   }),
 };
 

--- a/libs/designsystem/item/src/item.component.stories.ts
+++ b/libs/designsystem/item/src/item.component.stories.ts
@@ -140,7 +140,7 @@ export const ItemWithRadioModernSyntax: Story = {
   <kirby-radio value="3" slot="end">Slot end</kirby-radio>
   </kirby-item>
   <kirby-item size="md">
-    <kirby-radio value="4" slot="start">No slot</kirby-radio>
+    <kirby-radio value="4">No slot</kirby-radio>
   </kirby-item>
 </kirby-radio-group>`,
   }),


### PR DESCRIPTION
## Which issue does this PR close?

None, housekeeping.

## What is the new behavior?

Add additional `Checkbox` stories for visual regression tests before upgrading to new Ionic syntax.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

