### PR TITLE
Housekeeping: Refactor Toggle in Reorder List to comply with ion-toggle

### DIFF
--- a/apps/cookbook/src/app/examples/reorder-list-example/reorder-list-example.component.html
+++ b/apps/cookbook/src/app/examples/reorder-list-example/reorder-list-example.component.html
@@ -19,7 +19,11 @@
           <h3 [ngClass]="{ 'kirby-text-bold': !isSubItem }">{{ reorderItem.title }}</h3>
           <p *ngIf="!reorderItem.isOwnAccount" detail>{{ reorderItem.ownerName }}</p>
         </kirby-label>
-        <kirby-toggle slot="end" checked="true"></kirby-toggle>
+        <kirby-toggle
+          slot="end"
+          [checked]="true"
+          [attr.aria-label]="'hide or show account ' + reorderItem.title"
+        ></kirby-toggle>
       </kirby-item>
     </kirby-reorder-list>
   </kirby-page-content>

--- a/apps/cookbook/src/app/examples/reorder-list-example/reorder-list-example.component.ts
+++ b/apps/cookbook/src/app/examples/reorder-list-example/reorder-list-example.component.ts
@@ -60,7 +60,7 @@ export class ReorderListExampleComponent {
       ],
     },
   ];
-  headerTexts = ['skjul/vis', 'flyt'];
+  headerTexts = ['hide/show', 'move'];
 
   doReorderItem(ev: ReorderEvent) {
     ev.complete(this.items);

--- a/apps/cookbook/src/app/examples/toggle-example/examples/default.ts
+++ b/apps/cookbook/src/app/examples/toggle-example/examples/default.ts
@@ -9,7 +9,7 @@ const config = {
 
 @Component({
   selector: config.selector,
-  styleUrls: ['../toggle-example.component.scss'],
+  styleUrls: ['./toggle-examples.shared.scss'],
   template: config.template,
 })
 export class ToggleDefaultExampleComponent {

--- a/apps/cookbook/src/app/examples/toggle-example/examples/default.ts
+++ b/apps/cookbook/src/app/examples/toggle-example/examples/default.ts
@@ -2,9 +2,9 @@ import { Component } from '@angular/core';
 
 const config = {
   selector: 'cookbook-toggle-default-example',
-  template: `<kirby-toggle></kirby-toggle>
-<kirby-toggle checked="true" (checkedChange)="onCheckedChange($event)"></kirby-toggle>
-<kirby-toggle disabled="true"></kirby-toggle>`,
+  template: `<kirby-toggle>Default</kirby-toggle>
+<kirby-toggle checked="true" (checkedChange)="onCheckedChange($event)">Checked</kirby-toggle>
+<kirby-toggle disabled="true">Disabled</kirby-toggle>`,
 };
 
 @Component({

--- a/apps/cookbook/src/app/examples/toggle-example/examples/reactive-forms.ts
+++ b/apps/cookbook/src/app/examples/toggle-example/examples/reactive-forms.ts
@@ -38,21 +38,8 @@ toggleEnabled(checked: boolean) {
 
 @Component({
   selector: config.selector,
-  styleUrls: ['../toggle-example.component.scss'],
+  styleUrls: ['./toggle-examples.shared.scss'],
   template: config.template,
-  styles: [
-    `
-      :host {
-        display: flex;
-        align-items: center;
-        gap: 40px;
-      }
-
-      kirby-item h3 {
-        padding-inline-end: 40px;
-      }
-    `,
-  ],
 })
 export class ToggleReactiveFormsExampleComponent implements OnInit {
   template = config.template.split('<cookbook-example-configuration-wrapper>')[0];

--- a/apps/cookbook/src/app/examples/toggle-example/examples/reactive-forms.ts
+++ b/apps/cookbook/src/app/examples/toggle-example/examples/reactive-forms.ts
@@ -5,12 +5,11 @@ const config = {
   selector: 'cookbook-toggle-reactive-forms-example',
   template: `<form [formGroup]="form">
   <kirby-item>
-    <h3>Toggle in form</h3>
     <kirby-toggle
       slot="end"
       formControlName="myToggle"
       (checkedChange)="onCheckedChange()"
-    ></kirby-toggle>
+    >Toggle in form</kirby-toggle>
   </kirby-item>
       
 </form>

--- a/apps/cookbook/src/app/examples/toggle-example/examples/toggle-examples.shared.scss
+++ b/apps/cookbook/src/app/examples/toggle-example/examples/toggle-examples.shared.scss
@@ -1,9 +1,6 @@
-@use '../showcase.shared';
 @use '@kirbydesign/core/src/scss/utils';
 
-cookbook-toggle-default-example {
-  padding: 0;
-  margin-bottom: utils.size('s');
+:host {
   display: flex;
   flex-direction: column;
   gap: utils.size('s');
@@ -12,9 +9,4 @@ cookbook-toggle-default-example {
     flex-direction: row;
     gap: utils.size('xl');
   }
-}
-
-cookbook-reative-forms-example {
-  padding: 0;
-  margin-bottom: utils.size('s');
 }

--- a/apps/cookbook/src/app/examples/toggle-example/toggle-example.component.scss
+++ b/apps/cookbook/src/app/examples/toggle-example/toggle-example.component.scss
@@ -1,7 +1,1 @@
-@use '@kirbydesign/core/src/scss/utils';
-
-:host {
-  kirby-toggle {
-    margin-right: utils.size('s');
-  }
-}
+@use '../examples.shared';

--- a/apps/cookbook/src/app/showcase/reorder-list-showcase/reorder-list-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/reorder-list-showcase/reorder-list-showcase.component.html
@@ -11,7 +11,7 @@
   </p>
   <h2>Accessibility</h2>
   <p>
-    When using a toggle as in the example below, remember to set the
+    When using a toggle as in the example below, set the
     <code>aria-label</code>
     property to inform screen reader users what the toggle is controlling.
   </p>

--- a/apps/cookbook/src/app/showcase/reorder-list-showcase/reorder-list-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/reorder-list-showcase/reorder-list-showcase.component.html
@@ -9,6 +9,12 @@
       to function correctly.
     </em>
   </p>
+  <h2>Accessibility</h2>
+  <p>
+    When using a toggle as in the example below, remember to set the
+    <code>aria-label</code>
+    property to inform screen reader users what the toggle is controlling.
+  </p>
   <div class="example-wrapper">
     <cookbook-code-viewer [html]="exampleHtml"></cookbook-code-viewer>
     <cookbook-iphone src="/examples/reorder-list" showExternalLink="true"></cookbook-iphone>

--- a/apps/cookbook/src/app/showcase/toggle-showcase/toggle-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/toggle-showcase/toggle-showcase.component.html
@@ -1,4 +1,12 @@
 <div class="example">
+  <p>
+    Toggle is an input control for binary options, commonly used for managing choices and switches.
+  </p>
+
+  <kirby-divider [hasMargin]="true"></kirby-divider>
+
+  <h2>Examples</h2>
+
   <cookbook-toggle-default-example #toggleDefaultExample></cookbook-toggle-default-example>
   <cookbook-code-viewer [html]="toggleDefaultExample.template"></cookbook-code-viewer>
 
@@ -25,7 +33,20 @@
       #toggleReactiveFormsExample
     ></cookbook-toggle-reactive-forms-example>
   </cookbook-example-viewer>
-  <h4>Toggle properties:</h4>
+
+  <h2>Accessibility</h2>
+  <p>
+    Always provide a label for the toggle to inform screen reader users what the toggle is
+    controlling.
+  </p>
+  <p>
+    When using the toggle without a visible label remember to set the
+    <code>aria-label</code>
+    property instead.
+  </p>
+
+  <h2>API</h2>
+  <h3>Properties:</h3>
   <cookbook-api-description-properties
     [properties]="properties"
   ></cookbook-api-description-properties>

--- a/apps/cookbook/src/app/showcase/toggle-showcase/toggle-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/toggle-showcase/toggle-showcase.component.html
@@ -40,7 +40,7 @@
     controlling.
   </p>
   <p>
-    When using the toggle without a visible label remember to set the
+    When using the toggle without a visible label, set the
     <code>aria-label</code>
     property instead.
   </p>

--- a/libs/designsystem/toggle/src/toggle.component.html
+++ b/libs/designsystem/toggle/src/toggle.component.html
@@ -6,4 +6,7 @@
   (keyup.space)="_onInactive()"
   (blur)="_onInactive()"
   (ionChange)="onCheckedChange($event.detail.checked)"
-></ion-toggle>
+  [attr.aria-label]="_ariaLabel"
+>
+  <ng-content></ng-content>
+</ion-toggle>

--- a/libs/designsystem/toggle/src/toggle.component.ts
+++ b/libs/designsystem/toggle/src/toggle.component.ts
@@ -3,10 +3,12 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ElementRef,
   EventEmitter,
   forwardRef,
   HostBinding,
   Input,
+  OnInit,
   Output,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -27,8 +29,24 @@ import { IonToggle } from '@ionic/angular/standalone';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ToggleComponent implements ControlValueAccessor {
-  constructor(private cdr: ChangeDetectorRef) {}
+export class ToggleComponent implements ControlValueAccessor, OnInit {
+  constructor(private cdr: ChangeDetectorRef, private elementRef: ElementRef<HTMLElement>) {}
+
+  ngOnInit(): void {
+    this.inheritAriaAttributes();
+  }
+
+  _ariaLabel: string;
+
+  private inheritAriaAttributes() {
+    const el = this.elementRef.nativeElement;
+    const attribute = 'aria-label';
+    if (el.hasAttribute(attribute)) {
+      const value = el.getAttribute(attribute);
+      el.removeAttribute(attribute);
+      this._ariaLabel = value;
+    }
+  }
 
   @Input() checked: boolean = false;
   @Input() disabled: boolean = false;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3481

## What is the new behavior?

Adds `aria-label` to `Toggle` in `Reorder List` example.
Also improves a11y in toggle docs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

