### PR TITLE
Add option to use subtitle directive instead of subtitle string

### DIFF
--- a/apps/cookbook/src/app/examples/header-example/examples/subtitle-directive.ts
+++ b/apps/cookbook/src/app/examples/header-example/examples/subtitle-directive.ts
@@ -1,0 +1,32 @@
+import { Component } from '@angular/core';
+
+const config = {
+  selector: 'cookbook-header-example-subtitle-directive',
+  template: `<kirby-header [title]="'Title'" subtitle1="Subtitle one" subtitle2="Subtitle two">
+  <div *kirbyHeaderSubtitle>
+    <div>
+    subtitle one using directive
+    </div>
+    <div>
+    subtitle two <a href="#">using directive with link</a>
+    </div>
+  </div>
+</kirby-header>`,
+  styles: [
+    `.custom-flag {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}`,
+  ],
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+  styles: config.styles,
+})
+export class HeaderExampleSubtitleDirectiveComponent {
+  template: string = config.template;
+  styles: string = config.styles.join('\n\n');
+}

--- a/apps/cookbook/src/app/examples/header-example/header-example.module.ts
+++ b/apps/cookbook/src/app/examples/header-example/header-example.module.ts
@@ -26,6 +26,7 @@ import { HeaderExampleCombinedComponent } from './examples/combined';
 import { HeaderExampleCustomSectionComponent } from './examples/custom-section';
 import { HeaderExampleTitleScalingComponent } from './examples/title-scaling';
 import { HeaderExampleCustomFlagComponent } from './examples/custom-flag';
+import { HeaderExampleSubtitleDirectiveComponent } from '~/app/examples/header-example/examples/subtitle-directive';
 
 const COMPONENT_DECLARATIONS = [
   HeaderExampleComponent,
@@ -39,6 +40,7 @@ const COMPONENT_DECLARATIONS = [
   HeaderExampleCustomSectionComponent,
   HeaderExampleCustomFlagComponent,
   HeaderExampleTitleScalingComponent,
+  HeaderExampleSubtitleDirectiveComponent,
 ];
 
 @NgModule({

--- a/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
@@ -66,6 +66,23 @@
   </div>
 
   <div class="header-example-container">
+    <h2>SubtitleDirective</h2>
+    <p>
+      Custom markup can also be added to the subtitles section. This can be achieved by applying the
+      directive
+      <code>*kirbyHeaderSubtitle</code>
+      to your custom subtitle markup.
+    </p>
+    <cookbook-example-viewer [html]="customFlagExample.template" [css]="customFlagExample.styles">
+      <div class="header-example">
+        <cookbook-header-example-subtitle-directive
+          #customFlagExample
+        ></cookbook-header-example-subtitle-directive>
+      </div>
+    </cookbook-example-viewer>
+  </div>
+
+  <div class="header-example-container">
     <h2>Key value</h2>
     <p>
       In some cases a number is the primary information on a page. When that's the case you should

--- a/libs/designsystem/header/src/header.component.html
+++ b/libs/designsystem/header/src/header.component.html
@@ -31,12 +31,18 @@
     <h3 *ngIf="!!value" class="value kirby-text-display-3" [kirbyFitHeading]="fitHeadingConfig">{{ value }}<span class="value-unit semi-dark-text" *ngIf="!!valueUnit">{{ valueUnit }}</span></h3>
   
     <!-- Subtitles: -->
-    <ng-container
+    <ng-container *ngIf="!!subtitleTemplate;else subTitleAsProperty">
+        <div *ngTemplateOutlet="subtitleTemplate"></div>
+    </ng-container>
+    <ng-template #subTitleAsProperty>
+      <!-- Fallback to subtitle properties -->
+      <ng-container
         *ngTemplateOutlet="subTitleTemplate; context: { $implicit: _subtitles1 }"
       ></ng-container>
-    <ng-container
-      *ngTemplateOutlet="subTitleTemplate; context: { $implicit: _subtitles2 }"
-    ></ng-container>
+      <ng-container
+        *ngTemplateOutlet="subTitleTemplate; context: { $implicit: _subtitles2 }"
+      ></ng-container>
+    </ng-template>
 
     <!-- Custom section -->
     <div

--- a/libs/designsystem/header/src/header.component.ts
+++ b/libs/designsystem/header/src/header.component.ts
@@ -44,6 +44,11 @@ export class HeaderTitleActionIconDirective {}
 })
 export class HeaderCustomFlagDirective {}
 
+@Directive({
+  selector: '[kirbyHeaderSubtitle]',
+})
+export class HeaderSubtitleDirective {}
+
 @Component({
   selector: 'kirby-header',
   templateUrl: './header.component.html',
@@ -88,6 +93,11 @@ export class HeaderComponent implements AfterContentInit, OnChanges, OnInit {
 
   @ContentChild(HeaderTitleActionIconDirective, { read: TemplateRef })
   titleActionIconTemplate: TemplateRef<HeaderTitleActionIconDirective>;
+
+  @ContentChild(HeaderSubtitleDirective, {
+    read: TemplateRef<HeaderSubtitleDirective>,
+  })
+  subtitleTemplate?: TemplateRef<HeaderSubtitleDirective>;
 
   @Input() title?: string | null;
   @Input() value?: string | null;

--- a/libs/designsystem/header/src/header.module.ts
+++ b/libs/designsystem/header/src/header.module.ts
@@ -7,6 +7,7 @@ import {
   HeaderComponent,
   HeaderCustomFlagDirective,
   HeaderCustomSectionDirective,
+  HeaderSubtitleDirective,
   HeaderTitleActionIconDirective,
 } from './header.component';
 
@@ -16,6 +17,7 @@ const declarations = [
   HeaderCustomSectionDirective,
   HeaderTitleActionIconDirective,
   HeaderCustomFlagDirective,
+  HeaderSubtitleDirective,
 ];
 
 @NgModule({

--- a/libs/designsystem/header/src/public_api.ts
+++ b/libs/designsystem/header/src/public_api.ts
@@ -4,6 +4,7 @@ export {
   HeaderCustomFlagDirective,
   HeaderCustomSectionDirective,
   HeaderTitleActionIconDirective,
+  HeaderSubtitleDirective,
 } from './header.component';
 
 export { HeaderModule } from './header.module';


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes # (insert issue number here)
#3563 

## What is the new behavior?

You can now use HTML in subtitle as demonstrated in the cookbook example

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

