### PR TITLE
Page: remove deprecated `MaxWidth` options

### DIFF
--- a/libs/core/src/scss/base/_variables.scss
+++ b/libs/core/src/scss/base/_variables.scss
@@ -130,7 +130,6 @@ $page-content-max-widths: (
   full: 100%,
 );
 $page-content-max-width-default: map.get($page-content-max-widths, 'default');
-$page-content-max-width: $page-content-max-width-default;
 
 /* Modal
 ****************************************************************************/

--- a/libs/designsystem/page/src/page.component.scss
+++ b/libs/designsystem/page/src/page.component.scss
@@ -267,7 +267,6 @@ ion-content {
     --padding-top: 0;
   }
 
-  &.max-width-optimized, // TODO: Remove deprecated option 'optimized' in Kirby v10
   &.max-width-lg {
     --page-content-max-width: #{utils.get-page-content-max-width('lg')};
   }

--- a/libs/designsystem/page/src/page.component.spec.ts
+++ b/libs/designsystem/page/src/page.component.spec.ts
@@ -157,6 +157,14 @@ describe('PageComponent', () => {
       ionScrollElement = await ionContent.getScrollElement();
     });
 
+    it('should apply the correct content width', async () => {
+      await TestHelper.whenReady(ionContent);
+      const contentInner = ionContent.querySelector('.content-inner');
+      expect(contentInner).toHaveComputedStyle({
+        'max-width': DesignTokenHelper.pageContentMaxWidth('default'),
+      });
+    });
+
     describe('on phone', () => {
       beforeAll(async () => {
         await TestHelper.resizeTestWindow(TestHelper.screensize.phone);
@@ -808,17 +816,9 @@ describe('PageComponent', () => {
     });
 
     describe('with maxWidth is defined', () => {
-      it('should apply the correct content width', async () => {
-        await TestHelper.whenReady(ionContent);
-        const contentInner = ionContent.querySelector('.content-inner');
-        expect(contentInner).toHaveComputedStyle({
-          'max-width': DesignTokenHelper.pageContentMaxWidth('default'),
-        });
-      });
-
-      describe('and is set to standard', () => {
+      describe('and is set to default', () => {
         beforeEach(() => {
-          spectator.component.maxWidth = 'standard';
+          spectator.component.maxWidth = 'default';
           spectator.detectChanges();
         });
 
@@ -827,21 +827,6 @@ describe('PageComponent', () => {
           const contentInner = ionContent.querySelector('.content-inner');
           expect(contentInner).toHaveComputedStyle({
             'max-width': DesignTokenHelper.pageContentMaxWidth('default'),
-          });
-        });
-      });
-
-      describe('and is set to optimized', () => {
-        beforeEach(() => {
-          spectator.component.maxWidth = 'optimized';
-          spectator.detectChanges();
-        });
-
-        it('should apply correct content width', async () => {
-          await TestHelper.whenReady(ionContent);
-          const contentInner = ionContent.querySelector('.content-inner');
-          expect(contentInner).toHaveComputedStyle({
-            'max-width': DesignTokenHelper.pageContentMaxWidth('lg'),
           });
         });
       });

--- a/libs/designsystem/page/src/page.component.ts
+++ b/libs/designsystem/page/src/page.component.ts
@@ -70,13 +70,7 @@ const contentScrolledOffsetInPixels = 4;
 
 type stickyConfig = { sticky: boolean };
 type fixedConfig = { fixed: boolean };
-type MaxWidth = 'default' | 'standard' | 'optimized' | 'lg' | 'xl' | 'full'; // TODO: Remove deprecated options 'standard' and 'optimized' in Kirby v10
-
-const PAGE_WIDTH_STANDARD_DEPRECATION_WARNING =
-  'Deprecation warning: The support for "standard" as a maxWidth option will be removed in Kirby version 10. After that the "standard" width will be the default width and does not need to be specified.';
-
-const PAGE_WIDTH_OPTIMIZED_DEPRECATION_WARNING =
-  'Deprecation warning: The "optimized" maxWidth option is deprecated, please use "lg" instead. The support for "optimized" as a maxWidth option will be removed in Kirby version 10.';
+type MaxWidth = 'default' | 'lg' | 'xl' | 'full';
 
 export const PAGE_BACK_BUTTON_OVERRIDE = new InjectionToken<PageBackButtonOverride>(
   'page-back-button-override'
@@ -241,15 +235,6 @@ export class PageComponent
   @Input() hasInteractiveTitle: boolean;
 
   @Input() set maxWidth(width: MaxWidth) {
-    // TODO: Remove deprecation warning in Kirby v10
-    if (width === 'standard') {
-      console.warn(PAGE_WIDTH_STANDARD_DEPRECATION_WARNING);
-    }
-    // TODO: Remove deprecation warning in Kirby v10
-    if (width === 'optimized') {
-      console.warn(PAGE_WIDTH_OPTIMIZED_DEPRECATION_WARNING);
-    }
-
     this._maxWidth = width;
   }
 

--- a/libs/designsystem/testing-base/src/lib/components/mock.page.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.page.component.ts
@@ -167,7 +167,7 @@ export class MockPageComponent {
   @Input() defaultBackHref: string;
   @Input() hideBackButton: boolean;
   @Input() titleMaxLines: number;
-  @Input() maxWidth: 'default' | 'standard' | 'optimized' | 'full';
+  @Input() maxWidth: 'default' | 'lg' | 'xl' | 'full';
   @Input() tabBarBottomHidden: boolean;
   @Output() enter = new EventEmitter<void>();
   @Output() leave = new EventEmitter<void>();


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3204 and closes #3470

## What is the new behavior?

Deprecated `Page.MaxWidth` options have been removed.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

