### PR TITLE
Icon: remove deprecated `customName` property

### DIFF
--- a/apps/cookbook/src/app/examples/icon-example/examples/custom.ts
+++ b/apps/cookbook/src/app/examples/icon-example/examples/custom.ts
@@ -21,7 +21,7 @@ const config = {
 
 const customIcons = [
     { 
-        name: 'customIconName',
+        name: 'custom-icon-name',
         svg: '[PATH_TO_SVG_FILE]',
     },
     ...

--- a/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.ts
@@ -17,12 +17,6 @@ export class EmptyStateShowcaseComponent {
       type: ['string'],
     },
     {
-      name: 'customIconName',
-      description: 'Deprecated: Use iconName input property instead.',
-      defaultValue: 'null',
-      type: ['string'],
-    },
-    {
       name: 'title',
       description: 'The title.',
       defaultValue: 'null',

--- a/apps/cookbook/src/app/showcase/icon-showcase/icon-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/icon-showcase/icon-showcase.component.html
@@ -30,7 +30,7 @@
     . We recommend registering icons that are reused across an application in a top-level module. If
     icons are registered in modules that are not shared across the application consider namespacing
     them, e.g.
-    <code>my-feature-customIconName</code>
+    <code>my-feature-custom-icon-name</code>
     to avoid collisions.
   </p>
 

--- a/apps/cookbook/src/app/showcase/icon-showcase/icon-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/icon-showcase/icon-showcase.component.ts
@@ -48,11 +48,5 @@ export class IconShowcaseComponent {
         'dark',
       ],
     },
-    {
-      name: 'customName',
-      description: 'Deprecated: Use IconRegistryService and the name input property instead.',
-      defaultValue: 'null',
-      type: ['string'],
-    },
   ];
 }

--- a/libs/designsystem/empty-state/src/empty-state.component.html
+++ b/libs/designsystem/empty-state/src/empty-state.component.html
@@ -1,5 +1,5 @@
 <article>
-  <div *ngIf="iconName || customIconName" class="icon-outline">
+  <div *ngIf="iconName" class="icon-outline">
     <kirby-icon [name]="iconName" size="lg"></kirby-icon>
   </div>
   <h3 *ngIf="title" class="title">{{ title }}</h3>

--- a/libs/designsystem/empty-state/src/empty-state.component.stories.ts
+++ b/libs/designsystem/empty-state/src/empty-state.component.stories.ts
@@ -19,9 +19,4 @@ export const EmptyState: Story = {
     title: 'No items',
     subtitle: `You don't have any items. Call support to add some items to your account.`,
   },
-  argTypes: {
-    customIconName: {
-      control: 'text',
-    },
-  },
 };

--- a/libs/designsystem/empty-state/src/empty-state.component.ts
+++ b/libs/designsystem/empty-state/src/empty-state.component.ts
@@ -8,9 +8,6 @@ import {
 } from '@angular/core';
 import { ButtonComponent } from '@kirbydesign/designsystem/button';
 
-const CUSTOM_ICON_NAME_DEPRECATION_WARNING =
-  'Deprecation warning: The customIconName input property of "kirby-empty-state" is deprecated and will be removed in v10. The iconName input property already supports custom icons registered via the iconRegistryService.';
-
 @Component({
   selector: 'kirby-empty-state',
   templateUrl: './empty-state.component.html',
@@ -19,10 +16,6 @@ const CUSTOM_ICON_NAME_DEPRECATION_WARNING =
 })
 export class EmptyStateComponent implements AfterContentInit {
   @Input() iconName: string;
-  @Input() set customIconName(customName: string) {
-    this.iconName = customName;
-    console.warn(CUSTOM_ICON_NAME_DEPRECATION_WARNING);
-  }
   @Input() title: string;
   @Input() subtitle: string;
 

--- a/libs/designsystem/icon/src/icon.component.spec.ts
+++ b/libs/designsystem/icon/src/icon.component.spec.ts
@@ -71,36 +71,9 @@ describe('IconComponent', () => {
       fixture.detectChanges();
 
       expect(console.warn).toHaveBeenCalledWith(
-        `Built-in icon with name "${noExistingIconName}" was not found. 
-        Do you have a typo in 'name' or
-        did you mean to use a custom icon? If so, please use: 
-        <kirby-icon customName="${noExistingIconName}"></kirby-icon>`
-      );
-    });
-
-    it('should set default icon if custom icon name not found', () => {
-      const noExistingIconName = 'no-existing-custom-icon-name';
-      const fixture = createTestComponent(
-        `<kirby-icon customName="${noExistingIconName}"></kirby-icon>`
-      );
-      const component = fixture.debugElement.query(By.directive(IconComponent)).componentInstance;
-
-      expect(component.customName).toBe(noExistingIconName);
-      expect(component.icon.name).toBe(component.defaultIcon.name);
-    });
-
-    it('should warn if custom icon name not found', () => {
-      spyOn(console, 'warn');
-      const noExistingIconName = 'no-existing-custom-icon-name';
-      const fixture = createTestComponent(
-        `<kirby-icon customName="${noExistingIconName}"></kirby-icon>`
-      );
-      fixture.detectChanges();
-
-      expect(console.warn).toHaveBeenCalledWith(
-        `Custom icon with name "${noExistingIconName}" was not found. 
-        Do you have a typo in 'customName' or
-        forgot to configure the custom icon through the 'IconRegistryService'?`
+        `Icon with name "${noExistingIconName}" was not found. 
+Do you have a typo in 'name' for a built-in icon or
+forgot to configure the custom icon through the 'IconRegistryService'?`
       );
     });
 
@@ -110,24 +83,6 @@ describe('IconComponent', () => {
       const component = fixture.debugElement.query(By.directive(IconComponent)).componentInstance;
 
       expect(component.icon.name).toBe('verify');
-    });
-
-    it('should use custom icon from IconRegistryService', () => {
-      const fixture = createTestComponent(
-        `<kirby-icon customName="customIconNameFromIconRegistry"></kirby-icon>`
-      );
-
-      const iconRegistryService = TestBed.get(IconRegistryService);
-      iconRegistryService.addIcon(
-        'customIconNameFromIconRegistry',
-        'customIconSvgFromIconRegistry'
-      );
-
-      fixture.detectChanges();
-      const component = fixture.debugElement.query(By.directive(IconComponent)).componentInstance;
-
-      expect(component.icon.name).toBe('customIconNameFromIconRegistry');
-      expect(component.icon.svg).toBe('customIconSvgFromIconRegistry');
     });
   });
 

--- a/libs/designsystem/icon/src/icon.component.stories.ts
+++ b/libs/designsystem/icon/src/icon.component.stories.ts
@@ -4,11 +4,6 @@ import { IconComponent } from '@kirbydesign/designsystem/icon';
 const meta: Meta<IconComponent> = {
   component: IconComponent,
   title: 'Components / Icon',
-  argTypes: {
-    customName: {
-      control: 'text',
-    },
-  },
 };
 export default meta;
 type Story = StoryObj<IconComponent>;

--- a/libs/designsystem/icon/src/icon.component.ts
+++ b/libs/designsystem/icon/src/icon.component.ts
@@ -17,9 +17,6 @@ export enum IconSize {
   LG = 'lg',
 }
 
-const CUSTOM_NAME_DEPRECATION_WARNING =
-  'Deprecation warning: The customName input property for "kirby-icon" is deprecated and will be removed in v10. The name input property already supports icons registered via the iconRegistryService, and should be used instead of customName.';
-
 @Component({
   selector: 'kirby-icon',
   templateUrl: './icon.component.html',
@@ -31,27 +28,19 @@ const CUSTOM_NAME_DEPRECATION_WARNING =
 export class IconComponent implements OnChanges {
   defaultIcon: Icon = this.iconRegistryService.getIcon('cog');
   private _icon = (this.icon = this.defaultIcon);
-  private _customName;
   @HostBinding('class')
   @Input()
   size: IconSize | `${IconSize}`;
 
   @Input() name: string;
 
-  @Input() set customName(customName: string) {
-    console.warn(CUSTOM_NAME_DEPRECATION_WARNING);
-    this._customName = customName;
-  }
-  get customName(): string {
-    return this._customName;
-  }
   get icon(): Icon {
     return this._icon;
   }
 
   set icon(icon: Icon) {
     // If icon are not found, set default icon
-    if (!icon && (this.name || this.customName)) {
+    if (!icon && this.name) {
       this.warnAboutMissingIcon();
 
       icon = this.defaultIcon;
@@ -70,16 +59,9 @@ export class IconComponent implements OnChanges {
   }
 
   private warnAboutMissingIcon(): void {
-    if (this.customName) {
-      console.warn(`Custom icon with name "${this.customName}" was not found. 
-        Do you have a typo in 'customName' or
-        forgot to configure the custom icon through the 'IconRegistryService'?`);
-    } else {
-      console.warn(`Built-in icon with name "${this.name}" was not found. 
-        Do you have a typo in 'name' or
-        did you mean to use a custom icon? If so, please use: 
-        <kirby-icon customName="${this.name}"></kirby-icon>`);
-    }
+    console.warn(`Icon with name "${this.name}" was not found. 
+Do you have a typo in 'name' for a built-in icon or
+forgot to configure the custom icon through the 'IconRegistryService'?`);
   }
 
   constructor(private iconRegistryService: IconRegistryService) {}
@@ -87,8 +69,6 @@ export class IconComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.name && changes.name.currentValue) {
       this.icon = this.iconRegistryService.getIcon(changes.name.currentValue);
-    } else if (changes.customName && changes.customName.currentValue) {
-      this.icon = this.iconRegistryService.getIcon(changes.customName.currentValue);
     }
   }
 }

--- a/libs/designsystem/src/lib/components/page-local-navigation/page-local-navigation.component.html
+++ b/libs/designsystem/src/lib/components/page-local-navigation/page-local-navigation.component.html
@@ -19,13 +19,7 @@
             [themeColor]="badge.themeColor"
           >
             <ng-container *ngIf="badge.content.name; else badgeTextContent">
-              <kirby-icon
-                *ngIf="badge.content.isCustom; else defaultIconName"
-                [customName]="badge.content.name"
-              ></kirby-icon>
-              <ng-template #defaultIconName>
-                <kirby-icon [name]="badge.content.name"></kirby-icon>
-              </ng-template>
+              <kirby-icon [name]="badge.content.name"></kirby-icon>
             </ng-container>
             <ng-template #badgeTextContent>
               {{ badge.content.text }}

--- a/libs/designsystem/testing-base/src/lib/components/mock.empty-state.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.empty-state.component.ts
@@ -17,7 +17,6 @@ import { EmptyStateComponent } from '@kirbydesign/designsystem/empty-state';
 })
 export class MockEmptyStateComponent {
   @Input() iconName: string;
-  @Input() customIconName: string;
   @Input() title: string;
   @Input() subtitle: string;
 }

--- a/libs/designsystem/testing-base/src/lib/components/mock.icon.component.ts
+++ b/libs/designsystem/testing-base/src/lib/components/mock.icon.component.ts
@@ -18,7 +18,6 @@ import { IconComponent, IconSize } from '@kirbydesign/designsystem';
 export class MockIconComponent {
   @Input() size: IconSize | `${IconSize}`;
   @Input() name: string;
-  @Input() customName: string;
 }
 
 // #endregion


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3472

## What is the new behavior?

Removes deprecated `customName` property from `Icon` and corresponding `customIconName` property from `EmptyState`.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

