### PR TITLE
Modal: remove deprecated alert config

### DIFF
--- a/libs/designsystem/modal/src/modal-navigation.service.ts
+++ b/libs/designsystem/modal/src/modal-navigation.service.ts
@@ -12,12 +12,11 @@ import { EMPTY, firstValueFrom, Observable } from 'rxjs';
 import { filter, map, pairwise, skipUntil, startWith, takeUntil } from 'rxjs/operators';
 
 import { Location } from '@angular/common';
-import { ModalRouteActivation, NavigationData } from './modal.interfaces';
-import { AlertConfig } from './public_api';
+import { ModalRouteActivation } from './modal.interfaces';
 
 @Injectable({ providedIn: 'root' })
 export class ModalNavigationService {
-  constructor(private router: Router, private route: ActivatedRoute, private location: Location) {}
+  constructor(private router: Router, private route: ActivatedRoute) {}
 
   isModalRoute(url: string): boolean {
     return url.includes('(modal:');
@@ -225,10 +224,8 @@ export class ModalNavigationService {
         this.modalRouteSetContainsPath(modalRouteSet, navigationEnd, modalRoutesContainsUrlParams)
       ),
       map((navigationEnd) => {
-        const locationState = this.location.getState() as NavigationData;
         return {
           route: this.getCurrentActivatedRoute(),
-          modalData: locationState.navigationData,
           isNewModal: this.isNewModalWindow(navigationEnd),
         };
       })
@@ -309,18 +306,12 @@ export class ModalNavigationService {
     return { activated$: EMPTY, deactivated$: EMPTY };
   }
 
-  async navigateToModal(
-    path: string | string[],
-    queryParams?: Params,
-    alertConfig?: AlertConfig
-  ): Promise<boolean> {
+  async navigateToModal(path: string | string[], queryParams?: Params): Promise<boolean> {
     const commands = Array.isArray(path) ? [...path] : path.split('/');
     const childPath = commands.pop();
-    const navigationData: NavigationData = { navigationData: { alertConfig } };
     const result = await this.router.navigate([...commands, { outlets: { modal: [childPath] } }], {
       queryParams,
       relativeTo: this.getCurrentActivatedRoute(),
-      state: navigationData,
     });
     return result;
   }

--- a/libs/designsystem/modal/src/modal.interfaces.ts
+++ b/libs/designsystem/modal/src/modal.interfaces.ts
@@ -2,7 +2,7 @@ import { AfterViewInit, Component, ElementRef, OnDestroy, Optional } from '@angu
 import { ActivatedRoute } from '@angular/router';
 
 import { KirbyAnimation } from '@kirbydesign/designsystem/helpers';
-import { AlertConfig, ShowAlertCallback } from './public_api';
+import { ShowAlertCallback } from './public_api';
 export interface OverlayEventDetail<T = any> {
   data?: T;
   role?: string;
@@ -15,17 +15,8 @@ export interface Overlay {
   isDismissing?: boolean;
 }
 
-export interface ModalData {
-  alertConfig: AlertConfig;
-}
-
-export interface NavigationData {
-  navigationData: ModalData;
-}
-
 export interface ModalRouteActivation {
   route: ActivatedRoute;
-  modalData: ModalData;
   isNewModal: boolean;
 }
 

--- a/libs/designsystem/modal/src/modal/services/modal.controller.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.controller.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, Params, Routes, ROUTES } from '@angular/router';
 import { Observable, Subject } from 'rxjs';
 import { filter, map, takeUntil } from 'rxjs/operators';
 
-import { ModalData, ModalRouteActivation, Overlay } from '../../modal.interfaces';
+import { ModalRouteActivation, Overlay } from '../../modal.interfaces';
 import { ActionSheetConfig } from '../action-sheet/config/action-sheet-config';
 import { AlertConfig } from '../alert/config/alert-config';
 
@@ -56,7 +56,6 @@ export class ModalController implements OnDestroy {
           await this.showModalRoute(
             modalRouteActivation.route,
             siblingModalRouteActivated$,
-            modalRouteActivation.modalData,
             navigateOnWillClose
           );
         }
@@ -74,23 +73,12 @@ export class ModalController implements OnDestroy {
       });
   }
 
-  public async showModal(
-    config: ModalConfig,
-    onClose?: (data?: any) => void,
-    alertConfig?: AlertConfig
-  ): Promise<void> {
-    await this.showAndRegisterOverlay(
-      () => this.modalHelper.showModalWindow(config, alertConfig),
-      onClose
-    );
+  public async showModal(config: ModalConfig, onClose?: (data?: any) => void): Promise<void> {
+    await this.showAndRegisterOverlay(() => this.modalHelper.showModalWindow(config), onClose);
   }
 
-  public async navigateToModal(
-    path: string | string[],
-    queryParams?: Params,
-    alertConfig?: AlertConfig
-  ): Promise<boolean> {
-    return this.modalNavigationService.navigateToModal(path, queryParams, alertConfig);
+  public async navigateToModal(path: string | string[], queryParams?: Params): Promise<boolean> {
+    return this.modalNavigationService.navigateToModal(path, queryParams);
   }
 
   public async navigateWithinModal(relativePath: string, queryParams?: Params): Promise<boolean> {
@@ -100,7 +88,6 @@ export class ModalController implements OnDestroy {
   private async showModalRoute(
     modalRoute: ActivatedRoute,
     siblingModalRouteActivated$: Observable<ActivatedRoute>,
-    modalData: ModalData,
     onWillClose: (data?: any) => void
   ): Promise<void> {
     const config: ModalConfig = {
@@ -110,7 +97,7 @@ export class ModalController implements OnDestroy {
       siblingModalRouteActivated$: siblingModalRouteActivated$,
     };
     await this.showAndRegisterOverlay(
-      () => this.modalHelper.showModalWindow(config, modalData?.alertConfig),
+      () => this.modalHelper.showModalWindow(config),
       null,
       onWillClose
     );

--- a/libs/designsystem/modal/src/modal/services/modal.helper.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.helper.ts
@@ -10,7 +10,6 @@ import {
   ModalSize,
   ModalWrapperComponent,
 } from '../../modal-wrapper';
-import { AlertConfig } from '../alert/config/alert-config';
 
 import { ModalAnimationBuilderService } from './modal-animation-builder.service';
 import { CanDismissHelper } from './can-dismiss.helper';
@@ -33,7 +32,7 @@ export class ModalHelper {
   */
   private isModalOpening = false;
 
-  public async showModalWindow(config: ModalConfig, alertConfig?: AlertConfig): Promise<Overlay> {
+  public async showModalWindow(config: ModalConfig): Promise<Overlay> {
     if (this.isModalOpening) return;
 
     config.flavor = config.flavor || 'modal';
@@ -66,25 +65,6 @@ export class ModalHelper {
 
     if (config.canDismiss) {
       canDismiss = this.canDismissHelper.getCanDismissCallback(config.canDismiss);
-    }
-
-    // This functionality is kept to prevent breaking changes, but should be depracated in the next major.
-    // It will be replaced by the new 'config.canDismiss' callback
-    if (alertConfig) {
-      console.warn(
-        "This way of passing an alertConfig to the modal will be deprecated in the next major version. We recommend using the 'config.canDismiss' callback instead."
-      );
-
-      // Remembers the modal dismissal response from user to prevent multiple alerts on
-      // approval since the callback is invoked more than once when closing.
-      let canBeDismissed = false;
-      canDismiss = async () => {
-        if (!canBeDismissed) {
-          canBeDismissed = await this.canDismissHelper.showAlert(alertConfig);
-        }
-
-        return canBeDismissed;
-      };
     }
 
     this.isModalOpening = true;

--- a/libs/designsystem/src/lib/directives/modal-router-link/modal-router-link.directive.ts
+++ b/libs/designsystem/src/lib/directives/modal-router-link/modal-router-link.directive.ts
@@ -1,6 +1,6 @@
 import { Directive, ElementRef, HostListener, Input, OnInit } from '@angular/core';
 import { Params } from '@angular/router';
-import { AlertConfig, ModalNavigationService } from '@kirbydesign/designsystem/modal';
+import { ModalNavigationService } from '@kirbydesign/designsystem/modal';
 
 @Directive({
   selector: `[kirbyModalRouterLink]`,
@@ -18,15 +18,12 @@ export class ModalRouterLinkDirective implements OnInit {
   @Input('kirbyModalRouterLink') path: string | string[];
   // eslint-disable-next-line @angular-eslint/no-input-rename
   @Input('kirbyModalQueryParams') queryParams?: Params;
-  // eslint-disable-next-line @angular-eslint/no-input-rename
-  @Input('kirbyAlertConfig') alertConfig?: AlertConfig;
 
   @HostListener('click')
   onClick(): boolean {
     this.modalNavigationService.navigateToModal(
       this.path,
-      typeof this.queryParams !== 'string' ? this.queryParams : null,
-      this.alertConfig || null
+      typeof this.queryParams !== 'string' ? this.queryParams : null
     );
     return false;
   }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3120

## What is the new behavior?

Removes the deprecated way of passing and alert config to modal that has been replaced på `canDismiss`.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

