### PR TITLE
Card: remove deprecated flat property

### DIFF
--- a/apps/cookbook/src/app/showcase/badge-showcase/badge-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/badge-showcase/badge-showcase.component.html
@@ -10,7 +10,7 @@
 <h3>Badge with numbers</h3>
 <p>Using a badge with a number can be a good way to indicate specific status on an element.</p>
 <p>
-  <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+  <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
     <cookbook-badge-example-number #badgeExampleNumber></cookbook-badge-example-number>
     <cookbook-example-viewer [html]="badgeExampleNumber.template"></cookbook-example-viewer>
   </kirby-card>
@@ -21,7 +21,7 @@
   Badges can also be used together with a text. Flags might in some cases be a better alternative.
 </p>
 <p>
-  <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+  <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
     <cookbook-badge-example-text #badgeExampleText></cookbook-badge-example-text>
     <cookbook-example-viewer [html]="badgeExampleText.template"></cookbook-example-viewer>
   </kirby-card>
@@ -33,7 +33,7 @@
   existence of an associated element (e.g. an attachment).
 </p>
 <p>
-  <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+  <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
     <cookbook-badge-example-icon #badgeExampleIcon></cookbook-badge-example-icon>
     <br />
     <cookbook-example-viewer [html]="badgeExampleIcon.template"></cookbook-example-viewer>
@@ -50,7 +50,7 @@
   element.
 </p>
 <p>
-  <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+  <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
     <cookbook-badge-example-small #badgeExampleSmall></cookbook-badge-example-small>
     <cookbook-example-viewer [html]="badgeExampleSmall.template"></cookbook-example-viewer>
   </kirby-card>

--- a/apps/cookbook/src/app/showcase/chart-showcase/chart-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/chart-showcase/chart-showcase.component.html
@@ -27,7 +27,7 @@
   options.
 </p>
 <p>
-  <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+  <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
     <cookbook-example-viewer [html]="simpleColumnExample.template">
       <cookbook-chart-example-simple-column
         #simpleColumnExample
@@ -57,7 +57,7 @@
   .
 </p>
 <p>
-  <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+  <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
     <cookbook-example-viewer [html]="columnExample.template" [ts]="columnExample.codeSnippet">
       <cookbook-chart-example-column #columnExample></cookbook-chart-example-column>
     </cookbook-example-viewer>
@@ -74,7 +74,7 @@
   .
 </p>
 <p>
-  <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+  <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
     <cookbook-example-viewer [html]="barExample.template">
       <cookbook-chart-example-bar #barExample></cookbook-chart-example-bar>
     </cookbook-example-viewer>
@@ -91,7 +91,7 @@
   .
 </p>
 <p>
-  <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+  <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
     <cookbook-example-viewer [html]="lineExample.template">
       <cookbook-chart-example-line #lineExample></cookbook-chart-example-line>
     </cookbook-example-viewer>
@@ -145,7 +145,7 @@
   .
 </p>
 <p>
-  <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+  <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
     <cookbook-example-viewer
       [html]="interactionExample.template"
       [ts]="interactionExample.codeSnippet"
@@ -158,7 +158,7 @@
 <h3 id="stacked-bar-and-column-charts">Stacked Bar & column charts</h3>
 <p>Stacked charts can be created using a combination of custom options and datasets.</p>
 <p>
-  <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+  <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
     <cookbook-example-viewer [html]="stackedExample.template" [ts]="stackedExample.codeSnippet">
       <cookbook-chart-example-column-stacked
         #stackedExample
@@ -198,7 +198,7 @@
   used to draw a line:
 </p>
 <p>
-  <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+  <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
     <cookbook-example-viewer
       [html]="multipleDatasetsExample.template"
       [ts]="multipleDatasetsExample.codeSnippet"
@@ -272,7 +272,7 @@
 </p>
 
 <p>
-  <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+  <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
     <cookbook-example-viewer
       [html]="annotationsExample.template"
       [ts]="annotationsExample.codeSnippet"
@@ -296,7 +296,7 @@
   <a href="https://www.chartjs.org/docs/latest/samples/area/line-datasets.html">Area charts</a>
 </p>
 <p>
-  <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+  <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
     <cookbook-example-viewer [html]="lineAreaExample.template" [ts]="lineAreaExample.codeSnippet">
       <cookbook-chart-example-area-line #lineAreaExample></cookbook-chart-example-area-line>
     </cookbook-example-viewer>
@@ -368,7 +368,7 @@ to
 </p>
 
 <p>
-  <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+  <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
     <cookbook-example-viewer
       [html]="accessibilityExample.template"
       [ts]="accessibilityExample.codeSnippet"

--- a/apps/cookbook/src/app/showcase/item-sliding-showcase/item-sliding-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/item-sliding-showcase/item-sliding-showcase.component.html
@@ -33,7 +33,7 @@
       to display an icon.
     </p>
 
-    <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+    <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
       <cookbook-example-viewer [html]="simpleExample.template" [ts]="simpleExample.codeSnippet">
         <cookbook-item-sliding-simple-example #simpleExample></cookbook-item-sliding-simple-example>
       </cookbook-example-viewer>
@@ -46,7 +46,7 @@
       'delete' swipe action is conditionally disabled on a per item basis, based on whether it is
       deleteable.
     </p>
-    <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+    <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
       <cookbook-example-viewer
         [html]="conditionalExample.template"
         [ts]="conditionalExample.codeSnippet"

--- a/apps/cookbook/src/app/showcase/stock-chart-showcase/stock-chart-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/stock-chart-showcase/stock-chart-showcase.component.html
@@ -39,7 +39,7 @@
 </small>
 
 <p>
-  <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+  <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
     <cookbook-example-viewer [html]="stockExample.template" [ts]="stockExample.codeSnippet">
       <cookbook-chart-example-stock #stockExample></cookbook-chart-example-stock>
     </cookbook-example-viewer>
@@ -58,7 +58,7 @@
   values in the data labels will be suffixed with '%' as can be seen on the below example.
 </p>
 <p>
-  <kirby-card [flat]="true" [hasPadding]="_cardHasPadding">
+  <kirby-card variant="flat" [hasPadding]="_cardHasPadding">
     <cookbook-example-viewer
       [html]="stockComparisonExample.template"
       [ts]="stockComparisonExample.codeSnippet"

--- a/libs/designsystem/card/src/card.component.ts
+++ b/libs/designsystem/card/src/card.component.ts
@@ -9,17 +9,12 @@ import {
 } from '@angular/core';
 import { ResizeObserverService } from '@kirbydesign/designsystem/shared';
 
-const KIRBY_CARD_FLAT_PROPERTY_DEPRECATION_WARNING =
-  'Deprecation warning: Setting the "flat" property of kirby-card is deprecated and will be removed from Kirby v10. Use variant="flat" instead for identical behavior.';
-
 @Component({
   selector: 'kirby-card',
   templateUrl: './card.component.html',
   styleUrls: ['./card.component.scss'],
 })
 export class CardComponent implements OnInit, OnDestroy {
-  private _flat: boolean = false;
-
   @Input() title: string;
   @Input() subtitle: string;
 
@@ -50,26 +45,12 @@ export class CardComponent implements OnInit, OnDestroy {
     this.sizesSortedByBreakpoint = this.sortSizesByBreakpoint(value);
   }
 
-  /**
-   * @deprecated Setting the flat property is no longer recommended, and can now be set with variant="flat" instead. The 'flat' property will be removed in Kirby v10.
-   */
-  @Input()
-  set flat(isFlat: boolean) {
-    this._flat = isFlat;
-    console.warn(KIRBY_CARD_FLAT_PROPERTY_DEPRECATION_WARNING);
-  }
-
-  get flat(): boolean {
-    return this._flat;
-  }
-
   @Input()
   variant: 'elevated' | 'flat' | 'outlined' = 'elevated';
 
-  //TODO: remove "flat"-logic from below function in version 10.0
   @HostBinding('class')
   get _cssClass() {
-    return [this.variant, this.flat ? 'flat' : ''].filter((cssClass) => !!cssClass);
+    return [this.variant].filter((cssClass) => !!cssClass);
   }
 
   constructor(

--- a/libs/designsystem/card/src/card.component.ts
+++ b/libs/designsystem/card/src/card.component.ts
@@ -45,13 +45,9 @@ export class CardComponent implements OnInit, OnDestroy {
     this.sizesSortedByBreakpoint = this.sortSizesByBreakpoint(value);
   }
 
+  @HostBinding('class')
   @Input()
   variant: 'elevated' | 'flat' | 'outlined' = 'elevated';
-
-  @HostBinding('class')
-  get _cssClass() {
-    return [this.variant].filter((cssClass) => !!cssClass);
-  }
 
   constructor(
     private elementRef: ElementRef,


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3589

## What is the new behavior?
The `flat` property has been removed and all usages of this property can be replaced with the new `variant` property for identical behavior by inserting `variant="flat"` instead.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

