### PR TITLE
Housekeeping: add `border-radii` map

### DIFF
--- a/apps/cookbook/src/app/examples/card-example/examples/card-example.shared.scss
+++ b/apps/cookbook/src/app/examples/card-example/examples/card-example.shared.scss
@@ -42,7 +42,7 @@ button {
   height: utils.$fat-finger-size;
   width: utils.$fat-finger-size;
   border: none;
-  border-radius: 999px;
+  border-radius: utils.border-radius('circle');
   margin: 0;
   color: utils.get-color('black');
   cursor: pointer;

--- a/apps/cookbook/src/app/examples/example-configuration-wrapper/example-configuration-wrapper.component.scss
+++ b/apps/cookbook/src/app/examples/example-configuration-wrapper/example-configuration-wrapper.component.scss
@@ -51,9 +51,9 @@ $button-z-index: $card-z-index + 1;
   &.snap-to-viewport {
     kirby-card {
       position: fixed;
-      margin-top: utils.$border-radius;
+      margin-top: utils.border-radius('n');
       opacity: 0.5;
-      transform: rotate(-90deg) translateY(-#{utils.$border-radius + utils.size('xs')});
+      transform: rotate(-90deg) translateY(-#{utils.border-radius('n') + utils.size('xs')});
       transform-origin: top right;
       overflow: initial;
 

--- a/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.scss
+++ b/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.scss
@@ -25,7 +25,7 @@ button {
   height: utils.$fat-finger-size;
   width: utils.$fat-finger-size;
   border: none;
-  border-radius: 999px;
+  border-radius: utils.border-radius('circle');
   margin: 0;
   color: #fff;
   cursor: pointer;

--- a/apps/cookbook/src/app/examples/icon-example/examples/shared.scss
+++ b/apps/cookbook/src/app/examples/icon-example/examples/shared.scss
@@ -53,7 +53,7 @@ button {
   height: utils.$fat-finger-size;
   width: utils.$fat-finger-size;
   border: none;
-  border-radius: 999px;
+  border-radius: utils.border-radius('circle');
   margin: 0;
   color: utils.get-color('black');
   cursor: pointer;

--- a/apps/cookbook/src/app/examples/list-swipe-example/list-swipe-example.component.scss
+++ b/apps/cookbook/src/app/examples/list-swipe-example/list-swipe-example.component.scss
@@ -14,7 +14,7 @@ $dot-margin: utils.size('xxxs');
 .flag {
   width: 8px;
   height: 8px;
-  border-radius: 50%;
+  border-radius: utils.border-radius('circle');
 
   &.success {
     background: var(--kirby-success);

--- a/apps/cookbook/src/app/examples/segmented-control-example/color/color.scss
+++ b/apps/cookbook/src/app/examples/segmented-control-example/color/color.scss
@@ -16,7 +16,7 @@ button {
   height: utils.$fat-finger-size;
   width: utils.$fat-finger-size;
   border: none;
-  border-radius: 999px;
+  border-radius: utils.border-radius('circle');
   margin: 0;
   color: #fff;
   cursor: pointer;

--- a/libs/core/src/helpers/design-token-helper.ts
+++ b/libs/core/src/helpers/design-token-helper.ts
@@ -73,12 +73,24 @@ export class DesignTokenHelper {
     return ColorHelper.getBackgroundColor();
   }
 
-  public static borderRadius(): string {
-    return styles.borderRadius;
+  public static borderRadius(key: keyof typeof styles.borderRadii = undefined): string {
+    if (key === undefined) {
+      console.warn(
+        "Calling the borderRadius function without a parameter is deprecated. Please use `borderRadius('n')` instead."
+      );
+    }
+    return styles.borderRadii[key];
   }
 
+  /**
+   * @deprecated The borderRadiusRound function is deprecated.
+   * Please use `borderRadius('pill')` instead.
+   */
   public static borderRadiusRound(): string {
-    return styles.borderRadiusRound;
+    console.warn(
+      "The borderRadiusRound function is deprecated. Please use `borderRadius('pill')` instead."
+    );
+    return DesignTokenHelper.borderRadius('pill');
   }
 
   public static alertMaxWidth(): string {

--- a/libs/core/src/scss/_global-styles.scss
+++ b/libs/core/src/scss/_global-styles.scss
@@ -30,7 +30,7 @@ $modal-heights: (
   m: 565px,
   l: 754px,
 );
-$modal-border-radius: utils.size('l');
+$modal-border-radius: utils.border-radius('xl');
 $modal-gutter: #{utils.size('xxl')};
 $modal-header-height: 88px;
 $modal-expected-footer-height: 88px;
@@ -177,7 +177,7 @@ ion-modal.kirby-overlay {
 
   &.kirby-alert {
     --background: #{utils.get-color('background-color')};
-    --border-radius: #{utils.$border-radius};
+    --border-radius: #{utils.border-radius('n')};
     --box-shadow: #{utils.get-elevation(8)};
     --max-width: #{utils.$alert-max-width};
     --height: auto;

--- a/libs/core/src/scss/base/_design-tokens.scss
+++ b/libs/core/src/scss/base/_design-tokens.scss
@@ -39,6 +39,12 @@
   }
 }
 
+@mixin border-radii() {
+  @each $name, $value in variables.$border-radii {
+    --kirby-border-radius-#{$name}: #{$value};
+  }
+}
+
 @mixin elevations() {
   @each $name, $value in variables.$elevations {
     --kirby-elevation-#{$name}: #{$value};
@@ -91,6 +97,9 @@
   /* OVERLAY-COLORS */
   @include white-overlay-colors;
   @include dark-overlay-colors;
+
+  /* BORDER RADIUS */
+  @include border-radii;
 
   /* ELEVATIONS */
   @include elevations;

--- a/libs/core/src/scss/base/_functions.scss
+++ b/libs/core/src/scss/base/_functions.scss
@@ -71,6 +71,10 @@
   @return string.unquote('var(--kirby-decoration-color-' + $variant + '-' + $shade + ')');
 }
 
+@function border-radius($value) {
+  @return map.get(variables.$border-radii, $value);
+}
+
 @function get-elevation($value) {
   @return map.get(variables.$elevations, $value);
 }

--- a/libs/core/src/scss/base/_link.scss
+++ b/libs/core/src/scss/base/_link.scss
@@ -2,7 +2,7 @@
 @use '../utils';
 
 $_focus-ring-gap: 3px;
-$_focus-ring-border-radius: utils.size('xxxxs');
+$_focus-ring-border-radius: utils.border-radius('xxs');
 
 /*
  * Link-styles (anchor tag with href or kirbyModalRouterLink directive)

--- a/libs/core/src/scss/base/_list.scss
+++ b/libs/core/src/scss/base/_list.scss
@@ -1,17 +1,17 @@
 @use '@kirbydesign/core/src/scss/utils';
 
-@mixin rounded($border-radius: utils.$border-radius) {
+@mixin rounded($border-radius: utils.border-radius('n')) {
   @include rounded-top($border-radius);
   @include rounded-bottom($border-radius);
 }
 
-@mixin rounded-top($border-radius: utils.$border-radius) {
+@mixin rounded-top($border-radius: utils.border-radius('n')) {
   border-top-left-radius: $border-radius;
   border-top-right-radius: $border-radius;
   overflow: hidden;
 }
 
-@mixin rounded-bottom($border-radius: utils.$border-radius) {
+@mixin rounded-bottom($border-radius: utils.border-radius('n')) {
   border-bottom-left-radius: $border-radius;
   border-bottom-right-radius: $border-radius;
   overflow: hidden;

--- a/libs/core/src/scss/base/_variables.scss
+++ b/libs/core/src/scss/base/_variables.scss
@@ -82,8 +82,25 @@ $z-layers: (
   modal: 901,
   loading-overlay: 1001,
 ) !default;
-$border-radius: 16px !default;
-$border-radius-round: 999px !default;
+
+/* Border Radius
+****************************************************************************/
+$border-radii: (
+  xxs: 2px /* 0.125rem */,
+  xs: 4px /* 0.25rem */,
+  s: 8px /* 0.5rem */,
+  n: 16px /* 1rem */,
+  l: 24px /* 1.5rem */,
+  xl: 32px /* 2rem */,
+  circle: 50%,
+  pill: 999px,
+) !default;
+
+/// @deprecated Please use utils.border-radius('n') instead;
+$border-radius: map.get($border-radii, 'n') !default;
+
+/// @deprecated Please use utils.border-radius('pill') instead;
+$border-radius-round: map.get($border-radii, 'pill') !default;
 
 /* Breakpoints
 ****************************************************************************/

--- a/libs/designsystem/avatar/src/avatar.component.scss
+++ b/libs/designsystem/avatar/src/avatar.component.scss
@@ -31,7 +31,7 @@ $badge-diameter: utils.$avatar-badge-size;
   // default to size 'sm'
   width: $diameter-small;
   height: $diameter-small;
-  border-radius: 50%;
+  border-radius: utils.border-radius('circle');
   overflow: hidden;
   position: relative;
   z-index: 1;

--- a/libs/designsystem/badge/src/badge.component.scss
+++ b/libs/designsystem/badge/src/badge.component.scss
@@ -14,7 +14,7 @@
     --color: var(--kirby-badge-color, #{utils.get-color('white-contrast')});
 
     box-sizing: border-box; // Fixes https://github.com/kirbydesign/designsystem/issues/537
-    border-radius: utils.size('xxs');
+    border-radius: utils.border-radius('s');
     font-size: inherit;
     position: relative;
     box-shadow: var(--kirby-badge-elevation, none);

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -163,7 +163,7 @@ $button-margin: utils.size('xxxs');
   font-family: var(--kirby-font-family);
   background-color: var(--kirby-button-background-color, initial);
   color: var(--kirby-button-color, inherit);
-  border-radius: utils.$border-radius-round;
+  border-radius: utils.border-radius('pill');
   box-sizing: border-box; // Ensure border is not added to button height
   display: inline-flex;
   flex-direction: row;

--- a/libs/designsystem/button/src/button.component.spec.ts
+++ b/libs/designsystem/button/src/button.component.spec.ts
@@ -45,7 +45,7 @@ describe('ButtonComponent', () => {
     });
 
     it('should render with correct border-radius', () => {
-      const expected = DesignTokenHelper.borderRadiusRound();
+      const expected = DesignTokenHelper.borderRadius('pill');
 
       expect(element).toHaveComputedStyle({ 'border-radius': expected });
     });

--- a/libs/designsystem/card/src/card-header/card-header.component.scss
+++ b/libs/designsystem/card/src/card-header/card-header.component.scss
@@ -3,8 +3,8 @@
 
 :host {
   display: block;
-  border-top-left-radius: utils.$border-radius;
-  border-top-right-radius: utils.$border-radius;
+  border-top-left-radius: utils.border-radius('n');
+  border-top-right-radius: utils.border-radius('n');
   text-align: center;
   padding: 0;
   color: var(--kirby-card-header-color);

--- a/libs/designsystem/card/src/card.component.scss
+++ b/libs/designsystem/card/src/card.component.scss
@@ -31,7 +31,7 @@ $default-border-outline: 1px solid utils.get-color('medium');
     justify-content: inherit;
   }
 
-  border-radius: utils.$border-radius;
+  border-radius: utils.border-radius('n');
   box-shadow: utils.get-elevation(2);
   color: var(--kirby-card-main-color);
   background-color: var(--kirby-card-main-background-color);
@@ -64,8 +64,8 @@ $default-border-outline: 1px solid utils.get-color('medium');
         border-block-end: var(--kirby-card-border, $default-border-outline);
         border-inline-start: var(--kirby-card-border, $default-border-outline);
         border-inline-end: var(--kirby-card-border, $default-border-outline);
-        border-bottom-left-radius: utils.$border-radius;
-        border-bottom-right-radius: utils.$border-radius;
+        border-bottom-left-radius: utils.border-radius('n');
+        border-bottom-right-radius: utils.border-radius('n');
       }
     }
   }

--- a/libs/designsystem/dropdown/src/dropdown.component.scss
+++ b/libs/designsystem/dropdown/src/dropdown.component.scss
@@ -9,7 +9,7 @@ $min-screen-width: 375px;
 :host {
   @include interaction-state.apply-focus-visible {
     outline: none;
-    border-radius: utils.$border-radius-round;
+    border-radius: utils.border-radius('pill');
   }
 
   display: inline-block;

--- a/libs/designsystem/empty-state/src/empty-state.component.scss
+++ b/libs/designsystem/empty-state/src/empty-state.component.scss
@@ -21,7 +21,7 @@ article {
   flex-direction: column;
   justify-content: center;
   border: utils.size('xxxs') solid utils.get-color('medium');
-  border-radius: 50%;
+  border-radius: utils.border-radius('circle');
 }
 
 kirby-icon {

--- a/libs/designsystem/fab-sheet/src/fab-sheet.component.scss
+++ b/libs/designsystem/fab-sheet/src/fab-sheet.component.scss
@@ -26,7 +26,7 @@ ion-fab-button {
 
   @include interaction-state.apply-focus-visible {
     outline: none;
-    border-radius: utils.$border-radius-round;
+    border-radius: utils.border-radius('pill');
   }
 
   width: 64px;

--- a/libs/designsystem/flag/src/flag.component.scss
+++ b/libs/designsystem/flag/src/flag.component.scss
@@ -20,7 +20,7 @@
   background-color: var(--kirby-flag-background-color, transparent);
   color: var(--kirby-flag-color, utils.get-color('white-contrast'));
   border: 1px solid var(--kirby-flag-border-color, utils.get-color('medium'));
-  border-radius: utils.size('xxxs');
+  border-radius: utils.border-radius('xs');
   font-size: utils.font-size('n');
   padding: utils.size('xxxxs') utils.size('xxs');
   font-weight: utils.font-weight('medium');

--- a/libs/designsystem/form-field/src/_form-field-inputs.shared.scss
+++ b/libs/designsystem/form-field/src/_form-field-inputs.shared.scss
@@ -52,7 +52,7 @@ $form-field-label-height: 24px;
   outline: none;
   margin: 0;
   appearance: none;
-  border-radius: utils.size('s');
+  border-radius: utils.border-radius('n');
   box-shadow: var(--kirby-inputs-elevation);
   padding: $form-field-input-padding;
   width: 100%;

--- a/libs/designsystem/form-field/src/input/input.component.scss
+++ b/libs/designsystem/form-field/src/input/input.component.scss
@@ -38,7 +38,7 @@ $padding-block-size-md: shared.$form-field-input-padding * 0.5;
 }
 
 :host(.md) {
-  border-radius: utils.size('m');
+  border-radius: utils.border-radius('l');
   padding-block: $padding-block-size-md;
 
   &.error {

--- a/libs/designsystem/form-field/src/input/input.component.spec.ts
+++ b/libs/designsystem/form-field/src/input/input.component.spec.ts
@@ -57,7 +57,7 @@ describe('InputComponent', () => {
   });
 
   it('should render with correct border-radius', () => {
-    const expected = DesignTokenHelper.borderRadius();
+    const expected = DesignTokenHelper.borderRadius('n');
     expect(element).toHaveComputedStyle({ 'border-radius': expected });
   });
 

--- a/libs/designsystem/form-field/src/textarea/textarea.component.spec.ts
+++ b/libs/designsystem/form-field/src/textarea/textarea.component.spec.ts
@@ -47,7 +47,7 @@ describe('TextareaComponent', () => {
   });
 
   it('should render with correct border-radius', () => {
-    const expected = DesignTokenHelper.borderRadius();
+    const expected = DesignTokenHelper.borderRadius('n');
     expect(element).toHaveComputedStyle({ 'border-radius': expected });
   });
 

--- a/libs/designsystem/item/src/item.component.scss
+++ b/libs/designsystem/item/src/item.component.scss
@@ -160,7 +160,7 @@
 // Fixes https://github.com/kirbydesign/designsystem/issues/1711
 :host-context(.shape-rounded .is-single) {
   ion-item {
-    --border-radius: #{utils.$border-radius};
+    --border-radius: #{utils.border-radius('n')};
   }
 }
 
@@ -183,7 +183,7 @@
 // Fixes https://github.com/kirbydesign/designsystem/issues/1711
 :host-context(.shape-rounded.has-sections .list-items kirby-list-item:first-of-type) {
   ion-item::part(native) {
-    border-top-left-radius: utils.$border-radius;
-    border-top-right-radius: utils.$border-radius;
+    border-top-left-radius: utils.border-radius('n');
+    border-top-right-radius: utils.border-radius('n');
   }
 }

--- a/libs/designsystem/list/src/list-experimental/list-experimental.component.spec.ts
+++ b/libs/designsystem/list/src/list-experimental/list-experimental.component.spec.ts
@@ -6,7 +6,7 @@ import { MockComponent } from 'ng-mocks';
 
 import { ListExperimentalComponent } from './list-experimental.component';
 
-const borderRadius = DesignTokenHelper.borderRadius();
+const borderRadius = DesignTokenHelper.borderRadius('n');
 const { getElevation } = DesignTokenHelper;
 
 describe('ListExperimental', () => {

--- a/libs/designsystem/list/src/list.component.scss
+++ b/libs/designsystem/list/src/list.component.scss
@@ -147,7 +147,7 @@ ion-item-options[side='end'] {
 
   .list-items {
     box-shadow: $shadow;
-    border-radius: utils.$border-radius;
+    border-radius: utils.border-radius('n');
   }
 
   .footer {
@@ -164,14 +164,14 @@ ion-item-options[side='end'] {
 :host-context(.shape-rounded) {
   .list,
   .list-items {
-    border-radius: utils.$border-radius;
+    border-radius: utils.border-radius('n');
   }
 
   ion-item.first,
   ion-item-sliding.first,
   ion-list-header {
-    border-top-left-radius: utils.$border-radius;
-    border-top-right-radius: utils.$border-radius;
+    border-top-left-radius: utils.border-radius('n');
+    border-top-right-radius: utils.border-radius('n');
     mask-image: radial-gradient(
       white,
       black
@@ -188,8 +188,8 @@ ion-item-options[side='end'] {
   ion-item.last,
   ion-item-sliding.last,
   .footer {
-    border-bottom-left-radius: utils.$border-radius;
-    border-bottom-right-radius: utils.$border-radius;
+    border-bottom-left-radius: utils.border-radius('n');
+    border-bottom-right-radius: utils.border-radius('n');
     mask-image: radial-gradient(
       white,
       black

--- a/libs/designsystem/page/src/page.component.scss
+++ b/libs/designsystem/page/src/page.component.scss
@@ -193,7 +193,7 @@ ion-back-button {
 
   &::part(native) {
     opacity: 1; // required for interaction states to work
-    border-radius: utils.$border-radius-round;
+    border-radius: utils.border-radius('pill');
     overflow: hidden; // required for border radius to work
   }
 

--- a/libs/designsystem/progress-circle/src/progress-circle.component.scss
+++ b/libs/designsystem/progress-circle/src/progress-circle.component.scss
@@ -23,6 +23,6 @@ kirby-progress-circle-ring {
   justify-content: center;
   align-items: center;
   z-index: utils.z('default');
-  border-radius: 50%;
+  border-radius: utils.border-radius('circle');
   overflow: hidden;
 }

--- a/libs/designsystem/range/src/range.component.scss
+++ b/libs/designsystem/range/src/range.component.scss
@@ -76,7 +76,7 @@ ion-range {
 
   &::part(tick),
   &::part(tick-active) {
-    border-radius: 50%;
+    border-radius: utils.border-radius('circle');
     width: $tick-width;
     height: $tick-height;
     margin-top: 1px; // compensate for different height of ionic tick (8px)

--- a/libs/designsystem/reorder-list/src/reorder-list.component.scss
+++ b/libs/designsystem/reorder-list/src/reorder-list.component.scss
@@ -22,7 +22,7 @@ ion-backdrop {
   @include utils.slotted('kirby-item') {
     box-shadow: 0 0 10px rgb(0 0 0 / 40%);
     transform: scale(1.05, 1.05);
-    border-radius: utils.$border-radius;
+    border-radius: utils.border-radius('n');
     overflow: hidden;
   }
 }
@@ -42,8 +42,8 @@ ion-backdrop {
   }
 
   @include utils.slotted('div:last-child kirby-item') {
-    border-bottom-left-radius: utils.$border-radius;
-    border-bottom-right-radius: utils.$border-radius;
+    border-bottom-left-radius: utils.border-radius('n');
+    border-bottom-right-radius: utils.border-radius('n');
     overflow: hidden;
   }
 
@@ -51,7 +51,7 @@ ion-backdrop {
     @include utils.slotted('kirby-item') {
       box-shadow: 0 0 10px rgb(0 0 0 / 40%);
       transform: scale(1.05, 1.05);
-      border-radius: utils.$border-radius;
+      border-radius: utils.border-radius('n');
       overflow: hidden;
     }
   }
@@ -70,8 +70,8 @@ kirby-card {
   z-index: auto;
 
   @include utils.slotted('div:last-child ion-reorder-group div:last-child>kirby-item') {
-    border-bottom-left-radius: utils.$border-radius;
-    border-bottom-right-radius: utils.$border-radius;
+    border-bottom-left-radius: utils.border-radius('n');
+    border-bottom-right-radius: utils.border-radius('n');
     overflow: hidden;
   }
 
@@ -80,7 +80,7 @@ kirby-card {
   }
 
   @include utils.slotted('.content-layer > div:first-child > kirby-item') {
-    border-radius: utils.$border-radius;
+    border-radius: utils.border-radius('n');
     overflow: hidden;
   }
 

--- a/libs/designsystem/slide-button/src/slide-button.component.scss
+++ b/libs/designsystem/slide-button/src/slide-button.component.scss
@@ -22,7 +22,7 @@ $slide-button-text-padding: 0 $slide-button-container-radius 0 $total-slider-thu
 
   transition: interaction-state.transition();
   appearance: none;
-  border-radius: 50%;
+  border-radius: utils.border-radius('circle');
   background-color: $slider-thumb-bg-color;
   background-image: url('/assets/kirby/icons/svg/arrow-more.svg');
   background-repeat: no-repeat;

--- a/libs/designsystem/spinner/src/spinner.component.scss
+++ b/libs/designsystem/spinner/src/spinner.component.scss
@@ -12,7 +12,7 @@
 .outer-circle {
   width: 100%;
   height: 100%;
-  border-radius: 50%;
+  border-radius: utils.border-radius('circle');
   background-color: utils.get-color('primary');
   opacity: 0.6;
   position: absolute;

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -21,7 +21,7 @@
 
       @include interaction-state.apply-focus-visible {
         outline: none;
-        border-radius: utils.$border-radius-round;
+        border-radius: utils.border-radius('pill');
       }
     }
   }
@@ -95,7 +95,7 @@
 }
 
 ion-segment {
-  border-radius: utils.$border-radius-round;
+  border-radius: utils.border-radius('pill');
   grid-auto-columns: max-content;
   box-sizing: border-box;
 }
@@ -104,7 +104,7 @@ ion-segment-button {
   @include interaction-state.apply-focus-part($part: 'native');
   @include utils.accessible-target-size;
 
-  --border-radius: #{utils.$border-radius-round};
+  --border-radius: #{utils.border-radius('pill')};
   --border-style: none;
   --background: none;
   --color: var(--kirby-inputs-color);

--- a/libs/extensions/angular/image-banner/src/image-banner.component.scss
+++ b/libs/extensions/angular/image-banner/src/image-banner.component.scss
@@ -65,7 +65,7 @@ $main-image-height-large: 164px;
 .main-content-image-wrapper {
   display: flex;
   overflow: hidden;
-  border-radius: utils.size('xxs');
+  border-radius: utils.border-radius('s');
 
   @include utils.media('>=small') {
     flex: 1;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue, housekeeping.

## What is the new behavior?

- Adds a new `border-radii` map and `border-radius` utility function
- Updates `DesignTokenHelper.borderRadius` to use the `border-radii` map
- Replaces all usages of `size` with `border-radius` util function in `border-radius` declarations
- Replaces all usages of deprecated `$border-radius` variables with `border-radius` util function
- Replaces all hardcoded / magic string `border-radius` declarations with `border-radius` util function
- Ouputs the `border-radii` map as CSS custom properties

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

