### PR TITLE
Alert: use primary color instead of success color for ok button

### DIFF
--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -310,11 +310,6 @@ $button-margin: utils.size('xxxs');
   margin-inline-start: utils.size('s');
 }
 
-:host-context(kirby-alert).ok-btn {
-  --kirby-button-background-color: #{utils.get-color('success')};
-  --kirby-button-color: #{utils.get-color('success-contrast')};
-}
-
 :host-context(kirby-dropdown) {
   // place arrow-icon in dropdown correctly
   justify-content: space-between;

--- a/libs/designsystem/modal/src/modal/alert/alert.component.spec.ts
+++ b/libs/designsystem/modal/src/modal/alert/alert.component.spec.ts
@@ -1,10 +1,7 @@
 import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
-
-import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
-
 import { IconModule } from '@kirbydesign/designsystem/icon';
+
 import { AlertComponent } from './alert.component';
-const getColor = DesignTokenHelper.getColor;
 
 describe('AlertComponent', () => {
   let spectator: SpectatorHost<AlertComponent>;
@@ -57,13 +54,6 @@ describe('AlertComponent', () => {
       spectator.setInput({ cancelBtn: null });
 
       expect(okButton).toHaveClass('lg');
-    });
-
-    it('should have success colors on button', () => {
-      expect(okButton).toHaveComputedStyle({
-        'background-color': getColor('success'),
-        color: getColor('success', 'contrast'),
-      });
     });
 
     it('should have default size when cancel button', () => {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3554

## What is the new behavior?
See #3554 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

