### PR TITLE
Textarea: missing resize handle

### DIFF
--- a/libs/designsystem/form-field/src/textarea/textarea.component.scss
+++ b/libs/designsystem/form-field/src/textarea/textarea.component.scss
@@ -21,9 +21,6 @@
     }
     /* stylelint-enable no-duplicate-selectors */
   }
-  @include utils.media('>=medium') {
-    resize: vertical;
-  }
 
   // Wrap declarations to avoid mixing with nested rules.
   // See: https://sass-lang.com/documentation/breaking-changes/mixed-decls/
@@ -34,4 +31,8 @@
     resize: none;
   }
   /* stylelint-enable no-duplicate-selectors */
+
+  @include utils.media('>=medium') {
+    resize: vertical;
+  }
 }

--- a/libs/designsystem/form-field/src/textarea/textarea.component.spec.ts
+++ b/libs/designsystem/form-field/src/textarea/textarea.component.spec.ts
@@ -2,6 +2,7 @@ import { fakeAsync, tick } from '@angular/core/testing';
 import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
 
 import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
+import { TestHelper } from '@kirbydesign/designsystem/testing';
 
 import { TextareaComponent } from './textarea.component';
 
@@ -94,6 +95,22 @@ describe('TextareaComponent', () => {
     it('should render with correct background-color', () => {
       expect(element).toHaveComputedStyle({
         'background-color': getColor('light', 'tint'),
+      });
+    });
+  });
+
+  describe('on desktop', () => {
+    beforeAll(async () => {
+      await TestHelper.resizeTestWindow(TestHelper.screensize.desktop);
+    });
+
+    afterAll(() => {
+      TestHelper.resetTestWindow();
+    });
+
+    it('should render a resize handle', () => {
+      expect(element).toHaveComputedStyle({
+        resize: 'vertical',
       });
     });
   });


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3630 

## What is the new behavior?

Fixes missing resize handle on desktop.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

