### PR TITLE
Toggle Button: respect disabled state of slotted buttons

### DIFF
--- a/apps/cookbook/src/app/examples/toggle-button-example/toggle-button-example.component.ts
+++ b/apps/cookbook/src/app/examples/toggle-button-example/toggle-button-example.component.ts
@@ -15,6 +15,11 @@ const config = {
 <kirby-toggle-button [checked]="true" (checkChanged)="onCheckChanged($event)">
   <button kirby-button unchecked attentionLevel="3">Deactivated</button>
   <button kirby-button checked themeColor="danger">Activated</button>
+</kirby-toggle-button>
+
+<kirby-toggle-button (checkChanged)="onCheckChanged($event)">
+  <button kirby-button unchecked disabled attentionLevel="3">Disabled</button>
+  <button kirby-button checked >Activated</button>
 </kirby-toggle-button>`,
 };
 

--- a/libs/designsystem/toggle-button/src/toggle-button.component.html
+++ b/libs/designsystem/toggle-button/src/toggle-button.component.html
@@ -1,6 +1,2 @@
-<ng-container *ngIf="!checked">
-  <ng-content select="button[kirby-button][unchecked]"></ng-content>
-</ng-container>
-<ng-container *ngIf="checked">
-  <ng-content select="button[kirby-button][checked]"></ng-content>
-</ng-container>
+<ng-content *ngIf="!checked" select="button[kirby-button][unchecked]"></ng-content>
+<ng-content *ngIf="checked" select="button[kirby-button][checked]"></ng-content>

--- a/libs/designsystem/toggle-button/src/toggle-button.component.ts
+++ b/libs/designsystem/toggle-button/src/toggle-button.component.ts
@@ -16,8 +16,13 @@ export class ToggleButtonComponent {
   @Input() checked: boolean;
   @Output() checkChanged = new EventEmitter<boolean>();
 
-  @HostListener('click')
-  onClick() {
+  @HostListener('click', ['$event'])
+  onClick(event: PointerEvent) {
+    const targetElement = event.target as HTMLElement;
+    const buttonDisabled = targetElement.closest('button[kirby-button]:not(:disabled)');
+
+    if (!buttonDisabled) return;
+
     this.checked = !this.checked;
     this.checkChanged.emit(this.checked);
   }

--- a/libs/designsystem/toggle-button/src/toggle-button.component.ts
+++ b/libs/designsystem/toggle-button/src/toggle-button.component.ts
@@ -19,9 +19,9 @@ export class ToggleButtonComponent {
   @HostListener('click', ['$event'])
   onClick(event: PointerEvent) {
     const targetElement = event.target as HTMLElement;
-    const buttonDisabled = targetElement.closest('button[kirby-button]:not(:disabled)');
+    const buttonEnabled = targetElement.closest('button[kirby-button]:not(:disabled)');
 
-    if (!buttonDisabled) return;
+    if (!buttonEnabled) return;
 
     this.checked = !this.checked;
     this.checkChanged.emit(this.checked);


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?
Previously, clicking a disabled button inside the toggle button would still change the state of the toggle button. 
Now the toggle button respects the disabled state of any button inside.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

