### PR TITLE
Housekeeping: Use storybooks staticDir for assets in extensions lib

### DIFF
--- a/libs/extensions/angular/.storybook/main.ts
+++ b/libs/extensions/angular/.storybook/main.ts
@@ -17,6 +17,11 @@ const config: StorybookConfig = {
   docs: {
     autodocs: true,
   },
+  staticDirs: [
+    { from: '../../../designsystem/icon/src/icons/svg', to: '/assets/kirby/icons/svg' },
+    { from: '../../../../node_modules/ionicons/dist/ionicons/svg', to: '/svg' },
+    { from: '../docs/assets', to: '/assets/images' },
+  ],
 };
 
 export default config;

--- a/libs/extensions/angular/image-banner/src/image-banner.component.stories.ts
+++ b/libs/extensions/angular/image-banner/src/image-banner.component.stories.ts
@@ -45,7 +45,7 @@ export const Default: Story = {
     title: 'An Image Banner',
     bodyText: 'This is the body text.',
     actionButtonText: 'Read more',
-    imagePath: 'assets/leaves.jpg',
+    imagePath: 'assets/images/leaves.jpg',
     backgroundBlur: 'dark',
   },
 };
@@ -59,7 +59,7 @@ export const LightBackgroundBlur: Story = {
   args: {
     title: 'Light Background Blur',
     bodyText: 'This is the body text.',
-    imagePath: 'assets/leaves.jpg',
+    imagePath: 'assets/images/leaves.jpg',
     backgroundBlur: 'light',
     actionButtonText: 'Read more',
   },
@@ -70,7 +70,7 @@ export const NoBackgroundBlur: Story = {
     title: 'No Background Blur',
     bodyText: 'This is the body text.',
     actionButtonText: 'Read more',
-    imagePath: 'assets/leaves.jpg',
+    imagePath: 'assets/images/leaves.jpg',
     backgroundBlur: 'none',
   },
 };
@@ -84,7 +84,7 @@ export const ExternalLink: Story = {
     bodyText: 'Activating this banner will take you to www.kirby.design 👋',
     actionButtonText: 'Go to Kirby Design',
     externalLink: 'http://www.kirby.design',
-    imagePath: 'assets/leaves.jpg',
+    imagePath: 'assets/images/leaves.jpg',
   },
 };
 
@@ -97,7 +97,7 @@ export const NoDismiss: Story = {
     title: 'No Dismiss in Banner',
     bodyText: 'This is the body text.',
     actionButtonText: 'Read more',
-    imagePath: 'assets/leaves.jpg',
+    imagePath: 'assets/images/leaves.jpg',
     dismissClick: undefined,
   },
   // The render method with argsToTemplate() is needed for bannerDismiss to not be automatically inferred by storybook.

--- a/libs/extensions/angular/project.json
+++ b/libs/extensions/angular/project.json
@@ -47,34 +47,13 @@
     },
     "storybook": {
       "builder": "@storybook/angular:start-storybook",
+      "dependsOn": ["build"],
       "options": {
         "configDir": "libs/extensions/angular/.storybook",
         "port": 6006,
         "styles": [
           "libs/core/src/scss/_global-styles.scss",
           "libs/extensions/angular/.storybook/styles.css"
-        ],
-        "assets": [
-          {
-            "glob": "**/*",
-            "input": "libs/extensions/angular/docs/assets",
-            "output": "./assets"
-          },
-          {
-            "glob": "**/*.svg",
-            "input": "libs/designsystem/icon/src/icons/svg",
-            "output": "./assets/kirby/icons/svg"
-          },
-          {
-            "glob": "**/*.svg",
-            "input": "node_modules/ionicons/dist/ionicons/svg",
-            "output": "./svg"
-          },
-          {
-            "glob": "**/*.woff2",
-            "input": "node_modules/@fontsource/roboto/files",
-            "output": "./assets/fonts"
-          }
         ],
         "compodoc": true,
         "compodocArgs": [
@@ -97,28 +76,6 @@
         "styles": [
           "libs/core/src/scss/_global-styles.scss",
           "libs/extensions/angular/.storybook/styles.css"
-        ],
-        "assets": [
-          {
-            "glob": "**/*",
-            "input": "libs/extensions/angular/docs/assets",
-            "output": "./assets"
-          },
-          {
-            "glob": "**/*.svg",
-            "input": "libs/designsystem/icon/src/icons/svg",
-            "output": "./assets/kirby/icons/svg"
-          },
-          {
-            "glob": "**/*.svg",
-            "input": "node_modules/ionicons/dist/ionicons/svg",
-            "output": "./svg"
-          },
-          {
-            "glob": "**/*.woff2",
-            "input": "node_modules/@fontsource/roboto/files",
-            "output": "./assets/fonts"
-          }
         ],
         "compodoc": true,
         "compodocArgs": [


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?
Safari tests were flaky, and I noticed we were not using staticDir to serve assets, like we do in the designsystem.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

