### PR TITLE
Housekeeping: Use smaller asset in extension story

### DIFF
--- a/libs/extensions/angular/.storybook/preview-head.html
+++ b/libs/extensions/angular/.storybook/preview-head.html
@@ -2,7 +2,7 @@
 
 <link
   rel="preload"
-  href="assets/fonts/roboto-latin-300-normal.woff2"
+  href="roboto-latin-300-normal.woff2"
   as="font"
   type="font/woff2"
   crossorigin="anonymous"
@@ -10,7 +10,7 @@
 
 <link
   rel="preload"
-  href="assets/fonts/roboto-latin-400-normal.woff2"
+  href="roboto-latin-400-normal.woff2"
   as="font"
   type="font/woff2"
   crossorigin="anonymous"
@@ -18,7 +18,7 @@
 
 <link
   rel="preload"
-  href="assets/fonts/roboto-latin-500-normal.woff2"
+  href="roboto-latin-500-normal.woff2"
   as="font"
   type="font/woff2"
   crossorigin="anonymous"
@@ -26,7 +26,7 @@
 
 <link
   rel="preload"
-  href="assets/fonts/roboto-latin-700-normal.woff2"
+  href="roboto-latin-700-normal.woff2"
   as="font"
   type="font/woff2"
   crossorigin="anonymous"
@@ -34,7 +34,7 @@
 
 <link
   rel="preload"
-  href="assets/fonts/roboto-latin-900-normal.woff2"
+  href="roboto-latin-900-normal.woff2"
   as="font"
   type="font/woff2"
   crossorigin="anonymous"


### PR DESCRIPTION
## Which issue does this PR close?

This PR follows up on #3635 

## What is the new behavior?
The leaves.jpg image had a gigantic file-size of 6.6mb 😬 Which is total overkill for our docs page.
I replaced it with a much smaller version (66 kb), so it should load faster, and reduce (remove 🤞) current flakyness in safari.

I also aligned some preloading font stuff with the designsystem storybook.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No