### PR TITLE
Checkbox, Radio: fix slotted text not wrapping

### DIFF
--- a/libs/designsystem/checkbox/src/checkbox.component.scss
+++ b/libs/designsystem/checkbox/src/checkbox.component.scss
@@ -147,6 +147,7 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
 
     &::part(label-text-wrapper) {
       margin-inline: $spacing-to-label 0;
+      white-space: pre-line;
     }
 
     // Overrides for kirby-checkbox inside kirby-item
@@ -171,10 +172,6 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
           margin-inline: $spacing-to-label 0;
         }
       }
-    }
-
-    span {
-      white-space: pre-line;
     }
   }
 

--- a/libs/designsystem/radio/src/radio.component.scss
+++ b/libs/designsystem/radio/src/radio.component.scss
@@ -100,6 +100,7 @@ ion-radio {
 
   &::part(label-text-wrapper) {
     margin-inline: $spacing-to-label 0;
+    white-space: pre-line;
   }
 
   // Overrides for kirby-radio inside kirby-item
@@ -142,10 +143,6 @@ ion-radio {
         box-shadow: utils.get-elevation(4);
       }
     }
-  }
-
-  span {
-    white-space: pre-line;
   }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3648

## What is the new behavior?
Adding text in the default slot of checkbox or radio will now wrap, similar to how it does for text set with the text-property.
The `white-space` style declaration is moved to the label-text-wrapper part as it is used for both types of text.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

