### PR TITLE
Core: declare interaction-state, variables and colors scss exports

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kirbydesign/core",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "description": "Core styles and helpers for the Kirby Design System.",
   "type": "module",
   "main": "dist/index.js",
@@ -24,7 +24,10 @@
       "types": "./dist/types/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./scss/base/variables": "./scss/base/_variables.scss",
     "./scss/global-styles": "./scss/_global-styles.scss",
+    "./scss/interaction-state": "./scss/interaction-state/_index.scss",
+    "./scss/themes/colors": "./scss/themes/_colors.scss",
     "./scss/utils": "./scss/_utils.scss",
     "./src/scss/*": {
       "style": "./src/scss/*"

--- a/libs/designsystem/package.json
+++ b/libs/designsystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kirbydesign/designsystem",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "description": "The Kirby Design Angular Components.",
   "author": "kirby@bankdata.dk",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,7 +151,7 @@
     },
     "libs/core": {
       "name": "@kirbydesign/core",
-      "version": "0.0.65",
+      "version": "0.0.66",
       "license": "MIT",
       "dependencies": {
         "lit": "^3.1.4"
@@ -162,7 +162,7 @@
     },
     "libs/designsystem": {
       "name": "@kirbydesign/designsystem",
-      "version": "10.1.1",
+      "version": "10.1.2",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",


### PR DESCRIPTION
Fixes missing exports, as not everything was patched by #3665.
Also bumps versions so packages are ready for release of core v.0.0.66 and designsystem v10.1.2 