### PR TITLE
Core: declare print scss export

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kirbydesign/core",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "description": "Core styles and helpers for the Kirby Design System.",
   "type": "module",
   "main": "dist/index.js",
@@ -29,6 +29,7 @@
     "./scss/interaction-state": "./scss/interaction-state/_index.scss",
     "./scss/themes/colors": "./scss/themes/_colors.scss",
     "./scss/utils": "./scss/_utils.scss",
+    "./scss/print": "./scss/print/_index.scss",
     "./src/scss/*": {
       "style": "./src/scss/*"
     },

--- a/libs/designsystem/package.json
+++ b/libs/designsystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kirbydesign/designsystem",
-  "version": "10.1.2",
+  "version": "10.1.3",
   "description": "The Kirby Design Angular Components.",
   "author": "kirby@bankdata.dk",
   "repository": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,7 +151,7 @@
     },
     "libs/core": {
       "name": "@kirbydesign/core",
-      "version": "0.0.66",
+      "version": "0.0.67",
       "license": "MIT",
       "dependencies": {
         "lit": "^3.1.4"
@@ -162,7 +162,7 @@
     },
     "libs/designsystem": {
       "name": "@kirbydesign/designsystem",
-      "version": "10.1.2",
+      "version": "10.1.3",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",


### PR DESCRIPTION
Follow up to #3668 #3665. This is getting embarrassing! 
We need an additional scss style export to be properly backward compatible.
Also bumped package to prepare release.