### PR TITLE
Image Banner: fix missing padding-end on text in small view

### DIFF
--- a/libs/extensions/angular/image-banner/src/image-banner.component.scss
+++ b/libs/extensions/angular/image-banner/src/image-banner.component.scss
@@ -126,13 +126,19 @@ $container-query-breakpoint: 600px;
 }
 
 .main-content-header {
-  margin-right: utils.size('xl');
+  padding-inline-end: utils.size('xxs');
 
   p {
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
     margin-bottom: 0;
+  }
+}
+
+.main-content:has(.main-content-body-action-link) {
+  .main-content-header {
+    padding-inline-end: utils.size('xl');
   }
 }
 
@@ -169,6 +175,7 @@ $container-query-breakpoint: 600px;
   display: block;
   overflow: hidden;
   max-height: utils.size('xl');
+  padding-inline-end: utils.size('xxs');
 
   @include container-more-than-width {
     padding-inline-end: utils.size('xxl');


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue, but fixes a small issue where the inline-end side of body text and title did not have correct spacing to the inline-end side of the card, when in its small view:
![image](https://github.com/user-attachments/assets/4ce48a74-c1d6-459c-8ac8-ba7d833148ed)

This is now fixed, so it has equal inline padding.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

