### PR TITLE
Docs: improve empty state showcase

### DIFF
--- a/apps/cookbook/src/app/component-overview/component-configuration.json
+++ b/apps/cookbook/src/app/component-overview/component-configuration.json
@@ -91,10 +91,10 @@
       "route": "/home/showcase/dropdown"
     },
     {
-      "title": "Empty State",
-      "paragraph": "Empty State is presented when no content is available, offering user-friendly guidance and clear messaging to assist users in such situations.",
+      "title": "Message State",
+      "paragraph": "Message State provides feedback about the application, content or workflow state to the user while, if possible, giving constructive guidance about next steps.",
       "svgPath": "./assets/component-svg/Empty-State-Kirby-Component-Overview.svg",
-      "route": "/home/showcase/empty-state"
+      "route": "/home/showcase/message-state"
     },
     {
       "title": "FAB",

--- a/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.component.html
+++ b/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.component.html
@@ -1,5 +1,8 @@
 <h2>Message Types</h2>
 <cookbook-empty-state-message-types-example></cookbook-empty-state-message-types-example>
 
+<h2>Simple</h2>
+<cookbook-empty-state-simple-example></cookbook-empty-state-simple-example>
+
 <h2>Buttons</h2>
 <cookbook-empty-state-buttons-example></cookbook-empty-state-buttons-example>

--- a/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.component.html
+++ b/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.component.html
@@ -1,51 +1,5 @@
-<kirby-empty-state
-  iconName="help"
-  title="No items"
-  subtitle="You don't have any items. Call support to add some items to your account."
->
-  <button kirby-button>Call support</button>
-</kirby-empty-state>
-<hr />
-<kirby-empty-state
-  title="No items"
-  subtitle="You don't have any items. Call support to add some items to your account."
->
-  <button kirby-button>Call support</button>
-</kirby-empty-state>
-<hr />
-<kirby-empty-state
-  iconName="football"
-  title="No items"
-  subtitle="You don't have any items. Call support to add some items to your account."
-></kirby-empty-state>
-<hr />
-<kirby-empty-state
-  title="No items"
-  subtitle="You don't have any items. Call support to add some items to your account."
-></kirby-empty-state>
-<hr />
-<kirby-empty-state iconName="help">
-  <button kirby-button>Call support</button>
-</kirby-empty-state>
-<hr />
-<kirby-empty-state
-  iconName="help"
-  title="Theme Color"
-  subtitle="You can change color using theme color"
-  themeColor="warning"
-></kirby-empty-state>
-<kirby-empty-state
-  iconName="help"
-  title="Line break"
-  subtitle="You can make line breaks using '\n' or '&amp;&#35;10;'&#10;&#10;This is on another line"
-></kirby-empty-state>
-<hr />
-<kirby-empty-state
-  iconName="help"
-  title="Button attention levels"
-  subtitle="All slotted buttons will be rendered with attention level 3, except the first button if it is configured with attention level 1."
->
-  <button kirby-button attentionLevel="1">Call support</button>
-  <button kirby-button attentionLevel="2">Mail support</button>
-  <button kirby-button attentionLevel="3">Get directions</button>
-</kirby-empty-state>
+<h2>Message Types</h2>
+<cookbook-empty-state-message-types-example></cookbook-empty-state-message-types-example>
+
+<h2>Buttons</h2>
+<cookbook-empty-state-buttons-example></cookbook-empty-state-buttons-example>

--- a/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.component.scss
+++ b/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.component.scss
@@ -1,0 +1,1 @@
+@use '../examples.shared';

--- a/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.component.ts
+++ b/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.component.ts
@@ -3,5 +3,6 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'cookbook-empty-state-example',
   templateUrl: './empty-state-example.component.html',
+  styleUrls: ['./empty-state-example.component.scss'],
 })
 export class EmptyStateExampleComponent {}

--- a/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.module.ts
+++ b/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.module.ts
@@ -8,11 +8,13 @@ import { EmptyStateModule } from '@kirbydesign/designsystem/empty-state';
 import { EmptyStateMessageTypesExampleComponent } from './examples/message-types';
 import { EmptyStateButtonsExampleComponent } from './examples/buttons';
 import { EmptyStateExampleComponent } from './empty-state-example.component';
+import { EmptyStateSimpleExampleComponent } from './examples/simple';
 
 const COMPONENT_DECLARATIONS = [
   EmptyStateExampleComponent,
   EmptyStateButtonsExampleComponent,
   EmptyStateMessageTypesExampleComponent,
+  EmptyStateSimpleExampleComponent,
 ];
 
 @NgModule({

--- a/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.module.ts
+++ b/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.module.ts
@@ -7,8 +7,10 @@ import { IconModule } from '@kirbydesign/designsystem/icon';
 import { EmptyStateModule } from '@kirbydesign/designsystem/empty-state';
 import { EmptyStateMessageTypesExampleComponent } from './examples/message-types';
 import { EmptyStateButtonsExampleComponent } from './examples/buttons';
+import { EmptyStateExampleComponent } from './empty-state-example.component';
 
 const COMPONENT_DECLARATIONS = [
+  EmptyStateExampleComponent,
   EmptyStateButtonsExampleComponent,
   EmptyStateMessageTypesExampleComponent,
 ];

--- a/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.module.ts
+++ b/apps/cookbook/src/app/examples/empty-state-example/empty-state-example.module.ts
@@ -1,0 +1,21 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { ButtonComponent } from '@kirbydesign/designsystem/button';
+import { IconModule } from '@kirbydesign/designsystem/icon';
+
+import { EmptyStateModule } from '@kirbydesign/designsystem/empty-state';
+import { EmptyStateMessageTypesExampleComponent } from './examples/message-types';
+import { EmptyStateButtonsExampleComponent } from './examples/buttons';
+
+const COMPONENT_DECLARATIONS = [
+  EmptyStateButtonsExampleComponent,
+  EmptyStateMessageTypesExampleComponent,
+];
+
+@NgModule({
+  declarations: COMPONENT_DECLARATIONS,
+  imports: [CommonModule, EmptyStateModule, ButtonComponent, IconModule],
+  exports: COMPONENT_DECLARATIONS,
+})
+export class EmptyStateExampleModule {}

--- a/apps/cookbook/src/app/examples/empty-state-example/examples/buttons.ts
+++ b/apps/cookbook/src/app/examples/empty-state-example/examples/buttons.ts
@@ -3,7 +3,6 @@ import { Component } from '@angular/core';
 const config = {
   template: `<kirby-empty-state
   iconName="kirby"
-  title="Empty"
   title="Button attention levels"
   subtitle="Additional messaging via subtitle"
 >

--- a/apps/cookbook/src/app/examples/empty-state-example/examples/buttons.ts
+++ b/apps/cookbook/src/app/examples/empty-state-example/examples/buttons.ts
@@ -1,0 +1,22 @@
+import { Component } from '@angular/core';
+
+const config = {
+  template: `<kirby-empty-state
+  iconName="kirby"
+  title="Empty"
+  title="Button attention levels"
+  subtitle="Additional messaging via subtitle"
+>
+  <button kirby-button attentionLevel="1">Primary action</button>
+  <button kirby-button attentionLevel="2">Secondary action</button>
+</kirby-empty-state>
+`,
+};
+
+@Component({
+  selector: 'cookbook-empty-state-buttons-example',
+  template: config.template,
+})
+export class EmptyStateButtonsExampleComponent {
+  template: string = config.template;
+}

--- a/apps/cookbook/src/app/examples/empty-state-example/examples/empty-state-example.shared.scss
+++ b/apps/cookbook/src/app/examples/empty-state-example/examples/empty-state-example.shared.scss
@@ -1,0 +1,18 @@
+@use 'sass:map';
+@use '@kirbydesign/core/src/scss/utils';
+
+:host {
+  display: block;
+  container-type: inline-size;
+  padding: 0 1rem;
+}
+
+.message-type-container {
+  display: flex;
+  gap: 1rem;
+  justify-content: space-around;
+
+  @container (width < #{map.get(utils.$breakpoints, small)}) {
+    flex-direction: column;
+  }
+}

--- a/apps/cookbook/src/app/examples/empty-state-example/examples/message-types.ts
+++ b/apps/cookbook/src/app/examples/empty-state-example/examples/message-types.ts
@@ -14,7 +14,7 @@ const config = {
   subtitle="Additional messaging via subtitle"
 ></kirby-empty-state>
 <kirby-empty-state
-  iconName="kirby"
+  iconName="overview-outline"
   title="Empty"
   subtitle="Additional messaging via subtitle"
 ></kirby-empty-state>`,

--- a/apps/cookbook/src/app/examples/empty-state-example/examples/message-types.ts
+++ b/apps/cookbook/src/app/examples/empty-state-example/examples/message-types.ts
@@ -1,37 +1,31 @@
 import { Component } from '@angular/core';
 
 const config = {
-  template: `<kirby-empty-state
-  iconName="verify"
-  themeColor="success"
-  title="Success"
-  subtitle="Additional messaging via subtitle"
-></kirby-empty-state>
-<kirby-empty-state
-  iconName="help"
-  themeColor="warning"
-  title="Warning"
-  subtitle="Additional messaging via subtitle"
-></kirby-empty-state>
-<kirby-empty-state
-  iconName="overview-outline"
-  title="Empty"
-  subtitle="Additional messaging via subtitle"
-></kirby-empty-state>`,
+  template: `<div class="message-type-container">
+  <kirby-empty-state
+    iconName="verify"
+    themeColor="success"
+    title="Success"
+    subtitle="Additional messaging via subtitle"
+  ></kirby-empty-state>
+  <kirby-empty-state
+    iconName="help"
+    themeColor="warning"
+    title="Warning"
+    subtitle="Additional messaging via subtitle"
+  ></kirby-empty-state>
+  <kirby-empty-state
+    iconName="overview-outline"
+    title="Empty"
+    subtitle="Additional messaging via subtitle"
+  ></kirby-empty-state>
+</div>`,
 };
 
 @Component({
   selector: 'cookbook-empty-state-message-types-example',
   template: config.template,
-  styles: [
-    `
-      :host {
-        display: flex;
-        gap: 2rem;
-        justify-content: space-around;
-      }
-    `,
-  ],
+  styleUrls: ['./empty-state-example.shared.scss'],
 })
 export class EmptyStateMessageTypesExampleComponent {
   template: string = config.template;

--- a/apps/cookbook/src/app/examples/empty-state-example/examples/message-types.ts
+++ b/apps/cookbook/src/app/examples/empty-state-example/examples/message-types.ts
@@ -1,0 +1,38 @@
+import { Component } from '@angular/core';
+
+const config = {
+  template: `<kirby-empty-state
+  iconName="verify"
+  themeColor="success"
+  title="Success"
+  subtitle="Additional messaging via subtitle"
+></kirby-empty-state>
+<kirby-empty-state
+  iconName="help"
+  themeColor="warning"
+  title="Warning"
+  subtitle="Additional messaging via subtitle"
+></kirby-empty-state>
+<kirby-empty-state
+  iconName="kirby"
+  title="Empty"
+  subtitle="Additional messaging via subtitle"
+></kirby-empty-state>`,
+};
+
+@Component({
+  selector: 'cookbook-empty-state-message-types-example',
+  template: config.template,
+  styles: [
+    `
+      :host {
+        display: flex;
+        gap: 2rem;
+        justify-content: space-around;
+      }
+    `,
+  ],
+})
+export class EmptyStateMessageTypesExampleComponent {
+  template: string = config.template;
+}

--- a/apps/cookbook/src/app/examples/empty-state-example/examples/simple.ts
+++ b/apps/cookbook/src/app/examples/empty-state-example/examples/simple.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+
+const config = {
+  template: `<kirby-empty-state
+  title="Simple"
+  subtitle="A subtitle with a &#10; newline inserted in the template."
+>
+  <button kirby-button attentionLevel="1">Resolve state</button>
+</kirby-empty-state>
+`,
+};
+
+@Component({
+  selector: 'cookbook-empty-state-simple-example',
+  template: config.template,
+})
+export class EmptyStateSimpleExampleComponent {
+  template: string = config.template;
+}

--- a/apps/cookbook/src/app/examples/examples.common.ts
+++ b/apps/cookbook/src/app/examples/examples.common.ts
@@ -1,7 +1,6 @@
 import { ActionSheetExampleComponent } from './action-sheet-example/action-sheet-example.component';
 import { AlertExampleComponent } from './alert-example/alert-example.component';
 import { DividerExampleComponent } from './divider-example/divider-example.component';
-import { EmptyStateExampleComponent } from './empty-state-example/empty-state-example.component';
 import { ExamplesComponent } from './examples.component';
 import { FabSheetExampleComponent } from './fab-sheet-example/fab-sheet-example.component';
 import { FlagExampleComponent } from './flag-example/flag-example.component';
@@ -59,7 +58,6 @@ export const COMPONENT_DECLARATIONS: any[] = [
   ActionSheetExampleComponent,
   AlertExampleComponent,
   ToastExampleComponent,
-  EmptyStateExampleComponent,
   LoadingOverlayExampleComponent,
   LoadingOverlayServiceExampleComponent,
   FabSheetExampleComponent,

--- a/apps/cookbook/src/app/examples/examples.module.ts
+++ b/apps/cookbook/src/app/examples/examples.module.ts
@@ -40,6 +40,7 @@ import { ButtonExampleModule } from './button-example/button-example.module';
 import { ExampleConfigurationWrapperComponent } from './example-configuration-wrapper/example-configuration-wrapper.component';
 import { CalendarExampleModule } from './calendar-example/calendar-example.module';
 import { ListNoShapeExampleModule } from './list-no-shape-example/list-no-shape-example.module';
+import { EmptyStateExampleModule } from './empty-state-example/empty-state-example.module';
 
 const IMPORTS = [
   CodeViewerModule,
@@ -77,6 +78,7 @@ const IMPORTS = [
   IconExampleModule,
   ButtonExampleModule,
   ListNoShapeExampleModule,
+  EmptyStateExampleModule,
 ];
 
 @NgModule({

--- a/apps/cookbook/src/app/showcase/_showcase.shared.scss
+++ b/apps/cookbook/src/app/showcase/_showcase.shared.scss
@@ -12,3 +12,14 @@ cookbook-example-viewer,
 cookbook-code-viewer {
   margin-bottom: utils.size('l');
 }
+
+.example-frame {
+  position: relative;
+  border: 1px solid #ddd;
+  border-radius: 12px;
+  padding-block: utils.size('m');
+
+  &.no-vertical-padding {
+    padding-block: 0;
+  }
+}

--- a/apps/cookbook/src/app/showcase/calendar-showcase/calendar-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/calendar-showcase/calendar-showcase.component.scss
@@ -1,10 +1,1 @@
-@use '@kirbydesign/core/src/scss/utils';
 @use '../showcase.shared';
-
-.example-frame {
-  position: relative;
-  margin-bottom: utils.size('xxs');
-  border: 1px solid #ddd;
-  border-radius: 12px;
-  padding-block: utils.size('m');
-}

--- a/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.html
@@ -1,11 +1,23 @@
 <p>
-  The Messaging State component provides feedback about application, content or workflow state to
-  the user while, if possible, giving constructive guidance about next steps.
+  Message State provides feedback about the application, content or workflow state to the user
+  while, if possible, giving constructive guidance about next steps.
+</p>
+
+<kirby-flag themeColor="warning">Notice</kirby-flag>
+<p class="comment">
+  <em>
+    <strong>Empty State</strong>
+    redirects here as the concept has been renamed
+    <strong>Message State</strong>
+    . The component itself, when used in the template, is still called
+    <code>kirby-empty-state</code>
+    and awaits renaming.
+  </em>
 </p>
 
 <h2>Message Types</h2>
 <p>
-  The messaging state supports three different types of messaging with the
+  The message state supports three different types of messaging with the
   <code>themeColor</code>
   input. For each of these, an icon that supports the message should be set with
   <code>iconName</code>
@@ -45,12 +57,12 @@
 <p class="comment">
   <em>
     <strong>Please note:</strong>
-    The messaging state expands horizontally to fill its container, and the title and subtitle area
+    The message state expands horizontally to fill its container, and the title and subtitle area
     grows with it. If text needs to break differently a newline can be added with
   </em>
   <code>\n</code>
   <em>
-    if the text comes from an expression and
+    if the text comes from an expression or
     <code>&amp;#10;</code>
     in case it is written directly in the template.
   </em>

--- a/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.html
@@ -1,8 +1,34 @@
-<div class="example">
-  <cookbook-empty-state-example></cookbook-empty-state-example>
-  <cookbook-code-viewer [html]="exampleHtml"></cookbook-code-viewer>
-  <h4>Properties:</h4>
-  <cookbook-api-description-properties
-    [properties]="properties"
-  ></cookbook-api-description-properties>
-</div>
+<p>
+  The Empty State provides feedback to the user while, if possible, giving constructive guidance
+  about next steps.
+</p>
+<h2>Message Types</h2>
+<p>
+  The empty state supports different types of messages via the
+  <code>themeColor</code>
+  input.
+</p>
+<cookbook-example-viewer [html]="themeColorExample.template">
+  <div class="example-frame">
+    <cookbook-empty-state-message-types-example
+      #themeColorExample
+    ></cookbook-empty-state-message-types-example>
+  </div>
+</cookbook-example-viewer>
+
+<h2>Buttons</h2>
+<p>If the empty state acts as a call to action, one or more buttons can be added.</p>
+<p>
+  If the first button has attention-level 1, that level will be preserved. Any additional buttons
+  will be adjusted to attention-level 3 regardless of their initial attention-level.
+</p>
+<cookbook-example-viewer [html]="buttonsExample.template">
+  <div class="example-frame">
+    <cookbook-empty-state-buttons-example #buttonsExample></cookbook-empty-state-buttons-example>
+  </div>
+</cookbook-example-viewer>
+
+<h2>Properties:</h2>
+<cookbook-api-description-properties
+  [properties]="properties"
+></cookbook-api-description-properties>

--- a/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.html
@@ -74,15 +74,20 @@
   </div>
 </cookbook-example-viewer>
 
-<h2>Multiple Buttons</h2>
+<h2>Buttons</h2>
+
+<p>If you add buttons, the following guidelines apply:</p>
+<ul>
+  <li>A primary button should resolve the state for the user</li>
+  <li>
+    Any secondary buttons should present the user with further guidance or alternative options for
+    resolving the state
+  </li>
+</ul>
 <p>
-  Alternative options for resolving the state or providing further guidance can be added with
-  additional buttons.
-</p>
-<p>
-  If the first button has attention level 1, that level will be preserved. This button should aim to
-  resolve the state for the user. Any additional buttons will be adjusted to attention level 3
-  regardless of their initial level.
+  If the first button has attention level 1, that level will be preserved. This is the button that
+  should aim to resolve the state for the user. Any additional buttons will be adjusted to attention
+  level 3 regardless of their initial level.
 </p>
 <cookbook-example-viewer [html]="buttonsExample.template">
   <div class="example-frame">

--- a/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.html
@@ -1,13 +1,32 @@
 <p>
-  The Empty State provides feedback to the user while, if possible, giving constructive guidance
-  about next steps.
+  The Messaging State component provides feedback about application, content or workflow state to
+  the user while, if possible, giving constructive guidance about next steps.
 </p>
+
 <h2>Message Types</h2>
 <p>
-  The empty state supports different types of messages via the
+  The messaging state supports three different types of messaging with the
   <code>themeColor</code>
-  input.
+  input. For each of these, an icon that supports the message should be set with
+  <code>iconName</code>
+  .
 </p>
+<ul>
+  <li>
+    <strong>Success</strong>
+    - for positive messages like confirmations or receipts on longer flows
+  </li>
+  <li>
+    <strong>Warning</strong>
+    - for warnings, errors or something the user should be particularly aware of
+  </li>
+  <li>
+    <strong>Empty</strong>
+    - for communicating something that is empty, not configured or not used yet—like an inbox
+    without any messages
+  </li>
+</ul>
+
 <cookbook-example-viewer [html]="themeColorExample.template">
   <div class="example-frame">
     <cookbook-empty-state-message-types-example
@@ -16,11 +35,42 @@
   </div>
 </cookbook-example-viewer>
 
-<h2>Buttons</h2>
-<p>If the empty state acts as a call to action, one or more buttons can be added.</p>
+<h2>Simple</h2>
 <p>
-  If the first button has attention-level 1, that level will be preserved. Any additional buttons
-  will be adjusted to attention-level 3 regardless of their initial attention-level.
+  If setting a decorative icon does not add any value to the message, or if space is constrained, a
+  simple variant can be used. It has a title and subtitle, and should be supported by a call to
+  action button.
+</p>
+
+<p class="comment">
+  <em>
+    <strong>Please note:</strong>
+    The messaging state expands horizontally to fill its container, and the title and subtitle area
+    grows with it. If text needs to break differently a newline can be added with
+  </em>
+  <code>\n</code>
+  <em>
+    if the text comes from an expression and
+    <code>&amp;#10;</code>
+    in case it is written directly in the template.
+  </em>
+</p>
+
+<cookbook-example-viewer [html]="simpleExample.template">
+  <div class="example-frame">
+    <cookbook-empty-state-simple-example #simpleExample></cookbook-empty-state-simple-example>
+  </div>
+</cookbook-example-viewer>
+
+<h2>Multiple Buttons</h2>
+<p>
+  Alternative options for resolving the state or providing further guidance can be added with
+  additional buttons.
+</p>
+<p>
+  If the first button has attention level 1, that level will be preserved. This button should aim to
+  resolve the state for the user. Any additional buttons will be adjusted to attention level 3
+  regardless of their initial level.
 </p>
 <cookbook-example-viewer [html]="buttonsExample.template">
   <div class="example-frame">

--- a/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.scss
@@ -1,1 +1,5 @@
 @use '../showcase.shared';
+
+kirby-flag {
+  margin-bottom: var(--kirby-spacing-xxs);
+}

--- a/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.scss
@@ -1,0 +1,10 @@
+@use '@kirbydesign/core/src/scss/utils';
+@use '../showcase.shared';
+
+.example-frame {
+  position: relative;
+  margin-bottom: utils.size('xxs');
+  border: 1px solid #ddd;
+  border-radius: 12px;
+  padding-block: utils.size('m');
+}

--- a/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.scss
@@ -1,10 +1,1 @@
-@use '@kirbydesign/core/src/scss/utils';
 @use '../showcase.shared';
-
-.example-frame {
-  position: relative;
-  margin-bottom: utils.size('xxs');
-  border: 1px solid #ddd;
-  border-radius: 12px;
-  padding-block: utils.size('m');
-}

--- a/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/empty-state-showcase/empty-state-showcase.component.ts
@@ -1,14 +1,12 @@
 import { Component } from '@angular/core';
-import exampleHtml from '../../examples/empty-state-example/empty-state-example.component.html?raw';
 import { ApiDescriptionProperty } from '~/app/shared/api-description/api-description-properties/api-description-properties.component';
 
 @Component({
   selector: 'cookbook-empty-state-showcase',
   templateUrl: './empty-state-showcase.component.html',
+  styleUrl: './empty-state-showcase.component.scss',
 })
 export class EmptyStateShowcaseComponent {
-  exampleHtml = exampleHtml;
-
   properties: ApiDescriptionProperty[] = [
     {
       name: 'iconName',

--- a/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
@@ -10,7 +10,7 @@
     <h2>Default</h2>
 
     <cookbook-example-viewer [html]="defaultExample.template">
-      <div class="header-example">
+      <div class="example-frame no-vertical-padding">
         <cookbook-header-example-default #defaultExample></cookbook-header-example-default>
       </div>
     </cookbook-example-viewer>
@@ -26,7 +26,7 @@
     </p>
     <p>Try rezising the header below and watch how the subtitles wrap and truncate:</p>
     <cookbook-example-viewer [html]="subtitleListExample.template">
-      <div class="header-example">
+      <div class="example-frame no-vertical-padding">
         <cookbook-header-example-subtitle-list
           #subtitleListExample
         ></cookbook-header-example-subtitle-list>
@@ -42,7 +42,7 @@
       in the header which will position the flag correctly and manage spacing.
     </p>
     <cookbook-example-viewer [html]="flagExample.template">
-      <div class="header-example">
+      <div class="example-frame no-vertical-padding">
         <cookbook-header-example-flag #flagExample></cookbook-header-example-flag>
       </div>
     </cookbook-example-viewer>
@@ -57,7 +57,7 @@
       to your custom flag markup.
     </p>
     <cookbook-example-viewer [html]="customFlagExample.template" [css]="customFlagExample.styles">
-      <div class="header-example">
+      <div class="example-frame no-vertical-padding">
         <cookbook-header-example-custom-flag
           #customFlagExample
         ></cookbook-header-example-custom-flag>
@@ -79,7 +79,7 @@
       example below:
     </p>
     <cookbook-example-viewer [html]="valueExample.template">
-      <div class="header-example">
+      <div class="example-frame no-vertical-padding">
         <cookbook-header-example-value #valueExample></cookbook-header-example-value>
       </div>
     </cookbook-example-viewer>
@@ -107,7 +107,7 @@
       </em>
     </p>
     <cookbook-example-viewer [html]="avatarExample.template">
-      <div class="header-example">
+      <div class="example-frame no-vertical-padding">
         <cookbook-header-example-avatar #avatarExample></cookbook-header-example-avatar>
       </div>
     </cookbook-example-viewer>
@@ -120,7 +120,7 @@
       to show progress:
     </p>
     <cookbook-example-viewer [html]="progressCircleExample.template">
-      <div class="header-example">
+      <div class="example-frame no-vertical-padding">
         <cookbook-header-example-progress-circle-with-avatar
           #progressCircleExample
         ></cookbook-header-example-progress-circle-with-avatar>
@@ -151,7 +151,7 @@
       .
     </p>
     <cookbook-example-viewer [html]="titleScalingExample.template">
-      <div class="header-example">
+      <div class="example-frame no-vertical-padding">
         <cookbook-header-example-title-scaling
           #titleScalingExample
         ></cookbook-header-example-title-scaling>
@@ -307,7 +307,7 @@
       [html]="customSectionExample.template"
       [css]="customSectionExample.styles"
     >
-      <div class="header-example">
+      <div class="example-frame no-vertical-padding">
         <cookbook-header-example-custom-section
           #customSectionExample
         ></cookbook-header-example-custom-section>
@@ -360,7 +360,7 @@
     <h2>Combined</h2>
     <p>This example shows all the above options combined:</p>
     <cookbook-example-viewer [html]="combinedExample.template" [css]="combinedExample.styles">
-      <div class="header-example">
+      <div class="example-frame no-vertical-padding">
         <cookbook-header-example-combined #combinedExample></cookbook-header-example-combined>
       </div>
     </cookbook-example-viewer>

--- a/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.scss
@@ -1,11 +1,6 @@
 @use '@kirbydesign/core/src/scss/utils';
+@use '../showcase.shared';
 
 .header-example-container {
   margin-bottom: utils.size('l');
-}
-
-.header-example {
-  margin-bottom: utils.size('xxs');
-  border: 1px solid #ddd;
-  border-radius: 12px;
 }

--- a/apps/cookbook/src/app/showcase/showcase.routes.ts
+++ b/apps/cookbook/src/app/showcase/showcase.routes.ts
@@ -227,8 +227,13 @@ export const routes: Routes = [
         component: SegmentedControlShowcaseComponent,
       },
       {
-        path: 'empty-state',
+        path: 'message-state',
         component: EmptyStateShowcaseComponent,
+      },
+      {
+        path: 'empty-state',
+        redirectTo: 'message-state',
+        pathMatch: 'full',
       },
       {
         path: 'toolbar',

--- a/libs/designsystem/empty-state/src/empty-state.component.stories.ts
+++ b/libs/designsystem/empty-state/src/empty-state.component.stories.ts
@@ -1,12 +1,13 @@
 import { type Meta, moduleMetadata, type StoryObj } from '@storybook/angular';
 import { EmptyStateComponent, EmptyStateModule } from '@kirbydesign/designsystem/empty-state';
+import { EmptyStateExampleModule } from '~/app/examples/empty-state-example/empty-state-example.module';
 
 const meta: Meta<EmptyStateComponent> = {
   component: EmptyStateComponent,
   title: 'Components / Empty State',
   decorators: [
     moduleMetadata({
-      imports: [EmptyStateModule],
+      imports: [EmptyStateModule, EmptyStateExampleModule],
     }),
   ],
 };
@@ -19,4 +20,10 @@ export const EmptyState: Story = {
     title: 'No items',
     subtitle: `You don't have any items. Call support to add some items to your account.`,
   },
+};
+
+export const CookbookExample: Story = {
+  render: () => ({
+    template: `<cookbook-empty-state-example></cookbook-empty-state-example>`,
+  }),
 };


### PR DESCRIPTION
## Which issue does this PR close?

This PR is a docs preburner to #3679 and #3677, where empty-state plays a role in setting the modals label, if used inside the modal. I needed somewhere to document the behavior, so first we need to rewrite the docs page a bit. 

Also added the new example component page to storybook for that sweet sweet visual testing!

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

