### PR TITLE
Button: add `aria-disabled` support

### DIFF
--- a/apps/cookbook/src/app/examples/button-example/button-example.component.html
+++ b/apps/cookbook/src/app/examples/button-example/button-example.component.html
@@ -22,5 +22,8 @@
 <h2>Disabled</h2>
 <cookbook-button-example-disabled></cookbook-button-example-disabled>
 
+<h3>Accessible Disabled Buttons</h3>
+<cookbook-button-example-aria-disabled></cookbook-button-example-aria-disabled>
+
 <h2>Link Button</h2>
 <cookbook-button-example-link></cookbook-button-example-link>

--- a/apps/cookbook/src/app/examples/button-example/button-example.module.ts
+++ b/apps/cookbook/src/app/examples/button-example/button-example.module.ts
@@ -14,6 +14,7 @@ import { ButtonExampleAttentionLevelComponent } from './examples/attention-level
 import { ButtonExampleIconsComponent } from './examples/icons';
 import { ButtonExampleIconOnlyComponent } from './examples/icon-only';
 import { ButtonExampleDisabledComponent } from './examples/disabled';
+import { ButtonExampleAriaDisabledComponent } from './examples/aria-disabled';
 import { ButtonExampleUndecoratedComponent } from './examples/undecorated';
 import { ButtonExampleLinkComponent } from './examples/link';
 
@@ -26,6 +27,7 @@ const COMPONENT_DECLARATIONS = [
   ButtonExampleIconsComponent,
   ButtonExampleIconOnlyComponent,
   ButtonExampleDisabledComponent,
+  ButtonExampleAriaDisabledComponent,
   ButtonExampleUndecoratedComponent,
   ButtonExampleLinkComponent,
 ];

--- a/apps/cookbook/src/app/examples/button-example/examples/aria-disabled.ts
+++ b/apps/cookbook/src/app/examples/button-example/examples/aria-disabled.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+
+const config = {
+  selector: 'cookbook-button-example-aria-disabled',
+  template: `<button kirby-button aria-disabled="true">Aria Disabled</button>
+<a kirby-button aria-disabled="true" href="/">Aria Disabled Link</a>`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+  styleUrl: './_shared.scss',
+})
+export class ButtonExampleAriaDisabledComponent {
+  template: string = config.template;
+}

--- a/apps/cookbook/src/app/showcase/button-showcase/button-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/button-showcase/button-showcase.component.html
@@ -168,7 +168,7 @@
       target="_blank"
       href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled"
     >
-      Read more on aria-disabled on MDN
+      Read more about aria-disabled on MDN
     </a>
   </p>
   <p>

--- a/apps/cookbook/src/app/showcase/button-showcase/button-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/button-showcase/button-showcase.component.html
@@ -142,6 +142,47 @@
     <cookbook-button-example-disabled #disabledExample></cookbook-button-example-disabled>
   </cookbook-example-viewer>
 
+  <h3>Accessible Disabled Buttons</h3>
+  <p>
+    The
+    <code>disabled</code>
+    attribute effectively hides the button from assistive technologies, such as screen readers, by
+    removing the button from the focus order of the web page.
+  </p>
+  <p>
+    In many scenarios it's good practice to expose the button as disabled, but still available for
+    users to find when navigating via the
+    <kbd>Tab</kbd>
+    key.
+    <br />
+    An example of this could be a button that submits a form, but cannot be activated until the form
+    is complete. Using
+    <code>aria-disabled="true"</code>
+    instead of
+    <code>disabled</code>
+    will render the button perceivable but disabled.
+  </p>
+  <p>
+    <a
+      class="kirby-external-icon"
+      target="_blank"
+      href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled"
+    >
+      Read more on aria-disabled on MDN
+    </a>
+  </p>
+  <p>
+    Set the
+    <code>aria-disabled="true"</code>
+    attribute to render the button as disabled and prevent activation (mouse, touch and keyboard),
+    but allow it to be focused:
+  </p>
+  <cookbook-example-viewer [html]="ariaDisabledExample.template">
+    <cookbook-button-example-aria-disabled
+      #ariaDisabledExample
+    ></cookbook-button-example-aria-disabled>
+  </cookbook-example-viewer>
+
   <h2>Link Button</h2>
   <p>
     The kirby-button directive can also be applied to anchor-tags. This will allow use of attributes

--- a/apps/cookbook/src/app/showcase/button-showcase/button-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/button-showcase/button-showcase.component.html
@@ -150,7 +150,7 @@
     removing the button from the focus order of the web page.
   </p>
   <p>
-    In many scenarios it's good practice to expose the button as disabled, but still available for
+    In many scenarios it's good practice to expose the button as disabled, but still make it available for
     users to find when navigating via the
     <kbd>Tab</kbd>
     key.

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -267,7 +267,8 @@ $button-margin: utils.size('xxxs');
     width: 100%;
   }
 
-  &:disabled {
+  &:disabled,
+  &[aria-disabled='true'] {
     color: utils.get-color('semi-dark-shade');
     border-color: transparent;
     pointer-events: none;

--- a/libs/designsystem/button/src/button.component.spec.ts
+++ b/libs/designsystem/button/src/button.component.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
+import { createHostFactory, createKeyboardEvent, SpectatorHost } from '@ngneat/spectator';
 import { MockComponent } from 'ng-mocks';
 
 import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
@@ -84,6 +84,46 @@ describe('ButtonComponent', () => {
         expect(element).toHaveComputedStyle({
           color: getColor('semi-dark', 'shade'),
         });
+      });
+    });
+
+    describe('when aria-disabled=true', () => {
+      beforeEach(() => {
+        element.ariaDisabled = 'true';
+      });
+
+      it('should render with correct background-color', () => {
+        expect(element).toHaveComputedStyle({
+          'background-color': getColor('semi-light'),
+        });
+      });
+
+      it('should render with correct color', () => {
+        expect(element).toHaveComputedStyle({
+          color: getColor('semi-dark', 'shade'),
+        });
+      });
+
+      it('should prevent activation on Enter', () => {
+        const keyDownEvent = createKeyboardEvent('keydown', 'Enter', element);
+        const preventDefaultSpy = spyOn(keyDownEvent, 'preventDefault');
+        const stopImmediatePropagationSpy = spyOn(keyDownEvent, 'stopImmediatePropagation');
+
+        element.dispatchEvent(keyDownEvent);
+
+        expect(preventDefaultSpy).toHaveBeenCalled();
+        expect(stopImmediatePropagationSpy).toHaveBeenCalled();
+      });
+
+      it('should prevent activation on Space', () => {
+        const keyDownEvent = createKeyboardEvent('keydown', 'Space', element);
+        const preventDefaultSpy = spyOn(keyDownEvent, 'preventDefault');
+        const stopImmediatePropagationSpy = spyOn(keyDownEvent, 'stopImmediatePropagation');
+
+        element.dispatchEvent(keyDownEvent);
+
+        expect(preventDefaultSpy).toHaveBeenCalled();
+        expect(stopImmediatePropagationSpy).toHaveBeenCalled();
       });
     });
 

--- a/libs/designsystem/button/src/button.component.ts
+++ b/libs/designsystem/button/src/button.component.ts
@@ -6,6 +6,7 @@ import {
   ContentChild,
   ElementRef,
   HostBinding,
+  HostListener,
   Input,
   Renderer2,
 } from '@angular/core';
@@ -152,6 +153,15 @@ export class ButtonComponent implements AfterContentInit {
       this._isIconLeft =
         this.elementRef.nativeElement.querySelector('.content-layer').firstChild === iconElement;
       this._isIconRight = !this._isIconLeft;
+    }
+  }
+
+  @HostListener('keydown.enter', ['$event'])
+  @HostListener('keydown.space', ['$event'])
+  _onEnterOrSpace(event: KeyboardEvent) {
+    if (this.elementRef.nativeElement.ariaDisabled === 'true') {
+      event.preventDefault();
+      event.stopImmediatePropagation();
     }
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue, but is a pre-burner to #3681 

## What is the new behavior?

Add support for `aria-disabled` on `Button` component:

Setting `aria-disabled="true"` on the `Button` component will render the button as disabled and prevent activation through mouse, touch and keyboard but still allow the button to be focused and therefore percieveable.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

