### PR TITLE
Image Banner: make card same height as parent

### DIFF
--- a/libs/extensions/angular/image-banner/src/image-banner.component.scss
+++ b/libs/extensions/angular/image-banner/src/image-banner.component.scss
@@ -70,6 +70,10 @@ $container-query-breakpoint: 600px;
   object-position: center;
 }
 
+kirby-card {
+  height: 100%;
+}
+
 .main-content-wrapper {
   width: 100%;
   padding: utils.size('xxs');


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3712 

## What is the new behavior?
The nested card always grows to 100% of the image-banner, so it can be controlled from the otuside by setting the image banner height. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

