### PR TITLE
Item: improve keyboard interaction and semantics

### DIFF
--- a/apps/cookbook/src/app/showcase/item-showcase/item-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/item-showcase/item-showcase.component.ts
@@ -13,7 +13,7 @@ export class ItemShowcaseComponent {
   properties: ApiDescriptionProperty[] = [
     {
       name: 'selectable',
-      description: 'If `true`, a native button tag will be rendered and the item will be tappable.',
+      description: 'If `true`, a native button tag will be rendered under the hood and the item will become interactive.',
       defaultValue: 'false',
       type: ['boolean'],
     },

--- a/apps/cookbook/src/app/showcase/item-showcase/item-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/item-showcase/item-showcase.component.ts
@@ -13,7 +13,8 @@ export class ItemShowcaseComponent {
   properties: ApiDescriptionProperty[] = [
     {
       name: 'selectable',
-      description: 'If `true`, a native button tag will be rendered under the hood and the item will become interactive.',
+      description:
+        'If `true`, a native button tag will be rendered under the hood and the item will become interactive.',
       defaultValue: 'false',
       type: ['boolean'],
     },

--- a/apps/cookbook/src/app/showcase/item-showcase/item-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/item-showcase/item-showcase.component.ts
@@ -12,8 +12,8 @@ import {
 export class ItemShowcaseComponent {
   properties: ApiDescriptionProperty[] = [
     {
-      name: 'Selectable',
-      description: 'Make item selectable',
+      name: 'selectable',
+      description: 'If `true`, a native button tag will be rendered and the item will be tappable.',
       defaultValue: 'false',
       type: ['boolean'],
     },

--- a/libs/designsystem/item/src/item.component.html
+++ b/libs/designsystem/item/src/item.component.html
@@ -2,7 +2,7 @@
   lines="none"
   [attr.disabled]="disabled"
   [attr.button]="_renderAsButton ? true : null"
-  detail="false"
+  [detail]="false"
   (mousedown)="onMouseDown($event)"
 >
   <div class="outside" slot="start">

--- a/libs/designsystem/item/src/item.component.html
+++ b/libs/designsystem/item/src/item.component.html
@@ -2,7 +2,6 @@
   lines="none"
   [attr.disabled]="disabled"
   [attr.button]="_isIonicButton ? true : null"
-  [attr.tabindex]="selectable ? null : 0"
   detail="false"
   (mousedown)="onMouseDown($event)"
 >

--- a/libs/designsystem/item/src/item.component.html
+++ b/libs/designsystem/item/src/item.component.html
@@ -1,7 +1,7 @@
 <ion-item
   lines="none"
   [attr.disabled]="disabled"
-  [attr.button]="_isIonicButton ? true : null"
+  [attr.button]="_renderAsButton ? true : null"
   detail="false"
   (mousedown)="onMouseDown($event)"
 >

--- a/libs/designsystem/item/src/item.component.integration.spec.ts
+++ b/libs/designsystem/item/src/item.component.integration.spec.ts
@@ -47,7 +47,7 @@ describe('ItemComponent', () => {
         );
       });
 
-      it('should render general header, data and paragraph elements with correct font-weight', () => {
+      it('should render heading, data and paragraph elements with correct font-weight', () => {
         labelElements
           .filter((e) => !e.attributes.getNamedItem('detail'))
           .forEach((e) => {

--- a/libs/designsystem/item/src/item.component.integration.spec.ts
+++ b/libs/designsystem/item/src/item.component.integration.spec.ts
@@ -65,7 +65,7 @@ describe('ItemComponent', () => {
     });
   });
 
-  describe('when configured with selectable="true" and nested interactive element', () => {
+  describe('when configured with selectable="true"', () => {
     const nestedInteractiveElements = ['kirby-checkbox', 'kirby-radio', 'kirby-toggle'];
     nestedInteractiveElements.forEach((element) => {
       it(`should not render native button when there is a nested ${element}`, async () => {

--- a/libs/designsystem/item/src/item.component.integration.spec.ts
+++ b/libs/designsystem/item/src/item.component.integration.spec.ts
@@ -68,7 +68,7 @@ describe('ItemComponent', () => {
   describe('when configured with selectable="true" and nested interactive element', () => {
     const nestedInteractiveElements = ['kirby-checkbox', 'kirby-radio', 'kirby-toggle'];
     nestedInteractiveElements.forEach((element) => {
-      it(`should not render native button when has nested ${element}`, async () => {
+      it(`should not render native button when there is a nested ${element}`, async () => {
         spectator = createHost(`<kirby-item selectable="true">
           <${element}></${element}>
         </kirby-item>

--- a/libs/designsystem/item/src/item.component.integration.spec.ts
+++ b/libs/designsystem/item/src/item.component.integration.spec.ts
@@ -1,7 +1,9 @@
 import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
 
+import { CheckboxComponent } from '@kirbydesign/designsystem/checkbox';
+import { RadioModule } from '@kirbydesign/designsystem/radio';
+import { ToggleComponent } from '@kirbydesign/designsystem/toggle';
 import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
-
 import { TestHelper } from '@kirbydesign/designsystem/testing';
 
 import { ItemComponent } from './item.component';
@@ -9,22 +11,23 @@ import { LabelComponent } from '.';
 
 const { fontWeight } = DesignTokenHelper;
 
-describe('ItemComponent with LabelComponent', () => {
+describe('ItemComponent', () => {
   let ionItem: HTMLElement;
 
   let spectator: SpectatorHost<ItemComponent>;
   const createHost = createHostFactory({
     component: ItemComponent,
-    imports: [TestHelper.ionicModuleForTest],
+    imports: [TestHelper.ionicModuleForTest, CheckboxComponent, RadioModule, ToggleComponent],
     declarations: [LabelComponent],
   });
 
-  describe('selectable and selected', () => {
-    let labelElements: Element[];
+  describe('with kirby-label', () => {
+    describe('selectable and selected', () => {
+      let labelElements: Element[];
 
-    beforeEach(async () => {
-      spectator = createHost(
-        `
+      beforeEach(async () => {
+        spectator = createHost(
+          `
         <kirby-item selectable="true" selected="true">
           <kirby-label>
             <h3>Title</h3>
@@ -36,28 +39,46 @@ describe('ItemComponent with LabelComponent', () => {
           </kirby-label>
         </kirby-item>
         `
-      );
-      ionItem = spectator.queryHost('ion-label');
-      await TestHelper.whenReady(ionItem);
-      labelElements = spectator.queryAll(
-        'ion-item ion-label > :is(h1, h2, h3, h4, h5, h6, p, data)'
-      );
-    });
+        );
+        ionItem = spectator.queryHost('ion-label');
+        await TestHelper.whenReady(ionItem);
+        labelElements = spectator.queryAll(
+          'ion-item ion-label > :is(h1, h2, h3, h4, h5, h6, p, data)'
+        );
+      });
 
-    it('should render general header, data and paragraph elements with correct font-weight', () => {
-      labelElements
-        .filter((e) => !e.attributes.getNamedItem('detail'))
-        .forEach((e) => {
-          expect(e).toHaveComputedStyle({ 'font-weight': fontWeight('bold') });
-        });
-    });
+      it('should render general header, data and paragraph elements with correct font-weight', () => {
+        labelElements
+          .filter((e) => !e.attributes.getNamedItem('detail'))
+          .forEach((e) => {
+            expect(e).toHaveComputedStyle({ 'font-weight': fontWeight('bold') });
+          });
+      });
 
-    it('should render detail data and paragraph elements with correct font-weight', () => {
-      labelElements
-        .filter((e) => !!e.attributes.getNamedItem('detail'))
-        .forEach((e) => {
-          expect(e).toHaveComputedStyle({ 'font-weight': fontWeight('normal') });
-        });
+      it('should render detail data and paragraph elements with correct font-weight', () => {
+        labelElements
+          .filter((e) => !!e.attributes.getNamedItem('detail'))
+          .forEach((e) => {
+            expect(e).toHaveComputedStyle({ 'font-weight': fontWeight('normal') });
+          });
+      });
+    });
+  });
+
+  describe('when configured with selectable="true" and nested interactive element', () => {
+    const nestedInteractiveElements = ['kirby-checkbox', 'kirby-radio', 'kirby-toggle'];
+    nestedInteractiveElements.forEach((element) => {
+      it(`should not render native button when has nested ${element}`, async () => {
+        spectator = createHost(`<kirby-item selectable="true">
+          <${element}></${element}>
+        </kirby-item>
+        `);
+        ionItem = spectator.queryHost('ion-item');
+        await TestHelper.whenReady(ionItem);
+
+        const nativePart = ionItem.shadowRoot.querySelector('[part="native"]');
+        expect(nativePart.tagName).not.toEqual('BUTTON');
+      });
     });
   });
 });

--- a/libs/designsystem/item/src/item.component.spec.ts
+++ b/libs/designsystem/item/src/item.component.spec.ts
@@ -33,6 +33,14 @@ describe('ItemComponent', () => {
     });
   });
 
+  it('should not render a native button by default', async () => {
+    const ionItem = spectator.queryHost('ion-item');
+    await TestHelper.whenReady(ionItem);
+
+    const nativePart = ionItem.shadowRoot.querySelector('[part="native"]');
+    expect(nativePart.tagName).not.toEqual('BUTTON');
+  });
+
   describe('when configured with size', () => {
     describe('and size = xs', () => {
       it('should have correct item height and padding', () => {
@@ -226,6 +234,26 @@ describe('ItemComponent', () => {
       spectator.detectChanges();
 
       expect(spectator.element).toHaveComputedStyle({ 'pointer-events': 'none' });
+    });
+  });
+
+  describe('when configured with selectable', () => {
+    it('should not render a native button when selectable="false"', async () => {
+      spectator.setInput('selectable', false);
+      const ionItem = spectator.queryHost('ion-item');
+      await TestHelper.whenReady(ionItem);
+
+      const nativePart = ionItem.shadowRoot.querySelector('[part="native"]');
+      expect(nativePart.tagName).not.toEqual('BUTTON');
+    });
+
+    it('should render a native button when selectable="true"', async () => {
+      spectator.setInput('selectable', true);
+      const ionItem = spectator.queryHost('ion-item');
+      await TestHelper.whenReady(ionItem);
+
+      const nativePart = ionItem.shadowRoot.querySelector('[part="native"]');
+      expect(nativePart.tagName).toEqual('BUTTON');
     });
   });
 });

--- a/libs/designsystem/item/src/item.component.ts
+++ b/libs/designsystem/item/src/item.component.ts
@@ -9,6 +9,7 @@ import {
 
 import { CheckboxComponent } from '@kirbydesign/designsystem/checkbox';
 import { RadioComponent } from '@kirbydesign/designsystem/radio';
+import { ToggleComponent } from '@kirbydesign/designsystem/toggle';
 
 export enum ItemSize {
   XS = 'xs',
@@ -46,6 +47,8 @@ export class ItemComponent {
   private checkbox: ElementRef<HTMLElement>;
   @ContentChild(RadioComponent, { static: false, read: ElementRef })
   private radio: ElementRef<HTMLElement>;
+  @ContentChild(ToggleComponent, { static: false, read: ElementRef })
+  private toggle: ElementRef<HTMLElement>;
 
   // Prevent default when inside kirby-dropdown to avoid blurring dropdown:
   onMouseDown(event: MouseEvent) {
@@ -58,8 +61,8 @@ export class ItemComponent {
   }
 
   get _isIonicButton() {
-    // Ionic checks for slotted checkbox and radio
-    // and we shouldn't set the `button` prop in that scenario:
-    return this.selectable && !(this.checkbox || this.radio);
+    // We shouldn't render item as a button if the item contains
+    // nested interactive, i.e. checkbox, radio or toggle:
+    return this.selectable && !(this.checkbox || this.radio || this.toggle);
   }
 }

--- a/libs/designsystem/item/src/item.component.ts
+++ b/libs/designsystem/item/src/item.component.ts
@@ -60,7 +60,7 @@ export class ItemComponent {
     }
   }
 
-  get _isIonicButton() {
+  get _renderAsButton() {
     // We shouldn't render item as a button if the item contains
     // nested interactive, i.e. checkbox, radio or toggle:
     return this.selectable && !(this.checkbox || this.radio || this.toggle);


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3714

## What is the new behavior?

Removes `tabindex` from `ion-item`, as the item should only be focusable if it renders a native button (`[selectable]="true"`) or contains an interactive control (checkbox, radio or toggle).

In both cases the nested controls are focusable out of the box.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

