### PR TITLE
Icon: margin is missing when slotted to the end inside Item

### DIFF
--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -319,7 +319,7 @@ $button-margin: utils.size('xxxs');
 }
 
 :host-context(kirby-item)[slot='end'] {
-  margin-inline-start: utils.size('s');
+  margin-inline: utils.size('s') 0;
 }
 
 :host-context(kirby-dropdown) {

--- a/libs/designsystem/icon/src/icon.component.integration.spec.ts
+++ b/libs/designsystem/icon/src/icon.component.integration.spec.ts
@@ -1,0 +1,51 @@
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
+
+import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
+import { ItemModule } from '@kirbydesign/designsystem/item';
+
+import { TestHelper } from '@kirbydesign/designsystem/testing';
+import { IconComponent } from './icon.component';
+import { IconModule } from './icon.module';
+
+const size = DesignTokenHelper.size;
+
+describe('IconComponent in Item', () => {
+  let spectator: SpectatorHost<IconComponent>;
+
+  const createHost = createHostFactory({
+    component: IconComponent,
+    imports: [IconModule, ItemModule],
+  });
+
+  describe('slotted start', () => {
+    beforeEach(async () => {
+      spectator = createHost(`<kirby-item>
+        <kirby-icon slot="start"></kirby-icon>
+      </kirby-item>`);
+      const ionItem = spectator.queryHost('ion-item');
+      await TestHelper.whenReady(ionItem);
+    });
+
+    it(`should have correct vertical spacing`, () => {
+      expect(spectator.element).toHaveComputedStyle({
+        'margin-inline-end': size('xxs'),
+      });
+    });
+  });
+
+  describe('slotted end', () => {
+    beforeEach(async () => {
+      spectator = createHost(`<kirby-item>
+        <kirby-icon slot="end"></kirby-icon>
+      </kirby-item>`);
+      const ionItem = spectator.queryHost('ion-item');
+      await TestHelper.whenReady(ionItem);
+    });
+
+    it(`should have correct vertical spacing`, () => {
+      expect(spectator.element).toHaveComputedStyle({
+        'margin-inline-start': size('xxs'),
+      });
+    });
+  });
+});

--- a/libs/designsystem/item/src/item.component.scss
+++ b/libs/designsystem/item/src/item.component.scss
@@ -47,7 +47,6 @@
     }
 
     @include utils.slotted('[slot="end"]') {
-      margin-inline: 0;
       text-align: end;
 
       kirby-label {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3722

## What is the new behavior?

Ensures correct margin on `Icon` when slotted the end inside `Item`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

