### PR TITLE
Dropdown: fix z-index for overlayed card

### DIFF
--- a/apps/cookbook/src/app/examples/dropdown-example/dropdown-example.module.ts
+++ b/apps/cookbook/src/app/examples/dropdown-example/dropdown-example.module.ts
@@ -2,8 +2,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 
-import { KirbyModule } from '@kirbydesign/designsystem';
-
+import { ButtonComponent } from '@kirbydesign/designsystem/button';
+import { CardModule } from '@kirbydesign/designsystem/card';
+import { DropdownModule } from '@kirbydesign/designsystem/dropdown';
+import { IconModule } from '@kirbydesign/designsystem/icon';
+import { CheckboxComponent } from '@kirbydesign/designsystem/checkbox';
+import { ToastController, ToastHelper } from '@kirbydesign/designsystem/toast';
 import { DropdownExampleConfigurationComponent } from './dropdown-example-configuration-component/dropdown-example-configuration.component';
 import { DropdownExampleAttentionLevelComponent } from './examples/attention-level';
 import { DropdownExampleCustomItemTemplateComponent } from './examples/custom-item-template';
@@ -14,8 +18,10 @@ import { DropdownExampleNgFormsComponent } from './examples/ng-forms';
 import { DropdownExamplePreSelectedComponent } from './examples/pre-selected';
 import { DropdownExampleRightAlignedComponent } from './examples/right-aligned';
 import { DropdownExampleScrollComponent } from './examples/scroll';
+import { DropdownExampleComponent } from './dropdown-example.component';
 
 const COMPONENT_DECLARATIONS = [
+  DropdownExampleComponent,
   DropdownExampleConfigurationComponent,
   DropdownExampleDefaultComponent,
   DropdownExampleScrollComponent,
@@ -29,7 +35,16 @@ const COMPONENT_DECLARATIONS = [
 ];
 
 @NgModule({
-  imports: [CommonModule, KirbyModule, ReactiveFormsModule],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    ButtonComponent,
+    CardModule,
+    DropdownModule,
+    IconModule,
+    CheckboxComponent,
+  ],
+  providers: [ToastHelper, ToastController],
   declarations: COMPONENT_DECLARATIONS,
   exports: COMPONENT_DECLARATIONS,
 })

--- a/apps/cookbook/src/app/examples/examples.common.ts
+++ b/apps/cookbook/src/app/examples/examples.common.ts
@@ -37,7 +37,6 @@ import { TabExampleMenuComponent } from './tabs-example/tab/tab-example-menu.com
 import { TabsExampleComponent } from './tabs-example/tabs-example.component';
 import { ToastExampleComponent } from './toast-example/toast-example.component';
 import { PagePullToRefreshExampleComponent } from './page-example/pull-to-refresh/page-pull-to-refresh-example.component';
-import { DropdownExampleComponent } from './dropdown-example/dropdown-example.component';
 import { LoadingOverlayServiceExampleComponent } from './loading-overlay-example/service/loading-overlay-service-example.component';
 import { HeaderWithActionGroupExampleComponent } from './header-example/examples/action-group';
 import { HeaderWithEmphasizedActionGroupExampleComponent } from './header-example/examples/emphasize-actions';
@@ -81,7 +80,6 @@ export const COMPONENT_DECLARATIONS: any[] = [
   TabExampleMenuComponent,
   DividerExampleComponent,
   ReorderListExampleComponent,
-  DropdownExampleComponent,
   ProgressCircleExampleComponent,
   FlagExampleComponent,
   SlidesSimpleExampleComponent,

--- a/libs/core/src/scss/interaction-state/_focus.scss
+++ b/libs/core/src/scss/interaction-state/_focus.scss
@@ -95,5 +95,4 @@
     #{$shadow},
     0 0 0 $gap #{utils.get-color('background-color')},
     0 0 0 $gap + $stroke-width utils.$focus-ring-color;
-  z-index: utils.z('default');
 }

--- a/libs/designsystem/calendar/src/calendar.component.scss
+++ b/libs/designsystem/calendar/src/calendar.component.scss
@@ -91,6 +91,11 @@ td {
   height: $day-width;
   margin: utils.size('xxxs') 0;
   font-size: utils.font-size('n');
+
+  &:focus {
+    // In narrow viewports where buttons sit side-by-side, ensure focus ring is on top of adjacent buttons.
+    z-index: utils.z('default');
+  }
 }
 
 button[aria-disabled='true'] {

--- a/libs/designsystem/dropdown/src/dropdown.component.stories.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.stories.ts
@@ -1,12 +1,14 @@
 import { type Meta, moduleMetadata, type StoryObj } from '@storybook/angular';
 import { DropdownComponent, DropdownModule } from '@kirbydesign/designsystem/dropdown';
 
+import { DropdownExampleModule } from '~/app/examples/dropdown-example/dropdown-example.module';
+
 const meta: Meta<DropdownComponent> = {
   component: DropdownComponent,
   title: 'Components / Dropdown',
   decorators: [
     moduleMetadata({
-      imports: [DropdownModule],
+      imports: [DropdownModule, DropdownExampleModule],
     }),
   ],
   argTypes: {
@@ -60,4 +62,10 @@ export const Dropdown: Story = {
       control: { type: 'number' },
     },
   },
+};
+
+export const CookbookExample: Story = {
+  render: () => ({
+    template: `<cookbook-dropdown-example></cookbook-dropdown-example>`,
+  }),
 };

--- a/libs/designsystem/dropdown/src/dropdown.component.stories.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.stories.ts
@@ -70,15 +70,6 @@ export const CookbookExample: Story = {
   render: () => ({
     template: `<cookbook-dropdown-example></cookbook-dropdown-example>`,
   }),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    const dropdown = canvas.getByRole('button', {
-      name: 'Dropdown with plain text',
-    });
-
-    await userEvent.click(dropdown);
-  },
 };
 
 export const CookbookExampleWithActions: Story = {

--- a/libs/designsystem/dropdown/src/dropdown.component.stories.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.stories.ts
@@ -1,16 +1,19 @@
-import { type Meta, moduleMetadata, type StoryObj } from '@storybook/angular';
+import { argsToTemplate, type Meta, moduleMetadata, type StoryObj } from '@storybook/angular';
 import { userEvent, within } from '@storybook/test';
 
 import { DropdownComponent, DropdownModule } from '@kirbydesign/designsystem/dropdown';
 
+import { ButtonComponent } from '@kirbydesign/designsystem/button';
 import { DropdownExampleModule } from '~/app/examples/dropdown-example/dropdown-example.module';
+
+const items = ['Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5'];
 
 const meta: Meta<DropdownComponent> = {
   component: DropdownComponent,
   title: 'Components / Dropdown',
   decorators: [
     moduleMetadata({
-      imports: [DropdownModule, DropdownExampleModule],
+      imports: [DropdownModule, ButtonComponent, DropdownExampleModule],
     }),
   ],
   argTypes: {
@@ -31,7 +34,7 @@ type Story = StoryObj<DropdownComponent>;
 
 export const Dropdown: Story = {
   args: {
-    items: ['Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5'],
+    items: items,
     placeholder: 'Please select:',
     itemTextProperty: 'text',
     attentionLevel: '3',
@@ -66,21 +69,32 @@ export const Dropdown: Story = {
   },
 };
 
+export const DropdownOpened: Story = {
+  args: {
+    items: items,
+    selectedIndex: 0,
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <kirby-dropdown ${argsToTemplate(args)}></kirby-dropdown>
+      <br />
+      <button kirby-button>Button - below</button>
+    `,
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const dropdownToOpen = canvas.getByRole('button', {
+      name: 'Item 1',
+    });
+
+    await userEvent.click(dropdownToOpen);
+  },
+};
+
 export const CookbookExample: Story = {
   render: () => ({
     template: `<cookbook-dropdown-example></cookbook-dropdown-example>`,
   }),
-};
-
-export const CookbookExampleWithActions: Story = {
-  ...CookbookExample,
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    const dropdownBtn = canvas.getByRole('button', {
-      name: 'Dropdown with plain text',
-    });
-
-    await userEvent.click(dropdownBtn);
-  },
 };

--- a/libs/designsystem/dropdown/src/dropdown.component.stories.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.stories.ts
@@ -1,4 +1,6 @@
 import { type Meta, moduleMetadata, type StoryObj } from '@storybook/angular';
+import { userEvent, within } from '@storybook/test';
+
 import { DropdownComponent, DropdownModule } from '@kirbydesign/designsystem/dropdown';
 
 import { DropdownExampleModule } from '~/app/examples/dropdown-example/dropdown-example.module';
@@ -68,4 +70,26 @@ export const CookbookExample: Story = {
   render: () => ({
     template: `<cookbook-dropdown-example></cookbook-dropdown-example>`,
   }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const dropdown = canvas.getByRole('button', {
+      name: 'Dropdown with plain text',
+    });
+
+    await userEvent.click(dropdown);
+  },
+};
+
+export const CookbookExampleWithActions: Story = {
+  ...CookbookExample,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const dropdownBtn = canvas.getByRole('button', {
+      name: 'Dropdown with plain text',
+    });
+
+    await userEvent.click(dropdownBtn);
+  },
 };


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3725 

## What is the new behavior?
Card is displayed on top of other content when dropdown is opened.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

