### PR TITLE
Calendar: fix wrong date when using keyboard nav and UTC timezone

### DIFF
--- a/libs/designsystem/calendar/src/calendar.component.spec.ts
+++ b/libs/designsystem/calendar/src/calendar.component.spec.ts
@@ -879,6 +879,16 @@ describe('CalendarComponent', () => {
 
       expect(spectator.component.selectedDate).toEqual(localMidnightDate('1997-08-14'));
     });
+
+    it('should set focussedDate to midnight of focussed date when using UTC', () => {
+      spectator.setInput('timezone', 'UTC');
+      spectator.setInput('selectedDate', utcMidnightDate('1997-08-29'));
+
+      const focussedDay = spectator.query('.focussed');
+      spectator.dispatchKeyboardEvent(focussedDay, 'keydown', 'ArrowRight');
+
+      expect(spectator.component['focussedDate']).toEqual(utcMidnightDate('1997-08-30'));
+    });
   });
 
   // constants and utility functions

--- a/libs/designsystem/calendar/src/calendar.component.ts
+++ b/libs/designsystem/calendar/src/calendar.component.ts
@@ -547,6 +547,8 @@ export class CalendarComponent implements OnInit, OnChanges {
   private focusDate(newDate: Date | null) {
     if (!newDate) return;
 
+    newDate = this.normalizeDate(newDate);
+
     if (this.timezone === 'UTC') {
       newDate = zonedTimeToUtc(this.subtractTimezoneOffset(newDate), this.timeZoneName);
     }


### PR DESCRIPTION
## Which issue does this PR close?
This PR closes #3743

## What is the new behavior?
We normalize the date before setting focussed date, to ensure that timezone difference between local and utc time does not affect focussed day.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

