### PR TITLE
Housekeeping: build workspace library deps before running tests

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -57,6 +57,7 @@
       "cache": true
     },
     "test": {
+      "dependsOn": ["build", "^build"],
       "cache": true
     },
     "e2e": {


### PR DESCRIPTION
When running tests, the projects are not consistently built beforehand. That makes for some funky errors if a build does not yet exist, and a very cluttered log during test script execution.