### PR TITLE
Modal: re-introduce examples routing module to fix the route based modal example in the cookbook

### DIFF
--- a/apps/cookbook/src/app/app.routes.ts
+++ b/apps/cookbook/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { HomeComponent } from './home/home.component';
 import { IntroComponent } from './intro/intro.component';
 import { ExtensionsLandingPageComponent } from './extensions/extensions-landing-page.component';
 import { LocalizationComponent } from './localization/localization.component';
+import { ExamplesRoutingModule } from './examples/examples-routing.module';
 
 export const routes: Routes = [
   {
@@ -69,6 +70,7 @@ export const routes: Routes = [
   },
   {
     path: 'examples',
-    loadChildren: () => import('./examples/examples.routes').then((m) => m.EXAMPLE_ROUTES),
+    loadChildren: () =>
+      import('./examples/examples-routing.module').then((m) => m.ExamplesRoutingModule),
   },
 ];

--- a/apps/cookbook/src/app/app.routes.ts
+++ b/apps/cookbook/src/app/app.routes.ts
@@ -6,7 +6,6 @@ import { HomeComponent } from './home/home.component';
 import { IntroComponent } from './intro/intro.component';
 import { ExtensionsLandingPageComponent } from './extensions/extensions-landing-page.component';
 import { LocalizationComponent } from './localization/localization.component';
-import { ExamplesRoutingModule } from './examples/examples-routing.module';
 
 export const routes: Routes = [
   {
@@ -70,7 +69,6 @@ export const routes: Routes = [
   },
   {
     path: 'examples',
-    loadChildren: () =>
-      import('./examples/examples-routing.module').then((m) => m.ExamplesRoutingModule),
+    loadChildren: () => import('./examples/examples.routes').then((m) => m.EXAMPLE_ROUTES),
   },
 ];

--- a/libs/designsystem/modal/src/modal-navigation.service.ts
+++ b/libs/designsystem/modal/src/modal-navigation.service.ts
@@ -37,26 +37,16 @@ export class ModalNavigationService {
     moduleRootRoutePath?: string
   ): Promise<string[]> {
     const flattenedRoutes: Routes = [].concat(...routeConfig);
-    await this.addLazyLoadedChildRoutes(flattenedRoutes);
 
     let modalRoutes: string[] = [];
     const moduleRootPaths = await this.getModuleRootPath(flattenedRoutes, moduleRootRoutePath);
     if (moduleRootPaths) {
-      modalRoutes = this.getModalRoutePaths(flattenedRoutes, moduleRootPaths);
+      modalRoutes = await this.getModalRoutePaths(flattenedRoutes, moduleRootPaths);
     }
     return modalRoutes;
   }
 
-  private async addLazyLoadedChildRoutes(flattenedRoutes: Routes) {
-    for (const route of flattenedRoutes) {
-      const lazyLoadedRoutes = await this.getLazyLoadedChildRoutes(route);
-      if (lazyLoadedRoutes.length) {
-        flattenedRoutes.push(...lazyLoadedRoutes);
-      }
-    }
-  }
-
-  private async getLazyLoadedChildRoutes(route: Route): Promise<Route[]> {
+  private async getLazyLoadedChildRoutes(route: Route): Promise<Routes> {
     if (route?.loadChildren) {
       const lazyLoadedChildren = await route.loadChildren();
       if (Array.isArray(lazyLoadedChildren)) {
@@ -184,7 +174,7 @@ export class ModalNavigationService {
     return routes.concat(this.getRoutePaths(route.children, currentPath));
   }
 
-  private getModalRoutePath(route: Route, parentPath: string[]): string[] {
+  private async getModalRoutePath(route: Route, parentPath: string[]): Promise<string[]> {
     const modalOutletName = 'modal';
     if (!!route.path && route.outlet === modalOutletName) {
       const modalOutletPath = `(${modalOutletName}:${route.path})`;
@@ -195,13 +185,23 @@ export class ModalNavigationService {
     if (route.path) {
       currentPath.push(route.path);
     }
-    return ([] as string[]).concat(...this.getModalRoutePaths(route.children, currentPath));
+    //If route has lazy loaded childen then get the paths for those children
+    if (route.loadChildren) {
+      return ([] as string[]).concat(
+        await this.getModalRoutePaths(await this.getLazyLoadedChildRoutes(route), currentPath)
+      );
+    }
+    return ([] as string[]).concat(await this.getModalRoutePaths(route.children, currentPath));
   }
 
-  private getModalRoutePaths(routes: Routes, parentPath: string[]): string[] {
-    return Array.isArray(routes)
-      ? ([] as string[]).concat(...routes.map((route) => this.getModalRoutePath(route, parentPath)))
-      : [];
+  private async getModalRoutePaths(routes: Routes, parentPath: string[]): Promise<string[]> {
+    if (!Array.isArray(routes)) {
+      return [];
+    }
+    const modalRoutePaths = await Promise.all(
+      routes.map((route) => this.getModalRoutePath(route, parentPath))
+    );
+    return ([] as string[]).concat(...modalRoutePaths);
   }
 
   private isNewModalWindow(navigationEnd: NavigationEnd): boolean {

--- a/libs/designsystem/modal/src/modal-navigation.service.ts
+++ b/libs/designsystem/modal/src/modal-navigation.service.ts
@@ -37,12 +37,33 @@ export class ModalNavigationService {
     moduleRootRoutePath?: string
   ): Promise<string[]> {
     const flattenedRoutes: Routes = [].concat(...routeConfig);
+    await this.addLazyLoadedChildRoutes(flattenedRoutes);
+
     let modalRoutes: string[] = [];
     const moduleRootPaths = await this.getModuleRootPath(flattenedRoutes, moduleRootRoutePath);
     if (moduleRootPaths) {
       modalRoutes = this.getModalRoutePaths(flattenedRoutes, moduleRootPaths);
     }
     return modalRoutes;
+  }
+
+  private async addLazyLoadedChildRoutes(flattenedRoutes: Routes) {
+    for (const route of flattenedRoutes) {
+      const lazyLoadedRoutes = await this.getLazyLoadedChildRoutes(route);
+      if (lazyLoadedRoutes.length) {
+        flattenedRoutes.push(...lazyLoadedRoutes);
+      }
+    }
+  }
+
+  private async getLazyLoadedChildRoutes(route: Route): Promise<Route[]> {
+    if (route?.loadChildren) {
+      const lazyLoadedChildren = await route.loadChildren();
+      if (Array.isArray(lazyLoadedChildren)) {
+        return lazyLoadedChildren;
+      }
+    }
+    return [];
   }
 
   private async getModuleRootPath(routes: Routes, moduleRootRoutePath?: string): Promise<string[]> {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?
This example didn't work in the cookbook, but now it does.
<img width="1022" alt="image" src="https://github.com/user-attachments/assets/d2c51ace-f955-44c9-863d-ac014442d2f0" />

Re-introduced module based loading of example routes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

