### PR TITLE
Formatting Pipes: added string type to date and time pipe inputs

### DIFF
--- a/libs/extensions/angular/localization/src/date-time/abstract-timezone-compensating.pipe.ts
+++ b/libs/extensions/angular/localization/src/date-time/abstract-timezone-compensating.pipe.ts
@@ -13,12 +13,12 @@ export abstract class AbstractTimezoneCompensatingPipe implements PipeTransform 
 
   abstract transform(value: unknown, ...args: unknown[]): unknown;
 
-  protected format(time: number | Date, formatPattern: string): string {
+  protected format(time: number | Date | string, formatPattern: string): string {
     if (!time) {
       return '';
     }
 
-    const date = typeof time === 'number' ? new Date(time) : time;
+    const date = typeof time === 'number' || typeof time === 'string' ? new Date(time) : time;
 
     const timeZone = this.config.timeZone;
     const options = this.getIntlOptions(formatPattern);

--- a/libs/extensions/angular/localization/src/date-time/date-only/date-only.pipe.ts
+++ b/libs/extensions/angular/localization/src/date-time/date-only/date-only.pipe.ts
@@ -11,7 +11,7 @@ import { DateFormats } from '../date-formats';
   standalone: true,
 })
 export class DateOnlyPipe extends AbstractTimezoneCompensatingPipe implements PipeTransform {
-  transform(input: number | Date): string {
+  transform(input: number | Date | string): string {
     return this.format(input, DateFormats.SHORT_DATE_FORMAT);
   }
 }

--- a/libs/extensions/angular/localization/src/date-time/time-only/time-only.pipe.ts
+++ b/libs/extensions/angular/localization/src/date-time/time-only/time-only.pipe.ts
@@ -18,7 +18,7 @@ export type TimeOnlyFormat = 'short' | 'medium';
   standalone: true,
 })
 export class TimeOnlyPipe extends AbstractTimezoneCompensatingPipe implements PipeTransform {
-  transform(input: number | Date, format: TimeOnlyFormat = 'short'): string {
+  transform(input: number | Date | string, format: TimeOnlyFormat = 'short'): string {
     return this.format(input, this.getFormat(format));
   }
 

--- a/libs/extensions/angular/localization/src/date-time/time-or-date/time-or-date.pipe.ts
+++ b/libs/extensions/angular/localization/src/date-time/time-or-date/time-or-date.pipe.ts
@@ -18,7 +18,7 @@ import { DateFormats } from '../date-formats';
 })
 export class TimeOrDatePipe extends AbstractTimezoneCompensatingPipe implements PipeTransform {
   transform(
-    time: number | Date,
+    time: number | Date | string,
     showSeconds = false,
     formatMonth: 'month-as-digits' | 'month-as-letters' = 'month-as-digits'
   ): string {
@@ -26,7 +26,7 @@ export class TimeOrDatePipe extends AbstractTimezoneCompensatingPipe implements 
       return '';
     }
 
-    const date = typeof time === 'number' ? new Date(time) : time;
+    const date = typeof time === 'number' || typeof time === 'string' ? new Date(time) : time;
 
     const today = new Date();
     const sameDay =

--- a/libs/extensions/angular/localization/src/date-time/time-or-date/time-or-date.stories.ts
+++ b/libs/extensions/angular/localization/src/date-time/time-or-date/time-or-date.stories.ts
@@ -23,12 +23,12 @@ export class TimeOrDateExampleComponent {
   /**
    * An example timestamp to be formatted.
    */
-  @Input() myTimestamp!: number | Date;
+  @Input() myTimestamp!: number | Date | string;
 
   /**
    * The timestamp to be formatted.
    */
-  @Input() tomorrowTimestamp: number | Date = new Date(
+  @Input() tomorrowTimestamp: number | Date | string = new Date(
     new Date().setDate(new Date().getDate() + 1)
   );
 

--- a/libs/extensions/angular/package.json
+++ b/libs/extensions/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kirbydesign/extensions-angular",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "peerDependencies": {
     "@angular/common": "^18.0.0 || ^19.0.0",
     "@angular/compiler": "^18.0.0 || ^19.0.0",


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3786

## What is the new behavior?

Date and time pipes from the Localization extension can now be used with ISO date strings.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

