### PR TITLE
Housekeeping: remove redundant git add in lint-staged config

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,14 +1,11 @@
 {
 	"*.{ts,json,md,scss,html}": [
-		"prettier --write",
-		"git add"
+		"prettier --write"
 	],
 	"*.ts": [
-		"eslint --fix",
-		"git add"
+		"eslint --fix"
 	],
 	"*.scss": [
-		"stylelint --fix",
-		"git add"
+		"stylelint --fix"
 	]
 }


### PR DESCRIPTION

## Which issue does this PR close?

This PR closes no issue, but removes this warning when linting is run for our commits:

> ⚠ Some of your tasks use `git add` command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index.

## What is the new behavior?
`git add` is automatically run on linted files

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No