### PR TITLE
Housekeeping: Remove RXJS version from cookbook and add zone.js to storybook preview.ts

### DIFF
--- a/apps/cookbook/package.json
+++ b/apps/cookbook/package.json
@@ -12,8 +12,7 @@
     "@angular/platform-browser": "^19.1.1",
     "@angular/platform-browser-dynamic": "^19.1.1",
     "@angular/router": "^19.1.1",
-    "prismjs": "1.27.0",
-    "rxjs": "7.8.1"
+    "prismjs": "1.27.0"
   },
   "devDependencies": {
     "@angular-builders/custom-webpack": "^19.0.0",

--- a/libs/designsystem/.storybook/preview.ts
+++ b/libs/designsystem/.storybook/preview.ts
@@ -3,6 +3,8 @@ import { applicationConfig, Preview } from '@storybook/angular';
 import { KirbyIonicModule } from '@kirbydesign/designsystem/kirby-ionic-module';
 import { defaultParameters } from 'tools/storybook-config/shared-config';
 import { IconRegistryService } from '@kirbydesign/designsystem/icon';
+/** Zone JS is required by Angular itself. */
+import 'zone.js';
 
 const preview: Preview = {
   parameters: {

--- a/libs/extensions/angular/.storybook/preview.ts
+++ b/libs/extensions/angular/.storybook/preview.ts
@@ -1,6 +1,8 @@
 import { importProvidersFrom } from '@angular/core';
 import { applicationConfig, Preview } from '@storybook/angular';
 import { setCompodocJson } from '@storybook/addon-docs/angular';
+/** Zone JS is required by Angular itself. */
+import 'zone.js';
 
 import { KirbyIonicModule } from '@kirbydesign/designsystem/kirby-ionic-module';
 import { provideKirbyExtensionsLocalizationToken } from '@kirbydesign/extensions-angular/localization';
@@ -8,6 +10,7 @@ import { provideKirbyExtensionsLocalizationToken } from '@kirbydesign/extensions
 import { defaultParameters } from 'tools/storybook-config/shared-config';
 
 import docJson from '../docs/documentation.json';
+
 setCompodocJson(docJson);
 
 const preview: Preview = {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue, but fixes two problems in the build pipe. 

## What is the new behavior?

1. Remove RXJS dependency version from cookbook since it was starting to cause problems due to not using the same version of RXJS as in the designsystem.
2. Explicitly add `zone.js` to `preview.ts` since storybook now support zoneless testing and thus removed `zone.js` from their own globals file as described here: https://github.com/storybookjs/storybook/issues/30691

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

