### PR TITLE
Message State: Remove article from empty-state

### DIFF
--- a/libs/designsystem/empty-state/src/empty-state.component.html
+++ b/libs/designsystem/empty-state/src/empty-state.component.html
@@ -1,10 +1,8 @@
-<article>
-  <div *ngIf="iconName" class="icon-outline">
-    <kirby-icon [name]="iconName" size="lg"></kirby-icon>
-  </div>
-  <span *ngIf="title" class="title kirby-text-medium">{{ title }}</span>
-  <p *ngIf="subtitle" class="subtitle">{{ subtitle }}</p>
-  <div class="content">
-    <ng-content></ng-content>
-  </div>
-</article>
+<div *ngIf="iconName" class="icon-outline">
+  <kirby-icon [name]="iconName" size="lg"></kirby-icon>
+</div>
+<span *ngIf="title" class="title kirby-text-medium">{{ title }}</span>
+<p *ngIf="subtitle" class="subtitle">{{ subtitle }}</p>
+<div class="content">
+  <ng-content></ng-content>
+</div>

--- a/libs/designsystem/empty-state/src/empty-state.component.scss
+++ b/libs/designsystem/empty-state/src/empty-state.component.scss
@@ -1,6 +1,6 @@
 @use '@kirbydesign/core/src/scss/utils';
 
-article {
+:host {
   max-width: 330px;
   margin: auto;
   display: flex;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3811 

## What is the new behavior?

Removed surrounding `<article></article>` tag from empty-state component, since it is not correct to use article when looking at the definition here: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

