### PR TITLE
Input: pin date-mask font-size to match value

### DIFF
--- a/libs/designsystem/form-field/src/directives/date/date-input.directive.spec.ts
+++ b/libs/designsystem/form-field/src/directives/date/date-input.directive.spec.ts
@@ -3,7 +3,6 @@ import localeDa from '@angular/common/locales/da';
 import { LOCALE_ID } from '@angular/core';
 import { TestHelper } from '@kirbydesign/designsystem/testing';
 import { createDirectiveFactory, SpectatorDirective } from '@ngneat/spectator';
-// eslint-disable-next-line @nx/enforce-module-boundaries
 
 import { InputComponent } from '../../input/input.component';
 
@@ -108,8 +107,20 @@ describe('DateInputDirective', () => {
         expect(datemaskFontFamily).toEqual(inputFontFamily);
       });
 
-      it('should have the same font-size as input', () => {
-        const datemask = spectator.element.parentNode.querySelector('.date-mask');
+      it('should have the same font-size as input by default', () => {
+        const datemask = spectator.element.parentElement.querySelector('.date-mask');
+
+        const inputFontSize = TestHelper.getCssProperty(spectator.element, 'font-size');
+        const datemaskFontSize = TestHelper.getCssProperty(datemask, 'font-size');
+
+        expect(datemaskFontSize).toEqual(inputFontSize);
+      });
+
+      it('should have the same font-size as input regardless of host font-size', () => {
+        const hostElement = spectator.element.parentElement;
+        const datemask = hostElement.querySelector('.date-mask');
+
+        hostElement.style.fontSize = '20px';
 
         const inputFontSize = TestHelper.getCssProperty(spectator.element, 'font-size');
         const datemaskFontSize = TestHelper.getCssProperty(datemask, 'font-size');

--- a/libs/designsystem/form-field/src/input/input.component.scss
+++ b/libs/designsystem/form-field/src/input/input.component.scss
@@ -77,6 +77,7 @@ $padding-block-size-md: shared.$form-field-input-padding * 0.5;
 .date-mask {
   font-family: shared.$form-field-input-font-family;
   line-height: shared.$form-field-input-line-height;
+  font-size: var(--kirby-font-size-n);
   color: var(--kirby-white-contrast);
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Which issue does this PR close?
This PR closes #3876 

## What is the new behavior?
The date masks font-size is always set to match the (hard-coded, non resizeable (until #3586 is fixed)) font size of the input value when using the date-mask.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

