### PR TITLE
Page: fix unnecessary ellipsis on title

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kirbydesign/core",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "description": "Core styles and helpers for the Kirby Design System.",
   "type": "module",
   "main": "dist/index.js",

--- a/libs/core/src/scss/base/_line-clamp.scss
+++ b/libs/core/src/scss/base/_line-clamp.scss
@@ -1,58 +1,7 @@
 .kirby-line-clamp {
-  // Needed both for line-clamp support and for fallback solution
+  /* stylelint-disable value-no-vendor-prefix */
+  display: -webkit-box;
+  -webkit-line-clamp: var(--line-clamp, none);
+  -webkit-box-orient: vertical;
   overflow: hidden;
-
-  // Fallback solution with "explicit ellipsis"
-  // line-height value is expected to be in px unit
-
-  line-height: var(--line-height);
-  max-height: calc(var(--line-clamp) * var(--line-height));
-  position: relative;
-
-  // Ellipsis
-  &::before {
-    content: '…';
-    position: absolute;
-    right: 0;
-    bottom: 0;
-    background-color: var(--kirby-background-color);
-    line-height: var(--line-height);
-    height: var(--line-height);
-  }
-
-  // Cover ellipsis when number of lines is less than or equal to line-clamp value
-  &::after {
-    content: '';
-    position: absolute;
-    right: 0;
-    width: 1em;
-    height: var(--line-height);
-    line-height: var(--line-height);
-    background-color: var(--kirby-background-color);
-  }
-}
-
-// Non-standard line-clamp solution with wide browser support
-// See https://caniuse.com/mdn-css_properties_-webkit-line-clamp
-@supports (-webkit-line-clamp: 1) {
-  .kirby-line-clamp {
-    /* stylelint-disable value-no-vendor-prefix */
-    display: -webkit-box;
-    -webkit-line-clamp: var(--line-clamp, none);
-    -webkit-box-orient: vertical;
-
-    // Work around weird bug by setting visibility
-    // See https://bugs.webkit.org/show_bug.cgi?id=207013
-    // and https://stackoverflow.com/questions/41995229/webkit-line-clamp-does-not-work-on-chrome-unless-i-make-some-unrelated-css-chan
-    visibility: visible;
-
-    // Reset fallback properties that are not needed when support for line-clamp
-    max-height: initial;
-    position: initial;
-
-    &::before,
-    &::after {
-      display: none;
-    }
-  }
 }

--- a/libs/designsystem/package.json
+++ b/libs/designsystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kirbydesign/designsystem",
-  "version": "10.4.0",
+  "version": "10.4.1",
   "description": "The Kirby Design Angular Components.",
   "author": "kirby@bankdata.dk",
   "repository": {

--- a/libs/designsystem/shared/src/fit-heading/fit-heading.directive.ts
+++ b/libs/designsystem/shared/src/fit-heading/fit-heading.directive.ts
@@ -92,7 +92,7 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
 
     if (!this.hostElementClone) {
       this.hostElementClone = this.generateHostElementClone();
-      this.renderer.appendChild(this.elementRef.nativeElement, this.hostElementClone);
+      this.renderer.appendChild(this.elementRef.nativeElement.parentElement, this.hostElementClone);
     }
 
     this.renderer.setStyle(


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3892

## What is the new behavior?
The `FitHeading` directive used for the `titleMaxLines` functionality of page clones the title and uses that clone for available space/measurements of collisions, when re-scaling the title. 

In newer versions of Safari it seems that the clone, even with `position: absolute`, interferes with the box of the actual title, and results in an ellipsis, even when not needed. 

The clone is now added as a sibling to the title element instead, to avoid this problem.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

