### PR TITLE
Form Field Message: Add back support for null to preserve message spacing

### DIFF
--- a/libs/designsystem/form-field/src/form-field.component.ts
+++ b/libs/designsystem/form-field/src/form-field.component.ts
@@ -62,7 +62,7 @@ export class FormFieldComponent
     return this._message;
   }
 
-  set message(value: string) {
+  set message(value: string | null) {
     this._message = value;
     this.setNestedInteractiveElementAttributes();
   }


### PR DESCRIPTION
Added back `null` as a value for message on form-field that was accidentally removed in #3746