### PR TITLE
Checkbox, Radio, Toggle: fix click area expanding outside of element when not in item

### DIFF
--- a/libs/designsystem/checkbox/src/checkbox.component.scss
+++ b/libs/designsystem/checkbox/src/checkbox.component.scss
@@ -176,20 +176,25 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
   }
 
   &.has-hidden-label {
-    position: initial;
+    &:has(ion-checkbox.in-item) {
+      // reset position when checkbox is in item and has hidden label
+      // to ensure that it expands fills out its parent container
+      // so the entire item becomes clickable
+      position: initial;
+
+      ion-checkbox {
+        position: initial;
+
+        &.checkbox-label-placement-start::part(label-text-wrapper),
+        &.checkbox-label-placement-end::part(label-text-wrapper) {
+          margin-inline: 0;
+        }
+      }
+    }
 
     &[slot='end'] {
       ion-checkbox {
         margin-inline-start: $spacing-to-label;
-      }
-    }
-
-    ion-checkbox {
-      position: initial;
-
-      &.in-item.checkbox-label-placement-start::part(label-text-wrapper),
-      &.in-item.checkbox-label-placement-end::part(label-text-wrapper) {
-        margin-inline: 0;
       }
     }
 

--- a/libs/designsystem/checkbox/src/checkbox.component.scss
+++ b/libs/designsystem/checkbox/src/checkbox.component.scss
@@ -178,7 +178,7 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
   &.has-hidden-label {
     &:has(ion-checkbox.in-item) {
       // reset position when checkbox is in item and has hidden label
-      // to ensure that it expands fills out its parent container
+      // to ensure that it fills out its parent container
       // so the entire item becomes clickable
       position: initial;
 

--- a/libs/designsystem/checkbox/src/checkbox.component.spec.ts
+++ b/libs/designsystem/checkbox/src/checkbox.component.spec.ts
@@ -1,4 +1,9 @@
-import { createComponentFactory, Spectator } from '@ngneat/spectator';
+import {
+  createComponentFactory,
+  createHostFactory,
+  Spectator,
+  SpectatorHost,
+} from '@ngneat/spectator';
 
 import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
 
@@ -236,5 +241,42 @@ describe('CheckboxComponent', () => {
       spectator.component.setDisabledState(isDisabled);
       expect(spectator.component.disabled).toBe(isDisabled);
     });
+  });
+});
+
+describe('CheckboxComponent with aria label', () => {
+  const createHost = createHostFactory({
+    component: CheckboxComponent,
+    imports: [TestHelper.ionicModuleForTest],
+  });
+
+  let spectator: SpectatorHost<CheckboxComponent>;
+  let ionCheckbox: HTMLIonCheckboxElement;
+
+  beforeEach(async () => {
+    spectator = createHost(
+      '<kirby-checkbox [text]="text" [attr.aria-label]="ariaLabel"></kirby-checkbox>',
+      {
+        hostProps: {
+          text: 'test',
+          ariaLabel: 'my aria label',
+        },
+      }
+    );
+    ionCheckbox = spectator.query('ion-checkbox');
+    await TestHelper.whenReady(ionCheckbox);
+  });
+
+  it('should have same click area (.hidden-label element) size as ion-checkbox', () => {
+    const hiddenLabel: HTMLElement = ionCheckbox.querySelector('.hidden-label');
+    const hiddenLabelBoundingRect = hiddenLabel.getBoundingClientRect();
+    const ionCheckboxBoundingRect = ionCheckbox.getBoundingClientRect();
+
+    expect(hiddenLabelBoundingRect.height).toBe(ionCheckboxBoundingRect.height);
+    expect(hiddenLabelBoundingRect.width).toBe(ionCheckboxBoundingRect.width);
+    expect(hiddenLabelBoundingRect.left).toBe(ionCheckboxBoundingRect.left);
+    expect(hiddenLabelBoundingRect.right).toBe(ionCheckboxBoundingRect.right);
+    expect(hiddenLabelBoundingRect.top).toBe(ionCheckboxBoundingRect.top);
+    expect(hiddenLabelBoundingRect.bottom).toBe(ionCheckboxBoundingRect.bottom);
   });
 });

--- a/libs/designsystem/radio/src/radio.component.scss
+++ b/libs/designsystem/radio/src/radio.component.scss
@@ -41,24 +41,29 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
   }
 
   &.has-hidden-label {
-    position: initial;
+    &:has(ion-radio.in-item) {
+      // Reset position when radio is in item and has hidden label
+      // to ensure that it fills out its parent container
+      // so the entire item becomes clickable
+      position: initial;
+
+      ion-radio {
+        position: initial;
+
+        &::part(label) {
+          position: initial;
+        }
+
+        &.radio-label-placement-start::part(label-text-wrapper),
+        &.radio-label-placement-end::part(label-text-wrapper) {
+          margin-inline: 0;
+        }
+      }
+    }
 
     &[slot='end'] {
       ion-radio {
         margin-inline-start: $spacing-to-label;
-      }
-    }
-
-    ion-radio {
-      position: initial;
-
-      &::part(label) {
-        position: initial;
-      }
-
-      &.in-item.radio-label-placement-start::part(label-text-wrapper),
-      &.in-item.radio-label-placement-end::part(label-text-wrapper) {
-        margin-inline: 0;
       }
     }
 

--- a/libs/designsystem/radio/src/radio.component.spec.ts
+++ b/libs/designsystem/radio/src/radio.component.spec.ts
@@ -1,4 +1,9 @@
-import { createComponentFactory, Spectator } from '@ngneat/spectator';
+import {
+  createComponentFactory,
+  createHostFactory,
+  Spectator,
+  SpectatorHost,
+} from '@ngneat/spectator';
 
 import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
 
@@ -238,4 +243,41 @@ describe('RadioComponent', () => {
       height: radioIconInnerSize,
     });
   }
+});
+
+describe('RadioComponent with aria label', () => {
+  const createHost = createHostFactory({
+    component: RadioComponent,
+    imports: [TestHelper.ionicModuleForTest, IonRadio],
+  });
+
+  let spectator: SpectatorHost<RadioComponent>;
+  let ionRadio: HTMLIonRadioElement;
+
+  beforeEach(async () => {
+    spectator = createHost(
+      '<kirby-radio [text]="text" [attr.aria-label]="ariaLabel"></kirby-radio>',
+      {
+        hostProps: {
+          text: 'test',
+          ariaLabel: 'my aria label',
+        },
+      }
+    );
+    ionRadio = spectator.query('ion-radio');
+    await TestHelper.whenReady(ionRadio);
+  });
+
+  it('should have same click area (.hidden-label element) size as ion-radio', () => {
+    const hiddenLabel: HTMLElement = ionRadio.querySelector('.hidden-label');
+    const hiddenLabelBoundingRect = hiddenLabel.getBoundingClientRect();
+    const ionRadioBoundingRect = ionRadio.getBoundingClientRect();
+
+    expect(hiddenLabelBoundingRect.height).toBe(ionRadioBoundingRect.height);
+    expect(hiddenLabelBoundingRect.width).toBe(ionRadioBoundingRect.width);
+    expect(hiddenLabelBoundingRect.left).toBe(ionRadioBoundingRect.left);
+    expect(hiddenLabelBoundingRect.right).toBe(ionRadioBoundingRect.right);
+    expect(hiddenLabelBoundingRect.top).toBe(ionRadioBoundingRect.top);
+    expect(hiddenLabelBoundingRect.bottom).toBe(ionRadioBoundingRect.bottom);
+  });
 });

--- a/libs/designsystem/toggle/src/toggle.component.scss
+++ b/libs/designsystem/toggle/src/toggle.component.scss
@@ -14,23 +14,28 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
   }
 
   &.has-hidden-label {
-    position: initial;
+    &:has(ion-toggle.in-item) {
+      // reset position when toggle is in item and has hidden label
+      // to ensure that it expands fills out its parent container
+      // so the entire item becomes clickable
+      position: initial;
+
+      ion-toggle {
+        position: initial;
+
+        &::part(label) {
+          position: initial;
+        }
+
+        &::part(label-text-wrapper) {
+          margin-inline: 0;
+        }
+      }
+    }
 
     &[slot='end'] {
       ion-toggle {
         margin-inline-start: $spacing-to-label;
-      }
-    }
-
-    ion-toggle {
-      position: initial;
-
-      &::part(label) {
-        position: initial;
-      }
-
-      &.in-item::part(label-text-wrapper) {
-        margin-inline: 0;
       }
     }
 

--- a/libs/designsystem/toggle/src/toggle.component.scss
+++ b/libs/designsystem/toggle/src/toggle.component.scss
@@ -16,7 +16,7 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
   &.has-hidden-label {
     &:has(ion-toggle.in-item) {
       // reset position when toggle is in item and has hidden label
-      // to ensure that it expands fills out its parent container
+      // to ensure that it fills out its parent container
       // so the entire item becomes clickable
       position: initial;
 

--- a/libs/designsystem/toggle/src/toggle.component.spec.ts
+++ b/libs/designsystem/toggle/src/toggle.component.spec.ts
@@ -1,4 +1,9 @@
-import { createComponentFactory, Spectator } from '@ngneat/spectator';
+import {
+  createComponentFactory,
+  createHostFactory,
+  Spectator,
+  SpectatorHost,
+} from '@ngneat/spectator';
 import { TestHelper } from '@kirbydesign/designsystem/testing';
 import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
 import { ToggleComponent } from './toggle.component';
@@ -95,5 +100,42 @@ describe('ToggleComponent', () => {
 
       expect(spectator.component.disabled).toBeTrue();
     });
+  });
+});
+
+describe('ToggleComponent with aria label', () => {
+  const createHost = createHostFactory({
+    component: ToggleComponent,
+    imports: [TestHelper.ionicModuleForTest],
+  });
+
+  let spectator: SpectatorHost<ToggleComponent>;
+  let ionToggle: HTMLIonToggleElement;
+
+  beforeEach(async () => {
+    spectator = createHost(
+      '<kirby-toggle [attr.aria-label]="ariaLabel">{{ text }}</kirby-toggle>',
+      {
+        hostProps: {
+          text: 'test',
+          ariaLabel: 'my aria label',
+        },
+      }
+    );
+    ionToggle = spectator.query('ion-toggle');
+    await TestHelper.whenReady(ionToggle);
+  });
+
+  it('should have same click area (.hidden-label element) size as ion-toggle', () => {
+    const hiddenLabel: HTMLElement = ionToggle.querySelector('.hidden-label');
+    const hiddenLabelBoundingRect = hiddenLabel.getBoundingClientRect();
+    const ionToggleBoundingRect = ionToggle.getBoundingClientRect();
+
+    expect(hiddenLabelBoundingRect.height).toBe(ionToggleBoundingRect.height);
+    expect(hiddenLabelBoundingRect.width).toBe(ionToggleBoundingRect.width);
+    expect(hiddenLabelBoundingRect.left).toBe(ionToggleBoundingRect.left);
+    expect(hiddenLabelBoundingRect.right).toBe(ionToggleBoundingRect.right);
+    expect(hiddenLabelBoundingRect.top).toBe(ionToggleBoundingRect.top);
+    expect(hiddenLabelBoundingRect.bottom).toBe(ionToggleBoundingRect.bottom);
   });
 });


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3875 closes #3885 

## What is the new behavior?
We have functionality to reset the position of `ion-checkbox/radio/toggle` and the `kirby-checkbox/radio/toggle` host element, so it is not `position: relative`, in order for a nested click-area with `position: absolute` to expand to fill the entire parent container **_when in an item with a `kirby-label` and/or `aria-label` acting as label_**.

Accidentally, this style reset was not scoped to only happen when in an item, which means that when setting an `aria-label` on a control outside of an item, the click-area expands to the nearest positioned parent (potentially the entire page 😱 ).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

