### PR TITLE
Checkbox, Radio, Toggle: fix screen reader announcement of both visible and aria label

### DIFF
--- a/libs/designsystem/checkbox/src/checkbox.component.html
+++ b/libs/designsystem/checkbox/src/checkbox.component.html
@@ -9,8 +9,8 @@
   [justify]="_justify"
 >
   <span class="hidden-label" *ngIf="_labelText">{{ _labelText }}</span>
-  <span *ngIf="text">{{ text }}</span>
-  <span class="default-content">
+  <span *ngIf="text" [attr.aria-hidden]="_labelText ? true : undefined">{{ text }}</span>
+  <span class="default-content" [attr.aria-hidden]="_labelText ? true : undefined">
     <ng-content></ng-content>
   </span>
 </ion-checkbox>

--- a/libs/designsystem/radio/src/radio.component.html
+++ b/libs/designsystem/radio/src/radio.component.html
@@ -6,8 +6,8 @@
   [justify]="_justify"
 >
   <span class="hidden-label" *ngIf="_labelText">{{ _labelText }}</span>
-  <span *ngIf="text">{{ text }}</span>
-  <span class="default-content">
+  <span *ngIf="text" [attr.aria-hidden]="_labelText ? true : undefined">{{ text }}</span>
+  <span class="default-content" [attr.aria-hidden]="_labelText ? true : undefined">
     <ng-content></ng-content>
   </span>
 </ion-radio>

--- a/libs/designsystem/toggle/src/toggle.component.html
+++ b/libs/designsystem/toggle/src/toggle.component.html
@@ -10,7 +10,7 @@
   [labelPlacement]="_labelPlacement"
 >
   <span class="hidden-label" *ngIf="_labelText">{{ _labelText }}</span>
-  <span class="default-content">
+  <span class="default-content" [attr.aria-hidden]="_labelText ? true : undefined">
     <ng-content></ng-content>
   </span>
 </ion-toggle>


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3883

## What is the new behavior?
Whenever a hidden label (which is a consumer-defined aria-label or a fallback label inferred from any parent item) is present, we make sure to hide the visible label from screen readers, so it it possible to define both a visible label and an alternate aria-label without screen readers announcing both. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

