### PR TITLE
Global Config: Add providers through provideKirby function for backwards compatability

### DIFF
--- a/apps/cookbook/src/main.ts
+++ b/apps/cookbook/src/main.ts
@@ -12,8 +12,9 @@ import { provideHttpClient } from '@angular/common/http';
 import { bootstrapApplication, BrowserModule } from '@angular/platform-browser';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { FormsModule } from '@angular/forms';
-import { IconRegistryService, KirbyModule, provideKirby } from '@kirbydesign/designsystem';
+import { IconRegistryService } from '@kirbydesign/designsystem/icon';
 import { provideRouter, withInMemoryScrolling, withRouterConfig } from '@angular/router';
+import { provideKirby } from '@kirbydesign/designsystem/config';
 import { environment } from './environments/environment';
 
 import { AppComponent } from './app/app.component';
@@ -28,7 +29,7 @@ registerLocaleData(localeData);
 
 bootstrapApplication(AppComponent, {
   providers: [
-    importProvidersFrom(BrowserModule, FormsModule, KirbyModule),
+    importProvidersFrom(BrowserModule, FormsModule),
     provideKirby(),
     provideHttpClient(),
     provideAnimations(),

--- a/libs/designsystem/config/src/provide-kirby.ts
+++ b/libs/designsystem/config/src/provide-kirby.ts
@@ -6,6 +6,16 @@ import {
 } from '@angular/core';
 import { AnimationController, isPlatform, provideIonicAngular } from '@ionic/angular/standalone';
 import type { IonicConfig } from '@ionic/core';
+import { LoadingOverlayService } from '@kirbydesign/designsystem/loading-overlay';
+import {
+  ActionSheetHelper,
+  AlertHelper,
+  CanDismissHelper,
+  ModalController,
+  ModalHelper,
+} from '@kirbydesign/designsystem/modal';
+import { ResizeObserverFactory, ResizeObserverService } from '@kirbydesign/designsystem/shared';
+import { ToastController, ToastHelper } from '@kirbydesign/designsystem/toast';
 
 /**
  * Configuration object for global configuration of Kirby.
@@ -36,6 +46,21 @@ export const KIRBY_CONFIG = new InjectionToken<KirbyConfig>('KIRBY_CONFIG');
  * @param config - Optional configuration for the Kirby design system.
  */
 export function provideKirby(config?: KirbyConfig): EnvironmentProviders {
+  const providers: Provider[] = [
+    ModalController,
+    ActionSheetHelper,
+    ModalHelper,
+    AlertHelper,
+    ToastHelper,
+    ToastController,
+    LoadingOverlayService,
+    ResizeObserverFactory,
+    ResizeObserverService,
+    CanDismissHelper,
+  ];
+
+  if (config) providers.push({ provide: KIRBY_CONFIG, useValue: config });
+
   const shouldHaveNoopAnimation = !isPlatform('hybrid');
 
   // A no-op animation is parsed here when we are not on a native device,
@@ -47,11 +72,11 @@ export function provideKirby(config?: KirbyConfig): EnvironmentProviders {
   const ionicConfig: IonicConfig = {
     mode: 'ios',
     ...navAnimationConfig,
-    // pass the focusManager config on and instruct Ionic to focus the primary heading after each navigation
-    focusManagerPriority: config?.focusManager ? ['heading'] : undefined,
   };
 
-  const providers: Provider[] = config ? [{ provide: KIRBY_CONFIG, useValue: config }] : [];
+  if (config?.focusManager) {
+    ionicConfig.focusManagerPriority = ['heading'];
+  }
 
   // Provide both Kirby and Ionic config as environment providers,
   // to avoid multiple conflicting configurations of global options.

--- a/libs/designsystem/package.json
+++ b/libs/designsystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kirbydesign/designsystem",
-  "version": "10.5.0",
+  "version": "10.5.1",
   "description": "The Kirby Design Angular Components.",
   "author": "kirby@bankdata.dk",
   "repository": {

--- a/libs/designsystem/src/lib/kirby.module.ts
+++ b/libs/designsystem/src/lib/kirby.module.ts
@@ -151,23 +151,10 @@ const allExports = [...exportedModules, ...exportedDeclarations];
 
 const importedModules = [...exportedModules];
 
-const providers = [
-  ModalController,
-  ActionSheetHelper,
-  ModalHelper,
-  AlertHelper,
-  ToastHelper,
-  ToastController,
-  LoadingOverlayService,
-  ResizeObserverFactory,
-  ResizeObserverService,
-  CanDismissHelper,
-];
-
 @NgModule({
   imports: [CommonModule, RouterModule, ...importedModules],
   declarations: [declarations],
-  providers: providers,
+  providers: [provideKirby()],
   exports: [allExports],
 })
 export class KirbyModule {

--- a/package-lock.json
+++ b/package-lock.json
@@ -154,7 +154,7 @@
     },
     "libs/designsystem": {
       "name": "@kirbydesign/designsystem",
-      "version": "10.5.0",
+      "version": "10.5.1",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",

--- a/readme.md
+++ b/readme.md
@@ -68,8 +68,7 @@ export class AppModule {}
 Set up environment providers for Kirby with the `provideKirby()` function:
 
 ```ts
-import { importProvidersFrom } from '@angular/core';
-import { KirbyModule, provideKirby } from '@kirbydesign/designsystem';
+import { provideKirby } from '@kirbydesign/designsystem';
 
 ...
 
@@ -77,7 +76,6 @@ await bootstrapApplication(RootComponent, {
   providers: [
     ...,
     provideKirby() // optionally takes config object, e.g. { focusManager: true, setHtmlDocTitle: true }
-    importProvidersFrom(KirbyModule),
   ]
 });
 ```


### PR DESCRIPTION
## Which issue does this PR close?

This PR follows up on https://github.com/kirbydesign/designsystem/pull/3870

## What is the new behavior?
Providers are now returned by the `provideKirby` environment-provider function. 
This way, it can be reused in `KirbyModule` providers, ensuring proper setup of both Ionic config and Kirby providers.

In addition it is no longer needed to use `importProvidersFrom` with KirbyModule in standalone apps. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

