### PR TITLE
Modal: focus heading after modal is presented

### DIFF
--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.html
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.html
@@ -4,7 +4,7 @@
   (touchstart)="onHeaderTouchStart($event)"
 >
   <ion-toolbar>
-    <ion-title></ion-title>
+    <ion-title role="heading" aria-level="2" tabindex="-1"></ion-title>
     <ion-buttons
       slot="secondary"
       *ngIf="config.flavor === 'drawer' && config.drawerSupplementaryAction"

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
@@ -144,6 +144,14 @@ describe('ModalWrapperComponent', () => {
       const title = rootElement.querySelector('ion-title');
       expect(window.getComputedStyle(title).fontSize).toEqual(DesignTokenHelper.fontSize('n'));
     });
+
+    it('should have programatically focusable heading level 2 as title', async () => {
+      const title = spectator.query('ion-title');
+
+      expect(title.getAttribute('role')).toEqual('heading');
+      expect(title.getAttribute('aria-level')).toEqual('2');
+      expect(title.getAttribute('tabindex')).toEqual('-1');
+    });
   });
 
   describe('sizing', () => {

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
@@ -152,6 +152,16 @@ describe('ModalWrapperComponent', () => {
       expect(title.getAttribute('aria-level')).toEqual('2');
       expect(title.getAttribute('tabindex')).toEqual('-1');
     });
+
+    it('should have focus on ion-title when opened', async () => {
+      const ionTitle = spectator.query('ion-title');
+      await TestHelper.ionComponentOnReady(ionTitle);
+
+      spectator.component['ionModalDidPresent'].next();
+      spectator.component['ionModalDidPresent'].complete();
+
+      expect(document.activeElement).toEqual(ionTitle);
+    });
   });
 
   describe('sizing', () => {

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
@@ -191,6 +191,7 @@ export class ModalWrapperComponent
     this.listenForIonModalWillDismiss();
     this.listenForScroll();
     this.initializeResizeModalToModalWrapper();
+    this.focusModalTitle();
     this.componentPropsInjector = Injector.create({
       providers: [{ provide: COMPONENT_PROPS, useValue: this.config.componentProps }],
       parent: this.injector,
@@ -424,6 +425,14 @@ export class ModalWrapperComponent
       this.setAriaLabelFromTitleContent();
       this.observeTitleContentChanges();
     }
+  }
+
+  private focusModalTitle() {
+    // Focus the title element if content inside modal is not already focussed
+    if (this.elementRef.nativeElement.contains(document.activeElement)) return;
+    this.didPresent.then(() => {
+      this.ionTitleElement?.nativeElement.focus();
+    });
   }
 
   scrollToTop(scrollDuration?: KirbyAnimation.Duration) {

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
@@ -428,9 +428,9 @@ export class ModalWrapperComponent
   }
 
   private focusModalTitle() {
-    // Focus the title element if content inside modal is not already focussed
-    if (this.elementRef.nativeElement.contains(document.activeElement)) return;
-    this.didPresent.then(() => {
+    const focusAlreadyInModal = this.ionModalElement?.contains(document.activeElement);
+    if (focusAlreadyInModal) return;
+    this.ionModalDidPresent.pipe(takeUntil(this.willClose$)).subscribe(() => {
       this.ionTitleElement?.nativeElement.focus();
     });
   }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3904, closes #3866

## What is the new behavior?
If focus is not already inside the modal element, we make sure to focus the title so users of assistive technology lands in the most logical place.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

