### PR TITLE
aria-label and aria live added for voiceover

### DIFF
--- a/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.html
+++ b/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.html
@@ -1,6 +1,11 @@
-<kirby-slide-button [text]="'Slide to unlock'" (slideDone)="showAlert()"></kirby-slide-button>
 <kirby-slide-button
   [text]="'Slide to unlock'"
+  aria-label="Slide to unlock"
+  (slideDone)="showAlert()"
+></kirby-slide-button>
+<kirby-slide-button
+  [text]="'Slide to unlock'"
+  aria-label="Slide to unlock"
   expand="block"
   (slideDone)="showAlert()"
 ></kirby-slide-button>

--- a/libs/designsystem/slide-button/src/slide-button.component.html
+++ b/libs/designsystem/slide-button/src/slide-button.component.html
@@ -10,6 +10,10 @@
     [value]="value"
     max="100"
     [step]="step"
+    [attr.aria-label]="ariaLabel || 'Slide to complete action'"
   />
   <p class="slide-button-text slide-{{ pctInTens }}-pct">{{ text }}</p>
+  <div aria-live="polite" class="visually-hidden">
+    {{ value == 100 ? 'Goal reached' : '' }}
+  </div>
 </div>

--- a/libs/designsystem/slide-button/src/slide-button.component.html
+++ b/libs/designsystem/slide-button/src/slide-button.component.html
@@ -10,10 +10,9 @@
     [value]="value"
     max="100"
     [step]="step"
-    [attr.aria-label]="ariaLabel || 'Slide to complete action'"
   />
   <p class="slide-button-text slide-{{ pctInTens }}-pct">{{ text }}</p>
-  <div aria-live="polite" class="visually-hidden">
-    {{ value == 100 ? 'Goal reached' : '' }}
+  <div aria-live="polite" aria-atomic="true" class="visually-hidden">
+    {{ value == 100 ? 'Goal reached at ' : '' }}
   </div>
 </div>

--- a/libs/designsystem/slide-button/src/slide-button.component.scss
+++ b/libs/designsystem/slide-button/src/slide-button.component.scss
@@ -111,3 +111,12 @@ $slide-button-text-padding: 0 $slide-button-container-radius 0 $total-slider-thu
     pointer-events: none;
   }
 }
+
+.visually-hidden {
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  white-space: nowrap;
+}

--- a/libs/designsystem/slide-button/src/slide-button.component.ts
+++ b/libs/designsystem/slide-button/src/slide-button.component.ts
@@ -20,6 +20,7 @@ import {
 export class SlideButtonComponent implements OnDestroy {
   @Input() text = '';
   @Input() expand: 'block';
+  @Input() ariaLabel: '';
 
   @Output() slideDone = new EventEmitter();
   @Output() slidingPercentageChanged = new EventEmitter<number>();

--- a/libs/designsystem/slide-button/src/slide-button.component.ts
+++ b/libs/designsystem/slide-button/src/slide-button.component.ts
@@ -1,13 +1,17 @@
 import { CommonModule } from '@angular/common';
+import { forwardAttributes } from '@kirbydesign/designsystem/shared';
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ElementRef,
   EventEmitter,
   HostListener,
   Input,
   OnDestroy,
   Output,
+  Renderer2,
 } from '@angular/core';
 
 @Component({
@@ -17,10 +21,9 @@ import {
   styleUrls: ['./slide-button.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SlideButtonComponent implements OnDestroy {
+export class SlideButtonComponent implements OnDestroy, AfterViewInit {
   @Input() text = '';
   @Input() expand: 'block';
-  @Input() ariaLabel: '';
 
   @Output() slideDone = new EventEmitter();
   @Output() slidingPercentageChanged = new EventEmitter<number>();
@@ -40,6 +43,7 @@ export class SlideButtonComponent implements OnDestroy {
   }
 
   private _value: number = 0;
+
   private resetSliderIntervalTimer: any;
   private calculatePctInTens() {
     this.pctInTens = Math.ceil(this.value / 10) * 10;
@@ -49,6 +53,8 @@ export class SlideButtonComponent implements OnDestroy {
   private resetStep() {
     this.step = 1;
   }
+
+  private _attributesToForward = ['aria-label', 'aria-labelledby'];
   public get step() {
     return this._step;
   }
@@ -56,7 +62,20 @@ export class SlideButtonComponent implements OnDestroy {
     this._step = value;
   }
 
-  constructor(private changeDetectionRef: ChangeDetectorRef) {}
+  constructor(
+    private changeDetectionRef: ChangeDetectorRef,
+    private element: ElementRef<HTMLElement>,
+    private renderer: Renderer2
+  ) {}
+
+  ngAfterViewInit(): void {
+    forwardAttributes(
+      this.element.nativeElement,
+      this._attributesToForward,
+      this.renderer,
+      this.element.nativeElement.querySelector('ion-slide-button')
+    );
+  }
 
   ngOnDestroy(): void {
     if (this.resetSliderIntervalTimer) {
@@ -93,6 +112,10 @@ export class SlideButtonComponent implements OnDestroy {
   onSliderValueChange(val: string) {
     this.value = +val;
     this.slidingPercentageChanged.emit(this.value);
+    // If the slider is at the end, trigger change detection to update the aria-live region
+    if (this.value === 100) {
+      this.changeDetectionRef.detectChanges();
+    }
   }
 
   @HostListener('keydown.arrowup', ['$event'])


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3933

## What is the new behavior?

<!-- Added aria-label and aria-live to announce when slider has reached goal-->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

