### PR TITLE
Radio: fixed border-color of disabled state

### DIFF
--- a/libs/designsystem/radio/src/radio.component.scss
+++ b/libs/designsystem/radio/src/radio.component.scss
@@ -20,10 +20,14 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
 
     ion-radio {
       --color: #{utils.get-color('medium')};
-      --color-checked: #{utils.get-color('semi-dark')};
+      --color-checked: #{utils.get-color('medium')};
 
       &::part(container) {
         background-color: utils.get-color('semi-light');
+      }
+
+      &::part(mark) {
+        --color-checked: #{utils.get-color('semi-dark')};
       }
 
       &::part(label-text-wrapper) {

--- a/libs/designsystem/radio/src/radio.component.spec.ts
+++ b/libs/designsystem/radio/src/radio.component.spec.ts
@@ -209,7 +209,7 @@ describe('RadioComponent', () => {
           });
           expect(radioIcon).toHaveComputedStyle({
             'border-width': '1px',
-            'border-color': getColor('semi-dark'),
+            'border-color': getColor('medium'),
             'box-shadow': 'none',
           });
         });


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3912

## What is the new behavior?

Border on disabed checked color changed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

