### PR TITLE
added aria-label to Image Banner anchor tag

### DIFF
--- a/libs/extensions/angular/image-banner/src/image-banner.component.html
+++ b/libs/extensions/angular/image-banner/src/image-banner.component.html
@@ -58,6 +58,7 @@
       </div>
       <!-- On large screens we also show a button-like anchor tag in addition to the entire banner anchor -->
       @if (externalLink) {
+        @let buttonText = actionButtonText ?? translations.get('readMore');
         <a
           kirby-button
           class="main-content-body-action-text"
@@ -66,12 +67,9 @@
           [href]="externalLink"
           target="_blank"
           size="sm"
+          [attr.aria-label]="buttonText"
         >
-          @if (actionButtonText) {
-            {{ actionButtonText }}
-          } @else {
-            {{ translations.get('readMore') }}
-          }
+          {{ buttonText }}
           <kirby-icon name="link"></kirby-icon>
         </a>
       }

--- a/libs/extensions/angular/package.json
+++ b/libs/extensions/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kirbydesign/extensions-angular",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "peerDependencies": {
     "@angular/common": "^18.0.0 || ^19.0.0",
     "@angular/compiler": "^18.0.0 || ^19.0.0",


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3959 

## What is the new behavior?

Adds an aria label to the anchor rendered by the Image Banner extension when configured as an external link.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?
No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

As there are currently no tests or accessibility documentation, I have not implemented either of these as I would have had to add tests and documentation for existing functionality which I consider out of scope of this issue.

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

