### PR TITLE
Modal: fixed focus not correctly restored to activating element on dismiss

### DIFF
--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
@@ -160,6 +160,8 @@ describe('ModalWrapperComponent', () => {
       spectator.component['ionModalDidPresent'].next();
       spectator.component['ionModalDidPresent'].complete();
 
+      await TestHelper.whenTrue(() => document.activeElement !== document.body);
+
       expect(document.activeElement).toEqual(ionTitle);
     });
   });

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
@@ -428,10 +428,16 @@ export class ModalWrapperComponent
   }
 
   private focusModalTitle() {
-    const focusAlreadyInModal = this.ionModalElement?.contains(document.activeElement);
-    if (focusAlreadyInModal) return;
     this.ionModalDidPresent.pipe(takeUntil(this.willClose$)).subscribe(() => {
-      this.ionTitleElement?.nativeElement.focus();
+      // Use queueMicrotask to defer our focus until after Ionic has saved a reference
+      // to the element that should have focus restored when modal is closed.
+      // https://github.com/ionic-team/ionic-framework/blob/v8.6.1/core/src/utils/overlays.ts#L592
+      queueMicrotask(() => {
+        const focusAlreadyInModal = this.ionModalElement?.contains(document.activeElement);
+        if (focusAlreadyInModal) return;
+
+        this.ionTitleElement?.nativeElement.focus();
+      });
     });
   }
 

--- a/libs/designsystem/modal/src/modal/services/modal.helper.spec.ts
+++ b/libs/designsystem/modal/src/modal/services/modal.helper.spec.ts
@@ -124,7 +124,10 @@ describe('ModalHelper', () => {
 
   beforeAll(() => {
     dummyPresentingElement = window.document.createElement('div');
-    dummyPresentingElement.innerHTML = '<h1>Dummy Presenting Element</h1>';
+    dummyPresentingElement.innerHTML = `
+      <h1>Dummy Presenting Element</h1>
+      <button id="focus-btn">Dummy Focusable Button</button>
+    `;
     dummyPresentingElement.style.position = 'absolute';
     dummyPresentingElement.style.top = '0px';
     dummyPresentingElement.style.right = '0px';
@@ -561,6 +564,28 @@ describe('ModalHelper', () => {
 
         expect(ionToolbar).toHaveComputedStyle({ 'padding-top': '0px' });
       });
+    });
+  });
+
+  describe('focus', () => {
+    it('should be restored to the activating button after modal is dismissed', async () => {
+      const focusButton = window.document.getElementById('focus-btn');
+
+      focusButton.focus();
+
+      expect(document.activeElement).toBe(focusButton);
+
+      await openModal(PageTitleEmbeddedComponent);
+      const ionTitle = ionModal.querySelector('ion-title');
+      await TestHelper.ionComponentOnReady(ionTitle);
+
+      // Once opened the modal should take focus
+      expect(document.activeElement).not.toBe(focusButton);
+
+      await overlay.dismiss();
+
+      // After modal is closed, focus should return to the button
+      expect(document.activeElement).toBe(focusButton);
     });
   });
 });


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3963

## What is the new behavior?
We schedule the focus of headings when modals are presented for later, allowing Ionic to save a reference to the active element before focus is moved inside the modal.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

