### PR TITLE
Tooling: ignored co-pilot instructions in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@
 !.vscode/launch.json
 !.vscode/extensions.json
 
+.github/copilot-instructions.md
+
 # misc
 /.angular/cache
 /.sass-cache


### PR DESCRIPTION
Added copilot instructions to .gitignore to allow for custom/local inscructions