### PR TITLE
Alert: Allow dynamic text updates on button texts

### DIFF
--- a/apps/cookbook/src/app/examples/alert-example/alert-example.component.ts
+++ b/apps/cookbook/src/app/examples/alert-example/alert-example.component.ts
@@ -40,8 +40,8 @@ this.modalController.showAlert(config);`;
 const message$ = remainingSeconds$.pipe(
   map((remainingSeconds) => \`Time remaining: \${remainingSeconds}\`)
 );
-const logoutText$ = translationService.translate('logout');
-const takeMeBackText$ = translationService.translate('take_me_back');
+const logoutText$ = this.myTranslationService.get('logout');
+const takeMeBackText$ = this.myTranslationService.get('take_me_back');
 
 const config: AlertConfig = {
   title: title$,
@@ -51,7 +51,7 @@ const config: AlertConfig = {
   },
   message: message$,
   okBtn: logoutText$,
-  cancelBtn: 'takeMeBackText$',
+  cancelBtn: takeMeBackText$,
 };
   
 this.modalController.showAlert(config);`;

--- a/apps/cookbook/src/app/examples/alert-example/alert-example.component.ts
+++ b/apps/cookbook/src/app/examples/alert-example/alert-example.component.ts
@@ -37,22 +37,24 @@ this.modalController.showAlert(config);`;
   private alertClose$: Subject<void> = new Subject<void>();
 
   static readonly alertConfigWithDynamicValues = `const title$ = of('Need more time?');
-  const message$ = remainingSeconds$.pipe(
-    map((remainingSeconds) => \`Time remaining: \${remainingSeconds}\`)
-  );
+const message$ = remainingSeconds$.pipe(
+  map((remainingSeconds) => \`Time remaining: \${remainingSeconds}\`)
+);
+const logoutText$ = translationService.translate('logout');
+const takeMeBackText$ = translationService.translate('take_me_back');
 
-  const config: AlertConfig = {
-    title: title$,
-    icon: {
-      name: 'clock',
-      themeColor: 'warning',
-    },
-    message: message$,
-    okBtn: 'Logout',
-    cancelBtn: 'Take me back',
-  };
+const config: AlertConfig = {
+  title: title$,
+  icon: {
+    name: 'clock',
+    themeColor: 'warning',
+  },
+  message: message$,
+  okBtn: logoutText$,
+  cancelBtn: 'takeMeBackText$',
+};
   
-  this.modalController.showAlert(config);`;
+this.modalController.showAlert(config);`;
   constructor(
     private modalController: ModalController,
     private toastController: ToastController

--- a/apps/cookbook/src/app/showcase/alert-showcase/alert-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/alert-showcase/alert-showcase.component.html
@@ -12,12 +12,17 @@
     <cookbook-code-viewer [ts]="alertConfigWithIcon"></cookbook-code-viewer>
   </p>
   <p>
+    The string properties
     <code>title</code>
-    and
+    ,
     <code>message</code>
-    properties in
+    ,
+    <code>okBtn</code>
+    , and
+    <code>cancelBtn</code>
+    in
     <code>AlertConfig</code>
-    also accept an Observable for dynamic values:
+    also accept an Observable for dynamic values, often used for translation:
     <br />
     <em>
       (see "Example on github" for implementation details of the

--- a/apps/cookbook/src/app/showcase/alert-showcase/alert-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/alert-showcase/alert-showcase.component.ts
@@ -36,13 +36,16 @@ export class AlertShowcaseComponent {
       description:
         '(Optional) Defines the text that will appear on the OK button and if it should be destructive',
       defaultValue: 'OK',
-      type: ['string', '{ text: string, isDestructive: boolean }'],
+      type: [
+        'string | Observable<string>',
+        '{ text: string | Observable<string>, isDestructive: boolean }',
+      ],
     },
     {
       name: 'cancelBtn',
       description:
         '(Optional) The text that will appear on the cancel button. If not defined the cancel button will not be shown.',
-      type: ['string'],
+      type: ['string | Observable<string>'],
     },
   ];
 }

--- a/libs/designsystem/modal/src/modal/alert/alert.component.html
+++ b/libs/designsystem/modal/src/modal/alert/alert.component.html
@@ -13,7 +13,7 @@
       class="cancel-btn"
       (click)="onCancel()"
     >
-      {{ cancelBtn }}
+      {{ cancelBtn$ | async }}
     </button>
     <button
       kirby-button
@@ -23,7 +23,7 @@
       [class.destructive]="okBtnIsDestructive"
       (click)="onOk()"
     >
-      {{ okBtn }}
+      {{ okBtn$ | async }}
     </button>
   </div>
 </article>

--- a/libs/designsystem/modal/src/modal/alert/alert.component.html
+++ b/libs/designsystem/modal/src/modal/alert/alert.component.html
@@ -8,16 +8,16 @@
   <div class="buttongroup">
     <button
       kirby-button
-      *ngIf="cancelBtn"
+      *ngIf="cancelBtn$ | async as cancelBtn"
       attentionLevel="3"
       class="cancel-btn"
       (click)="onCancel()"
     >
-      {{ cancelBtn$ | async }}
+      {{ cancelBtn }}
     </button>
     <button
       kirby-button
-      [size]="cancelBtn ? null : 'lg'"
+      [size]="(cancelBtn$ | async) ? null : 'lg'"
       attentionLevel="1"
       class="ok-btn"
       [class.destructive]="okBtnIsDestructive"

--- a/libs/designsystem/modal/src/modal/alert/alert.component.spec.ts
+++ b/libs/designsystem/modal/src/modal/alert/alert.component.spec.ts
@@ -45,7 +45,6 @@ describe('AlertComponent', () => {
     it('should render', () => {
       const expected = 'Test OK Button Text';
 
-      expect(spectator.component.okBtn).toEqual(expected);
       expect(okButton).toHaveText(expected);
     });
 
@@ -82,7 +81,6 @@ describe('AlertComponent', () => {
     it('should render', () => {
       const expected = 'Test Cancel Button Text';
 
-      expect(spectator.component.cancelBtn).toEqual(expected);
       expect(cancelButton).toHaveText(expected);
     });
 

--- a/libs/designsystem/modal/src/modal/alert/alert.component.ts
+++ b/libs/designsystem/modal/src/modal/alert/alert.component.ts
@@ -14,7 +14,6 @@ import { ThemeColor } from '@kirbydesign/designsystem/helpers';
 import { ThemeColorDirective } from '@kirbydesign/designsystem/shared';
 import { EmptyStateModule } from '@kirbydesign/designsystem/empty-state';
 import { ButtonComponent } from '@kirbydesign/designsystem/button';
-import { ca } from 'date-fns/locale';
 
 @Component({
   imports: [

--- a/libs/designsystem/modal/src/modal/alert/alert.component.ts
+++ b/libs/designsystem/modal/src/modal/alert/alert.component.ts
@@ -14,6 +14,7 @@ import { ThemeColor } from '@kirbydesign/designsystem/helpers';
 import { ThemeColorDirective } from '@kirbydesign/designsystem/shared';
 import { EmptyStateModule } from '@kirbydesign/designsystem/empty-state';
 import { ButtonComponent } from '@kirbydesign/designsystem/button';
+import { ca } from 'date-fns/locale';
 
 @Component({
   imports: [

--- a/libs/designsystem/modal/src/modal/alert/alert.component.ts
+++ b/libs/designsystem/modal/src/modal/alert/alert.component.ts
@@ -43,15 +43,25 @@ export class AlertComponent implements AfterViewInit {
 
   message$: Observable<string>;
   @Input()
-  set message(message: string & Observable<string>) {
+  set message(message: string | Observable<string>) {
     this.message$ = typeof message === 'string' ? of(message) : message;
   }
 
   @Input() iconName: string;
   @Input() iconThemeColor: ThemeColor | `${ThemeColor}`;
-  @Input() okBtn: string;
+
+  okBtn$: Observable<string>;
+  @Input()
+  set okBtn(okBtn: string | Observable<string>) {
+    this.okBtn$ = typeof okBtn === 'string' ? of(okBtn) : okBtn;
+  }
   @Input() okBtnIsDestructive: boolean;
-  @Input() cancelBtn: string;
+
+  cancelBtn$: Observable<string>;
+  @Input()
+  set cancelBtn(cancelBtn: string | Observable<string>) {
+    this.cancelBtn$ = typeof cancelBtn === 'string' ? of(cancelBtn) : cancelBtn;
+  }
 
   constructor(
     private elementRef: ElementRef<HTMLElement>,

--- a/libs/designsystem/modal/src/modal/alert/config/alert-config.ts
+++ b/libs/designsystem/modal/src/modal/alert/config/alert-config.ts
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs';
 export interface AlertConfig {
   title: string | Observable<string>;
   message?: string | Observable<string>;
-  cancelBtn?: string;
+  cancelBtn?: string | Observable<string>;
 
   icon?: {
     name: string;
@@ -12,8 +12,9 @@ export interface AlertConfig {
 
   okBtn?:
     | string
+    | Observable<string>
     | {
-        text: string;
+        text: string | Observable<string>;
         isDestructive: boolean;
       };
 }

--- a/libs/designsystem/modal/src/modal/services/alert.helper.spec.ts
+++ b/libs/designsystem/modal/src/modal/services/alert.helper.spec.ts
@@ -101,34 +101,35 @@ describe('AlertHelper', () => {
   });
 
   describe('getComponentProps', () => {
+    const getComponentProps = (config) => alertHelper['getComponentProps'](config);
     it('should return okBtn as string when okBtn is a string', () => {
       const config = { title: 'test', okBtn: 'OK' };
-      const props = alertHelper.getComponentProps(config);
+      const props = getComponentProps(config);
       expect(props.okBtn).toBe('OK');
     });
 
     it('should return okBtn as observable when okBtn is an observable', () => {
       const okBtnObservable = of('OK');
       const config = { title: 'test', okBtn: okBtnObservable };
-      const props = alertHelper.getComponentProps(config);
+      const props = getComponentProps(config);
       expect(props.okBtn).toEqual(okBtnObservable);
     });
 
     it('should return okBtn as text property when okBtn is an object with text property', () => {
       const config = { title: 'test', okBtn: { text: 'OK', isDestructive: true } };
-      const props = alertHelper.getComponentProps(config);
+      const props = getComponentProps(config);
       expect(props.okBtn).toBe('OK');
     });
 
     it('should return okBtnIsDestructive as true when okBtn is an object with isDestructive set to true', () => {
       const config = { title: 'test', okBtn: { text: 'OK', isDestructive: true } };
-      const props = alertHelper.getComponentProps(config);
+      const props = getComponentProps(config);
       expect(props.okBtnIsDestructive).toBeTrue();
     });
 
     it('should return cancelBtn as string when cancelBtn is a string', () => {
       const config = { title: 'test', okBtn: 'OK' };
-      const props = alertHelper.getComponentProps(config);
+      const props = getComponentProps(config);
       expect(props.okBtn).toBe('OK');
     });
 
@@ -137,7 +138,7 @@ describe('AlertHelper', () => {
         title: 'test',
         icon: { name: 'alert-icon', themeColor: 'danger' },
       };
-      const props = alertHelper.getComponentProps(config);
+      const props = getComponentProps(config);
       expect(props.iconName).toBe('alert-icon');
       expect(props.iconThemeColor).toBe('danger');
     });

--- a/libs/designsystem/modal/src/modal/services/alert.helper.spec.ts
+++ b/libs/designsystem/modal/src/modal/services/alert.helper.spec.ts
@@ -7,6 +7,7 @@ import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
 import { WindowRef } from '@kirbydesign/designsystem/types';
 import { TestHelper } from '@kirbydesign/designsystem/testing';
 
+import { of } from 'rxjs';
 import { Overlay } from '../../modal.interfaces';
 import { AlertHelper } from './alert.helper';
 
@@ -96,6 +97,49 @@ describe('AlertHelper', () => {
       await TestHelper.whenTrue(() => dialogElement.hasAttribute('aria-label'));
 
       expect(dialogElement.getAttribute('aria-label')).toBe(title);
+    });
+  });
+
+  describe('getComponentProps', () => {
+    it('should return okBtn as string when okBtn is a string', () => {
+      const config = { title: 'test', okBtn: 'OK' };
+      const props = alertHelper.getComponentProps(config);
+      expect(props.okBtn).toBe('OK');
+    });
+
+    it('should return okBtn as observable when okBtn is an observable', () => {
+      const okBtnObservable = of('OK');
+      const config = { title: 'test', okBtn: okBtnObservable };
+      const props = alertHelper.getComponentProps(config);
+      expect(props.okBtn).toEqual(okBtnObservable);
+    });
+
+    it('should return okBtn as text property when okBtn is an object with text property', () => {
+      const config = { title: 'test', okBtn: { text: 'OK', isDestructive: true } };
+      const props = alertHelper.getComponentProps(config);
+      expect(props.okBtn).toBe('OK');
+    });
+
+    it('should return okBtnIsDestructive as true when okBtn is an object with isDestructive set to true', () => {
+      const config = { title: 'test', okBtn: { text: 'OK', isDestructive: true } };
+      const props = alertHelper.getComponentProps(config);
+      expect(props.okBtnIsDestructive).toBeTrue();
+    });
+
+    it('should return cancelBtn as string when cancelBtn is a string', () => {
+      const config = { title: 'test', okBtn: 'OK' };
+      const props = alertHelper.getComponentProps(config);
+      expect(props.okBtn).toBe('OK');
+    });
+
+    it('should return iconName and iconThemeColor from config icon', () => {
+      const config = {
+        title: 'test',
+        icon: { name: 'alert-icon', themeColor: 'danger' },
+      };
+      const props = alertHelper.getComponentProps(config);
+      expect(props.iconName).toBe('alert-icon');
+      expect(props.iconThemeColor).toBe('danger');
     });
   });
 });

--- a/libs/designsystem/modal/src/modal/services/alert.helper.ts
+++ b/libs/designsystem/modal/src/modal/services/alert.helper.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { ModalController } from '@ionic/angular/standalone';
+import { isObservable, Observable } from 'rxjs';
 import { Overlay } from '../../modal.interfaces';
 
 import { AlertComponent } from '../alert/alert.component';
@@ -26,27 +27,27 @@ export class AlertHelper {
     };
   }
 
-  private getComponentProps(config: AlertConfig) {
+  public getComponentProps(config: AlertConfig) {
     return {
       ...config,
       okBtn: this.getOkBtn(config),
-      cancelBtn: config.cancelBtn,
       okBtnIsDestructive: this.getOkBtnIsDestructive(config),
       iconName: config.icon && config.icon.name,
       iconThemeColor: config.icon && config.icon.themeColor,
     };
   }
 
-  private getOkBtn(config: AlertConfig) {
-    let text: string;
+  private getOkBtn(config: AlertConfig): string | Observable<string> {
+    let text: string | Observable<string>;
 
     if (config.okBtn) {
-      if (typeof config.okBtn === 'string') {
+      if (typeof config.okBtn === 'string' || isObservable(config.okBtn)) {
         text = config.okBtn;
       } else {
-        text = config.okBtn.text;
+        text = config.okBtn?.text;
       }
     }
+
     return text;
   }
 

--- a/libs/designsystem/modal/src/modal/services/alert.helper.ts
+++ b/libs/designsystem/modal/src/modal/services/alert.helper.ts
@@ -27,7 +27,7 @@ export class AlertHelper {
     };
   }
 
-  public getComponentProps(config: AlertConfig) {
+  private getComponentProps(config: AlertConfig) {
     return {
       ...config,
       okBtn: this.getOkBtn(config),


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3989 

## What is the new behavior?

It is now possible to add observable<string> as argument for ok-button text and cancel-button text.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

