### PR TITLE
Segmented Control: Added optional aria label for segment item

### DIFF
--- a/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
@@ -166,9 +166,7 @@
   </li>
 </ul>
 <h3>
-  Provide custom
-  <code>aria-label</code>
-  for segment buttons
+  Accessible names for segment buttons
 </h3>
 <p>
   The optional

--- a/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
@@ -165,14 +165,20 @@
     <kbd>End</kbd> moves focus to the last segment button
   </li>
 </ul>
-<h3>Provide aria-label for segment buttons</h3>
+<h3>
+  Provide custom
+  <code>aria-label</code>
+  for segment buttons
+</h3>
 <p>
   The optional
   <code>ariaLabel</code>
   property of a
   <code>SegmentItem</code>
-  can be included to provide an aria-label for each segment button. This is useful when the text of
-  the segment button is not descriptive enough on its own.
+  can be included to provide an
+  <code>aria-label</code>
+  for each segment button. This is useful when the text of the segment button is not descriptive
+  enough on its own.
 </p>
 
 <kirby-divider [hasMargin]="true"></kirby-divider>

--- a/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
@@ -165,9 +165,7 @@
     <kbd>End</kbd> moves focus to the last segment button
   </li>
 </ul>
-<h3>
-  Accessible names for segment buttons
-</h3>
+<h3>Accessible names for segment buttons</h3>
 <p>
   The optional
   <code>ariaLabel</code>
@@ -175,7 +173,7 @@
   <code>SegmentItem</code>
   can be included to provide an
   <code>aria-label</code>
-  for one or more segment buttons. This is useful when the text of the segment button is not 
+  for one or more segment buttons. This is useful when the text of the segment button is not
   descriptive enough on its own when used with Assistive Technology like a screen reader.
 </p>
 

--- a/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
@@ -175,8 +175,8 @@
   <code>SegmentItem</code>
   can be included to provide an
   <code>aria-label</code>
-  for each segment button. This is useful when the text of the segment button is not descriptive
-  enough on its own.
+  for one or more segment buttons. This is useful when the text of the segment button is not 
+  descriptive enough on its own when used with Assistive Technology like a screen reader.
 </p>
 
 <kirby-divider [hasMargin]="true"></kirby-divider>

--- a/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.html
@@ -165,6 +165,15 @@
     <kbd>End</kbd> moves focus to the last segment button
   </li>
 </ul>
+<h3>Provide aria-label for segment buttons</h3>
+<p>
+  The optional
+  <code>ariaLabel</code>
+  property of a
+  <code>SegmentItem</code>
+  can be included to provide an aria-label for each segment button. This is useful when the text of
+  the segment button is not descriptive enough on its own.
+</p>
 
 <kirby-divider [hasMargin]="true"></kirby-divider>
 

--- a/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/segmented-control-showcase/segmented-control-showcase.component.ts
@@ -52,6 +52,7 @@ export class SegmentedControlShowcaseComponent {
         `[{
   id: string,
   text: string,
+  ariaLabel?: string,
   badge?: {
     content?: string,
     icon?: string,

--- a/libs/designsystem/src/lib/components/segmented-control/segment-item.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segment-item.ts
@@ -9,5 +9,6 @@ type SegmentItemBadge = {
 export interface SegmentItem {
   id: string;
   text: string;
+  ariaLabel?: string;
   badge?: SegmentItemBadge;
 }

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
@@ -8,6 +8,7 @@
   <ion-segment-button
     *ngFor="let item of items; let i = index"
     [value]="item.id"
+    [attr.aria-label]="item.ariaLabel || item.text"
     [attr.tabindex]="getTabIndex(item, i)"
     (click)="focusNativeButton($event)"
   >

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.html
@@ -8,7 +8,7 @@
   <ion-segment-button
     *ngFor="let item of items; let i = index"
     [value]="item.id"
-    [attr.aria-label]="item.ariaLabel || item.text"
+    [attr.aria-label]="item.ariaLabel"
     [attr.tabindex]="getTabIndex(item, i)"
     (click)="focusNativeButton($event)"
   >

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.spec.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.spec.ts
@@ -382,6 +382,45 @@ describe('SegmentedControlComponent', () => {
     });
   });
 
+  describe('SegmentedControl with ariaLabel', () => {
+    const itemsWithAriaLabel: SegmentItem[] = [
+      {
+        text: 'First Item',
+        id: 'first',
+        ariaLabel: 'First item aria label',
+      },
+      {
+        text: 'Second item',
+        id: 'second',
+      },
+    ];
+
+    let spectator: SpectatorHost<SegmentedControlComponent>;
+
+    const createHost = createHostFactory({
+      component: SegmentedControlComponent,
+      imports: [TestHelper.ionicModuleForTest],
+    });
+
+    beforeEach(() => {
+      spectator = createHost(
+        `<kirby-segmented-control [items]="items">
+         </kirby-segmented-control>`,
+        { hostProps: { items: itemsWithAriaLabel } }
+      );
+    });
+
+    it('should render aria-label on segment button with ariaLabel when defined', () => {
+      const segmentButtons = spectator.queryHostAll('ion-segment-button');
+      expect(segmentButtons[0].getAttribute('aria-label')).toBe(itemsWithAriaLabel[0].ariaLabel);
+    });
+
+    it('should render aria-label on segment button with text when ariaLabel undefined', () => {
+      const segmentButtons = spectator.queryHostAll('ion-segment-button');
+      expect(segmentButtons[1].getAttribute('aria-label')).toBe(null);
+    });
+  });
+
   describe('SegmentedControl with Badge', () => {
     const itemsWithBadge: SegmentItem[] = [
       {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3991 

## What is the new behavior?

This PR adds the option to provide an `aria-label` for the `SegmentItem` in the `SegmentedControlComponent`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Are there any additional context?

None

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

