### PR TITLE
Docs: remove random string generation from slides example

### DIFF
--- a/apps/cookbook/src/app/examples/slides-example/examples/height.ts
+++ b/apps/cookbook/src/app/examples/slides-example/examples/height.ts
@@ -23,14 +23,12 @@ const config = {
 })
 export class SlidesHeightExampleComponent {
   template = config.template;
-  lorem =
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce rhoncus leo quis libero posuere auctor. Quisque ornare lectus finibus tellus sollicitudin, et blandit quam semper. Ut sed lacus eget dui blandit consequat. Nam commodo sit amet augue vel dapibus. Mauris tincidunt nulla eget porttitor euismod. Ut at massa massa. Curabitur suscipit ullamcorper felis, vitae tincidunt eros varius in. Duis et tellus eu turpis varius dictum. Mauris mattis posuere ligula nec pharetra. Vestibulum a augue at nulla elementum fringilla. Duis vehicula finibus turpis, vel dignissim magna ullamcorper vitae. Nam vel elit orci.';
-
-  randomIntegerBetween = (max, min) => Math.floor(Math.random() * (max - min + 1) + min);
+  lorem = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+  additionalLorem = 'Fusce rhoncus leo quis libero posuere auctor.';
 
   slides = [...Array(9).keys()].map((number) => ({
     title: `Slide ${number + 1}`,
     subtitle: `Subtitle ${number + 1}`,
-    cardContent: this.lorem.split(' ').slice(0, this.randomIntegerBetween(6, 12)).join(' '),
+    cardContent: (number + 1) % 2 !== 0 ? this.lorem : this.lorem + this.additionalLorem,
   }));
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue, but is a housekeeping task

## What is the new behavior?
The slides component 'Inherit height' example in the cookbook has long been an issue in visual tests, as a long string is randomly generated on each new render.

So now, we no longer output a string based on random number generation when showcasing the 'inherit height' behavior of slides. Instead, the slides with additional content are determined based on their index.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

