### PR TITLE
Slide Button: Added hidden button below slide button for accessibility

### DIFF
--- a/apps/cookbook/src/app/examples/slide-button-example/examples/expand-block.ts
+++ b/apps/cookbook/src/app/examples/slide-button-example/examples/expand-block.ts
@@ -1,0 +1,38 @@
+import { Component } from '@angular/core';
+import { AlertConfig, ModalController, SlideButtonComponent } from '@kirbydesign/designsystem';
+
+const config = {
+  selector: 'cookbook-expand-block-slide-button-example',
+  template: `<kirby-slide-button
+  [text]="'Slide to confirm'"
+  aria-label="Confirm"
+  expand="block"
+  (slideDone)="showAlert()"
+></kirby-slide-button>
+`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+  imports: [SlideButtonComponent],
+})
+export class ExpandBlockSlideButtonExampleComponent {
+  template: string = config.template;
+
+  constructor(private modalController: ModalController) {}
+
+  showAlert() {
+    const config: AlertConfig = {
+      title: 'Confirmation',
+      message: 'Are you sure you want to proceed?',
+      okBtn: 'Ok',
+      cancelBtn: 'Cancel',
+    };
+    this.modalController.showAlert(config, this.onAlertClosed);
+  }
+
+  private onAlertClosed(selection: boolean) {
+    console.log(`Alert selection: ${selection}`);
+  }
+}

--- a/apps/cookbook/src/app/examples/slide-button-example/examples/simple.ts
+++ b/apps/cookbook/src/app/examples/slide-button-example/examples/simple.ts
@@ -1,0 +1,36 @@
+import { Component } from '@angular/core';
+import { AlertConfig, ModalController, SlideButtonComponent } from '@kirbydesign/designsystem';
+
+const config = {
+  selector: 'cookbook-simple-slide-button-example',
+  template: `<kirby-slide-button
+  [text]="'Slide to confirm'"
+  aria-label="Confirm"
+  (slideDone)="showAlert()"
+></kirby-slide-button>`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+  imports: [SlideButtonComponent],
+})
+export class SimpleSlideButtonExampleComponent {
+  template: string = config.template;
+
+  constructor(private modalController: ModalController) {}
+
+  showAlert() {
+    const config: AlertConfig = {
+      title: 'Confirmation',
+      message: 'Are you sure you want to proceed?',
+      okBtn: 'Ok',
+      cancelBtn: 'Cancel',
+    };
+    this.modalController.showAlert(config, this.onAlertClosed);
+  }
+
+  private onAlertClosed(selection: boolean) {
+    console.log(`Alert selection: ${selection}`);
+  }
+}

--- a/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.html
+++ b/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.html
@@ -1,13 +1,13 @@
-<kirby-slide-button
-  [text]="'Slide to confirm'"
-  aria-label="Confirm"
-  (slideDone)="showAlert()"
-  aria-label="Unlock"
-></kirby-slide-button>
-<kirby-slide-button
-  [text]="'Slide to confirm'"
-  aria-label="Confirm"
-  expand="block"
-  (slideDone)="showAlert()"
-  aria-label="Transfer"
-></kirby-slide-button>
+<div class="example-container">
+  <h1>Slide Button</h1>
+
+  <h2>Simple</h2>
+  <div class="example-frame">
+    <cookbook-simple-slide-button-example></cookbook-simple-slide-button-example>
+  </div>
+
+  <h2>Expand block</h2>
+  <div class="example-frame">
+    <cookbook-expand-block-slide-button-example></cookbook-expand-block-slide-button-example>
+  </div>
+</div>

--- a/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.html
+++ b/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.html
@@ -1,6 +1,11 @@
-<kirby-slide-button [text]="'Slide to unlock'" (slideDone)="showAlert()"></kirby-slide-button>
 <kirby-slide-button
   [text]="'Slide to unlock'"
+  (slideDone)="showAlert()"
+  aria-label="Unlock"
+></kirby-slide-button>
+<kirby-slide-button
+  [text]="'Slide to transfer'"
   expand="block"
   (slideDone)="showAlert()"
+  aria-label="Transfer"
 ></kirby-slide-button>

--- a/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.html
+++ b/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.html
@@ -1,10 +1,12 @@
 <kirby-slide-button
-  [text]="'Slide to unlock'"
+  [text]="'Slide to confirm'"
+  aria-label="Confirm"
   (slideDone)="showAlert()"
   aria-label="Unlock"
 ></kirby-slide-button>
 <kirby-slide-button
-  [text]="'Slide to transfer'"
+  [text]="'Slide to confirm'"
+  aria-label="Confirm"
   expand="block"
   (slideDone)="showAlert()"
   aria-label="Transfer"

--- a/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.scss
+++ b/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.scss
@@ -1,0 +1,1 @@
+@use '../examples.shared';

--- a/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.ts
+++ b/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.ts
@@ -1,30 +1,11 @@
 import { Component } from '@angular/core';
-
-import { AlertConfig, ModalController } from '@kirbydesign/designsystem';
 import { SimpleSlideButtonExampleComponent } from './examples/simple';
 import { ExpandBlockSlideButtonExampleComponent } from './examples/expand-block';
 
-const config = {
-  template: `<kirby-slide-button
-  [text]="'Slide to confirm'"
-  aria-label="Confirm"
-  (slideDone)="showAlert()"
-  aria-label="Unlock"
-></kirby-slide-button>
-<kirby-slide-button
-  [text]="'Slide to confirm'"
-  aria-label="Confirm"
-  expand="block"
-  (slideDone)="showAlert()"
-  aria-label="Transfer"
-></kirby-slide-button>`,
-};
 @Component({
   selector: 'cookbook-slide-button-example',
   templateUrl: './slide-button-example.component.html',
   styleUrl: './slide-button-example.component.scss',
   imports: [SimpleSlideButtonExampleComponent, ExpandBlockSlideButtonExampleComponent],
 })
-export class SlideButtonExampleComponent {
-  template: string = config.template;
-}
+export class SlideButtonExampleComponent {}

--- a/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.ts
+++ b/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.ts
@@ -3,12 +3,29 @@ import { Component } from '@angular/core';
 import { AlertConfig, ModalController } from '@kirbydesign/designsystem';
 import { SlideButtonComponent } from '@kirbydesign/designsystem/slide-button';
 
+const config = {
+  template: `<kirby-slide-button
+  [text]="'Slide to confirm'"
+  aria-label="Confirm"
+  (slideDone)="showAlert()"
+  aria-label="Unlock"
+></kirby-slide-button>
+<kirby-slide-button
+  [text]="'Slide to confirm'"
+  aria-label="Confirm"
+  expand="block"
+  (slideDone)="showAlert()"
+  aria-label="Transfer"
+></kirby-slide-button>`,
+};
 @Component({
   selector: 'cookbook-slide-button-example',
   templateUrl: './slide-button-example.component.html',
   imports: [SlideButtonComponent],
 })
 export class SlideButtonExampleComponent {
+  template: string = config.template;
+
   constructor(private modalController: ModalController) {}
 
   showAlert() {

--- a/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.ts
+++ b/apps/cookbook/src/app/examples/slide-button-example/slide-button-example.component.ts
@@ -1,7 +1,8 @@
 import { Component } from '@angular/core';
 
 import { AlertConfig, ModalController } from '@kirbydesign/designsystem';
-import { SlideButtonComponent } from '@kirbydesign/designsystem/slide-button';
+import { SimpleSlideButtonExampleComponent } from './examples/simple';
+import { ExpandBlockSlideButtonExampleComponent } from './examples/expand-block';
 
 const config = {
   template: `<kirby-slide-button
@@ -21,24 +22,9 @@ const config = {
 @Component({
   selector: 'cookbook-slide-button-example',
   templateUrl: './slide-button-example.component.html',
-  imports: [SlideButtonComponent],
+  styleUrl: './slide-button-example.component.scss',
+  imports: [SimpleSlideButtonExampleComponent, ExpandBlockSlideButtonExampleComponent],
 })
 export class SlideButtonExampleComponent {
   template: string = config.template;
-
-  constructor(private modalController: ModalController) {}
-
-  showAlert() {
-    const config: AlertConfig = {
-      title: 'Your alert',
-      message: 'Your alert message',
-      okBtn: 'Ok',
-      cancelBtn: 'Cancel',
-    };
-    this.modalController.showAlert(config, this.onAlertClosed);
-  }
-
-  private onAlertClosed(selection: boolean) {
-    console.log(`Alert selection: ${selection}`);
-  }
 }

--- a/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.html
@@ -1,8 +1,8 @@
 <div class="example">
   <p>
-    The slide button is a simple button that requires the user to slide it to the right to confirm
-    the action. The sliding gesture helps preventing accidental actions and is often used on touch
-    devices where the user needs to confirm an action.
+    The slide button is a interactive element that requires a sliding gesture to confirm the action.
+    The sliding gesture requires a degree of intent, reducing the chance of accidentally triggering
+    an action. Often used on touch devices.
   </p>
   <h2>Simple slide button</h2>
   <cookbook-example-viewer [html]="simpleSlideButtonExample.template">

--- a/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.html
@@ -1,4 +1,5 @@
 <h1>Slide button</h1>
+<p>Great slide button</p>
 <div class="example">
   <cookbook-slide-button-example></cookbook-slide-button-example>
   <cookbook-code-viewer [html]="exampleHtml"></cookbook-code-viewer>

--- a/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.html
@@ -1,8 +1,25 @@
-<h1>Slide button</h1>
-<p>Great slide button</p>
 <div class="example">
-  <cookbook-slide-button-example></cookbook-slide-button-example>
-  <cookbook-code-viewer [html]="exampleHtml"></cookbook-code-viewer>
+  <p>
+    The slide button is a simple button that requires the user to slide it to the right to confirm
+    the action. The sliding gesture helps preventing accidental actions and is often used on touch
+    devices where the user needs to confirm an action.
+  </p>
+  <h2>Example</h2>
+  <cookbook-example-viewer [html]="accordionDefaultExample.template">
+    <div class="example-frame">
+      <cookbook-slide-button-example #accordionDefaultExample></cookbook-slide-button-example>
+    </div>
+  </cookbook-example-viewer>
+
+  <h2>Accessibility</h2>
+  <p>
+    While a gesture is needed to activate the slide button for the touch user, it will act as a
+    regular button for users using a screen reader. If the text of the slide button contains the
+    gesture like "slide to...", then it is advised to provide an aria-label that describes the
+    action without the gesture, like "confirm" or "unlock". This way, the screen reader user will
+    not be confused by the gesture requirement.
+  </p>
+
   <cookbook-api-description-properties
     [properties]="properties"
   ></cookbook-api-description-properties>

--- a/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.html
@@ -1,3 +1,4 @@
+<h1>Slide button</h1>
 <div class="example">
   <cookbook-slide-button-example></cookbook-slide-button-example>
   <cookbook-code-viewer [html]="exampleHtml"></cookbook-code-viewer>

--- a/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.html
@@ -4,10 +4,22 @@
     the action. The sliding gesture helps preventing accidental actions and is often used on touch
     devices where the user needs to confirm an action.
   </p>
-  <h2>Example</h2>
-  <cookbook-example-viewer [html]="accordionDefaultExample.template">
+  <h2>Simple slide button</h2>
+  <cookbook-example-viewer [html]="simpleSlideButtonExample.template">
     <div class="example-frame">
-      <cookbook-slide-button-example #accordionDefaultExample></cookbook-slide-button-example>
+      <cookbook-simple-slide-button-example
+        #simpleSlideButtonExample
+      ></cookbook-simple-slide-button-example>
+    </div>
+  </cookbook-example-viewer>
+
+  <h3>Expand to fill width</h3>
+  <p>If needed the slide button can be expanded to fill the width of its container.</p>
+  <cookbook-example-viewer [html]="expandSlideButtonExample.template">
+    <div class="example-frame">
+      <cookbook-expand-block-slide-button-example
+        #expandSlideButtonExample
+      ></cookbook-expand-block-slide-button-example>
     </div>
   </cookbook-example-viewer>
 

--- a/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.html
@@ -1,8 +1,8 @@
 <div class="example">
   <p>
     The slide button is a interactive element that requires a sliding gesture to confirm the action.
-    The sliding gesture requires a degree of intent, reducing the chance of accidentally triggering
-    an action. Often used on touch devices.
+    The sliding gesture requires a degree of intent, reducing the risk of accidentally triggering an
+    action. Often used on touch devices.
   </p>
   <h2>Simple slide button</h2>
   <cookbook-example-viewer [html]="simpleSlideButtonExample.template">

--- a/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.scss
+++ b/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.scss
@@ -1,0 +1,11 @@
+@use '@kirbydesign/core/src/scss/utils';
+@use '../showcase.shared';
+
+h2:not(:first-child) {
+  margin-top: utils.size('l');
+}
+
+cookbook-example-viewer > *:first-child {
+  display: block;
+  margin-bottom: utils.size('s');
+}

--- a/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.ts
@@ -5,16 +5,19 @@ import { CodeViewerComponent } from '../../shared/code-viewer/code-viewer.compon
 import { ApiDescriptionPropertiesComponent } from '../../shared/api-description/api-description-properties/api-description-properties.component';
 import { ApiDescriptionProperty } from '~/app/shared/api-description/api-description-properties/api-description-properties.component';
 import { ExampleViewerComponent } from '~/app/shared/example-viewer/example-viewer.component';
+import { SimpleSlideButtonExampleComponent } from '~/app/examples/slide-button-example/examples/simple';
+import { ExpandBlockSlideButtonExampleComponent } from '~/app/examples/slide-button-example/examples/expand-block';
 
 @Component({
   selector: 'cookbook-slide-button-showcase',
   templateUrl: './slide-button-showcase.component.html',
   styleUrl: './slide-button-showcase.component.scss',
   imports: [
-    SlideButtonExampleComponent,
     CodeViewerComponent,
     ApiDescriptionPropertiesComponent,
     ExampleViewerComponent,
+    SimpleSlideButtonExampleComponent,
+    ExpandBlockSlideButtonExampleComponent,
   ],
 })
 export class SlideButtonShowcaseComponent {

--- a/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.ts
@@ -1,7 +1,5 @@
 import { Component } from '@angular/core';
 import exampleHtml from '../../examples/slide-button-example/slide-button-example.component.html?raw';
-import { SlideButtonExampleComponent } from '../../examples/slide-button-example/slide-button-example.component';
-import { CodeViewerComponent } from '../../shared/code-viewer/code-viewer.component';
 import { ApiDescriptionPropertiesComponent } from '../../shared/api-description/api-description-properties/api-description-properties.component';
 import { ApiDescriptionProperty } from '~/app/shared/api-description/api-description-properties/api-description-properties.component';
 import { ExampleViewerComponent } from '~/app/shared/example-viewer/example-viewer.component';
@@ -13,7 +11,6 @@ import { ExpandBlockSlideButtonExampleComponent } from '~/app/examples/slide-but
   templateUrl: './slide-button-showcase.component.html',
   styleUrl: './slide-button-showcase.component.scss',
   imports: [
-    CodeViewerComponent,
     ApiDescriptionPropertiesComponent,
     ExampleViewerComponent,
     SimpleSlideButtonExampleComponent,

--- a/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/slide-button-showcase/slide-button-showcase.component.ts
@@ -4,11 +4,18 @@ import { SlideButtonExampleComponent } from '../../examples/slide-button-example
 import { CodeViewerComponent } from '../../shared/code-viewer/code-viewer.component';
 import { ApiDescriptionPropertiesComponent } from '../../shared/api-description/api-description-properties/api-description-properties.component';
 import { ApiDescriptionProperty } from '~/app/shared/api-description/api-description-properties/api-description-properties.component';
+import { ExampleViewerComponent } from '~/app/shared/example-viewer/example-viewer.component';
 
 @Component({
   selector: 'cookbook-slide-button-showcase',
   templateUrl: './slide-button-showcase.component.html',
-  imports: [SlideButtonExampleComponent, CodeViewerComponent, ApiDescriptionPropertiesComponent],
+  styleUrl: './slide-button-showcase.component.scss',
+  imports: [
+    SlideButtonExampleComponent,
+    CodeViewerComponent,
+    ApiDescriptionPropertiesComponent,
+    ExampleViewerComponent,
+  ],
 })
 export class SlideButtonShowcaseComponent {
   exampleHtml = exampleHtml;

--- a/libs/designsystem/slide-button/src/slide-button.component.html
+++ b/libs/designsystem/slide-button/src/slide-button.component.html
@@ -10,10 +10,10 @@
     class="slide-button"
     [value]="value"
     max="100"
-    [step]="step"
+    aria-hidden="true"
   />
-  <p class="slide-button-text slide-{{ pctInTens }}-pct">{{ text }}</p>
-  <button #hiddenButton class="visually-hidden" (click)="handleSlideDone()">
+  <p class="slide-button-text slide-{{ pctInTens }}-pct" aria-hidden="true">{{ text }}</p>
+  <button #hiddenButton class="visually-hidden breakout" (click)="handleSlideDone()">
     {{ text }}
   </button>
 </div>

--- a/libs/designsystem/slide-button/src/slide-button.component.html
+++ b/libs/designsystem/slide-button/src/slide-button.component.html
@@ -1,5 +1,6 @@
 <div class="slide-button-container" [ngClass]="{ 'slide-done': isSlideDone }" [inert]="isSlideDone">
   <input
+    tabindex="-1"
     type="range"
     (mouseup)="onSliderMouseup()"
     (touchend)="onSliderMouseup()"
@@ -12,4 +13,7 @@
     [step]="step"
   />
   <p class="slide-button-text slide-{{ pctInTens }}-pct">{{ text }}</p>
+  <button #hiddenButton class="visually-hidden" (click)="handleSlideDone()">
+    {{ text }}
+  </button>
 </div>

--- a/libs/designsystem/slide-button/src/slide-button.component.scss
+++ b/libs/designsystem/slide-button/src/slide-button.component.scss
@@ -103,10 +103,6 @@ $slide-button-text-padding: 0 $slide-button-container-radius 0 $total-slider-thu
     @include _slider-thumb;
   }
 
-  .slide-button:focus-visible::-webkit-slider-thumb {
-    @include interaction-state.apply-focus-ring;
-  }
-
   .slide-done {
     transition: all 0.3s ease-in-out;
     opacity: 0;
@@ -118,8 +114,8 @@ $slide-button-text-padding: 0 $slide-button-container-radius 0 $total-slider-thu
 
 .visually-hidden {
   position: absolute;
-  width: 1px;
-  height: 1px;
+  width: 100%;
+  height: 100%;
   clip: rect(0, 0, 0, 0);
   clip-path: inset(50%);
   border: medium;

--- a/libs/designsystem/slide-button/src/slide-button.component.scss
+++ b/libs/designsystem/slide-button/src/slide-button.component.scss
@@ -60,6 +60,10 @@ $slide-button-text-padding: 0 $slide-button-container-radius 0 $total-slider-thu
     background-color: $slide-button-container-bg-color;
     height: $slide-button-container-height;
     border-radius: $slide-button-container-radius;
+
+    &:focus-within {
+      @include interaction-state.apply-focus-ring($shadow: utils.get-elevation(2));
+    }
   }
 
   @for $i from 1 through 10 {
@@ -110,4 +114,16 @@ $slide-button-text-padding: 0 $slide-button-container-radius 0 $total-slider-thu
     transform: scale(0);
     pointer-events: none;
   }
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  border: medium;
+  overflow: hidden;
+  white-space: nowrap;
+  padding: 0;
 }

--- a/libs/designsystem/slide-button/src/slide-button.component.scss
+++ b/libs/designsystem/slide-button/src/slide-button.component.scss
@@ -62,7 +62,9 @@ $slide-button-text-padding: 0 $slide-button-container-radius 0 $total-slider-thu
     border-radius: $slide-button-container-radius;
 
     &:focus-within {
-      @include interaction-state.apply-focus-ring($shadow: utils.get-elevation(2));
+      @include utils.not-touch {
+        @include interaction-state.apply-focus-ring($shadow: utils.get-elevation(2));
+      }
     }
   }
 

--- a/libs/designsystem/slide-button/src/slide-button.component.spec.ts
+++ b/libs/designsystem/slide-button/src/slide-button.component.spec.ts
@@ -1,25 +1,24 @@
-import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { fakeAsync, tick } from '@angular/core/testing';
 
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
 import { SlideButtonComponent } from './slide-button.component';
 
 describe('SlideButtonComponent', () => {
   let component: SlideButtonComponent;
-  let fixture: ComponentFixture<SlideButtonComponent>;
+  let spectator: SpectatorHost<SlideButtonComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [SlideButtonComponent],
-    }).compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(SlideButtonComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+  const createHost = createHostFactory({
+    component: SlideButtonComponent,
   });
 
+  beforeEach(() => {
+    spectator = createHost(
+      `<kirby-slide-button [text]="'slide to confirm'" aria-label="fake-label" aria-labelledby="fake-dom-label"></kirby-slide-button>`
+    );
+    component = spectator.component;
+  });
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(spectator.component).toBeTruthy();
   });
 
   describe('onSliderMouseup', () => {
@@ -71,5 +70,34 @@ describe('SlideButtonComponent', () => {
 
       expect(component.value).toBe(initVal - 2);
     }));
+  });
+
+  describe('input range', () => {
+    it('should not be tabbable', () => {
+      const inputRange = spectator.query('input[type="range"]');
+      expect(inputRange).toHaveAttribute('tabindex', '-1');
+    });
+  });
+
+  describe('aria attributes', () => {
+    it('should have aria-hidden on the input range', () => {
+      const inputRange = spectator.query('input[type="range"]');
+      expect(inputRange).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('should have aria-hidden on the text paragraph', () => {
+      const textParagraph = spectator.query('.slide-button-text');
+      expect(textParagraph).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('should have aria-labelledby on the hidden button', () => {
+      const hiddenButton = spectator.query('button.visually-hidden');
+      expect(hiddenButton).toHaveAttribute('aria-labelledby', 'fake-dom-label');
+    });
+
+    it('should have aria-label on the hidden button', () => {
+      const hiddenButton = spectator.query('button.visually-hidden');
+      expect(hiddenButton).toHaveAttribute('aria-label', 'fake-label');
+    });
   });
 });

--- a/libs/designsystem/slide-button/src/slide-button.component.ts
+++ b/libs/designsystem/slide-button/src/slide-button.component.ts
@@ -1,14 +1,19 @@
 import { CommonModule } from '@angular/common';
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ElementRef,
   EventEmitter,
   HostListener,
   Input,
   OnDestroy,
   Output,
+  Renderer2,
+  ViewChild,
 } from '@angular/core';
+import { forwardAttributes } from '@kirbydesign/designsystem/shared';
 
 @Component({
   imports: [CommonModule],
@@ -17,12 +22,17 @@ import {
   styleUrls: ['./slide-button.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SlideButtonComponent implements OnDestroy {
+export class SlideButtonComponent implements OnDestroy, AfterViewInit {
   @Input() text = '';
   @Input() expand: 'block';
 
   @Output() slideDone = new EventEmitter();
   @Output() slidingPercentageChanged = new EventEmitter<number>();
+
+  @ViewChild('hiddenButton', { read: ElementRef })
+  hiddenButton!: ElementRef<HTMLButtonElement>;
+
+  private _attributesToForward = ['aria-label', 'aria-labelledby'];
 
   readonly slideDoneFadeTime = 500;
   readonly slideResetTime = 100;
@@ -55,7 +65,20 @@ export class SlideButtonComponent implements OnDestroy {
     this._step = value;
   }
 
-  constructor(private changeDetectionRef: ChangeDetectorRef) {}
+  constructor(
+    private changeDetectionRef: ChangeDetectorRef,
+    private elementRef: ElementRef<HTMLElement>,
+    private renderer: Renderer2
+  ) {}
+
+  ngAfterViewInit(): void {
+    forwardAttributes(
+      this.elementRef.nativeElement,
+      this._attributesToForward,
+      this.renderer,
+      this.hiddenButton.nativeElement
+    );
+  }
 
   ngOnDestroy(): void {
     if (this.resetSliderIntervalTimer) {
@@ -111,7 +134,7 @@ export class SlideButtonComponent implements OnDestroy {
     clearInterval(this.resetSliderIntervalTimer);
   }
 
-  private handleSlideDone() {
+  handleSlideDone() {
     this.slideDone.emit();
     this.isSlideDone = true;
   }

--- a/libs/designsystem/slide-button/src/slide-button.component.ts
+++ b/libs/designsystem/slide-button/src/slide-button.component.ts
@@ -6,7 +6,6 @@ import {
   Component,
   ElementRef,
   EventEmitter,
-  HostListener,
   Input,
   OnDestroy,
   Output,
@@ -54,17 +53,6 @@ export class SlideButtonComponent implements OnDestroy, AfterViewInit {
     this.pctInTens = Math.ceil(this.value / 10) * 10;
   }
 
-  private _step = 1;
-  private resetStep() {
-    this.step = 1;
-  }
-  public get step() {
-    return this._step;
-  }
-  public set step(value) {
-    this._step = value;
-  }
-
   constructor(
     private changeDetectionRef: ChangeDetectorRef,
     private elementRef: ElementRef<HTMLElement>,
@@ -86,16 +74,7 @@ export class SlideButtonComponent implements OnDestroy, AfterViewInit {
     }
   }
 
-  @HostListener('keyup.arrowup', ['$event'])
-  @HostListener('keyup.arrowdown', ['$event'])
-  @HostListener('keyup.arrowleft', ['$event'])
-  @HostListener('keyup.arrowright', ['$event'])
-  @HostListener('keyup.pageup', ['$event'])
-  @HostListener('keyup.pagedown', ['$event'])
-  @HostListener('keyup.home', ['$event'])
-  @HostListener('keyup.end', ['$event'])
   onSliderMouseup() {
-    this.resetStep();
     if (this.value == 100) {
       this.handleSlideDone();
     } else {
@@ -117,19 +96,6 @@ export class SlideButtonComponent implements OnDestroy, AfterViewInit {
     this.slidingPercentageChanged.emit(this.value);
   }
 
-  @HostListener('keydown.arrowup', ['$event'])
-  @HostListener('keydown.arrowdown', ['$event'])
-  @HostListener('keydown.arrowleft', ['$event'])
-  @HostListener('keydown.arrowright', ['$event'])
-  onKeyDownEvents() {
-    clearInterval(this.resetSliderIntervalTimer);
-    this.step = 10;
-  }
-
-  @HostListener('keydown.pageup', ['$event'])
-  @HostListener('keydown.pagedown', ['$event'])
-  @HostListener('keydown.home', ['$event'])
-  @HostListener('keydown.end', ['$event'])
   onSliderMousedown() {
     clearInterval(this.resetSliderIntervalTimer);
   }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3933 

## What is the new behavior?

The kirby-slide-button is build using a range-input which is fine for the regular mouse/touch scenario. However the range is not useful for keyboard-navigation and especially when used together with a screenreader, it is actually completely useless as the user can't get it into its "done" state.

In this PR the keyboard-problem have been solved by adding a hidden button below the input-range, which will gain the focus when tabbed to, instead of the range. Clicking on the button will do the same as when the slide-button (range) has been dragged all the way to the right.

The hidden button has the same text as the slide-button, but also obtains the aria-label if that is applied to the kirby-slide-button, which is recommended to add. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

