### PR TITLE
Empty State: Use h2 element for title when within modal

### DIFF
--- a/libs/designsystem/empty-state/src/empty-state.component.html
+++ b/libs/designsystem/empty-state/src/empty-state.component.html
@@ -5,7 +5,11 @@
     </div>
   }
   @if (title) {
-    <span class="title kirby-text-medium">{{ title }}</span>
+    @if (_insideModal) {
+      <h2 class="title kirby-text-medium">{{ title }}</h2>
+    } @else {
+      <span class="title kirby-text-medium">{{ title }}</span>
+    }
   }
   @if (subtitle) {
     <p class="subtitle">{{ subtitle }}</p>

--- a/libs/designsystem/empty-state/src/empty-state.component.spec.ts
+++ b/libs/designsystem/empty-state/src/empty-state.component.spec.ts
@@ -37,4 +37,22 @@ describe('EmptyStateComponent', () => {
     const outlineElement = element.getElementsByClassName('icon-outline')[0];
     expect(outlineElement).toHaveComputedStyle({ 'border-width': DesignTokenHelper.size('xxxs') });
   });
+  it('should have title', () => {
+    const titleElement = element.querySelector('.title');
+    expect(titleElement).toBeTruthy();
+    expect(titleElement.textContent).toBe('No items');
+  });
+
+  it('should have title as span', () => {
+    const titleElement = element.querySelector('.title');
+    expect(titleElement?.tagName.toLowerCase()).toBe('span');
+  });
+
+  it('should have subtitle', () => {
+    const subtitleElement = element.querySelector('.subtitle');
+    expect(subtitleElement).toBeTruthy();
+    expect(subtitleElement.textContent).toBe(
+      "You don't have any items. Call support to add some items to your account."
+    );
+  });
 });

--- a/libs/designsystem/empty-state/src/empty-state.component.ts
+++ b/libs/designsystem/empty-state/src/empty-state.component.ts
@@ -36,6 +36,7 @@ export class EmptyStateComponent implements AfterContentInit, OnInit {
   get title(): string {
     return this._title;
   }
+  _insideModal: boolean = false;
 
   @Input() subtitle: string;
 
@@ -54,6 +55,7 @@ export class EmptyStateComponent implements AfterContentInit, OnInit {
      */
     this.ionModalDialog = getIonModalDialogAncestor(this.elementRef.nativeElement);
     if (this.ionModalDialog) {
+      this._insideModal = true;
       this.renderer.setAttribute(this.ionModalDialog, 'aria-label', this.title);
     }
   }

--- a/libs/designsystem/modal/src/modal/services/alert.helper.spec.ts
+++ b/libs/designsystem/modal/src/modal/services/alert.helper.spec.ts
@@ -98,6 +98,13 @@ describe('AlertHelper', () => {
 
       expect(dialogElement.getAttribute('aria-label')).toBe(title);
     });
+
+    it('should set alert title as h2', async () => {
+      await TestHelper.whenReady(ionModal);
+      const kirbyAlert = ionModal.querySelector('kirby-alert');
+      const titleTag = kirbyAlert.querySelector('.title')?.tagName?.toLowerCase();
+      expect(titleTag).toBe('h2');
+    });
   });
 
   describe('getComponentProps', () => {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4002 

## What is the new behavior?

Added boolean `_insideModal`-property, that is set to `true` when empty-state exists within a modal (which it does for alert). Now reading this new `_insideModal`-property to determine if an `h2` should be used instead of `span` for title element.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

