### PR TITLE
Decimal Mask: Trigger blur event for reactive forms

### DIFF
--- a/libs/designsystem/form-field/src/directives/decimal-mask/decimal-mask.directive.spec.ts
+++ b/libs/designsystem/form-field/src/directives/decimal-mask/decimal-mask.directive.spec.ts
@@ -290,6 +290,16 @@ describe('NumberInputDirective', () => {
         expect(spectator.element).toHaveAttribute('disabled');
         expect((spectator.element as HTMLInputElement).disabled).toBeTrue();
       });
+
+      it('should call onTouched when blurred', () => {
+        spectator = createDirective(`<input kirby-input kirby-decimal-mask type="number" />`);
+        const onTouchedSpy = jasmine.createSpy('onTouched');
+        spectator.directive.registerOnTouched(onTouchedSpy);
+
+        spectator.element.dispatchEvent(new Event('blur'));
+
+        expect(onTouchedSpy).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/libs/designsystem/form-field/src/directives/decimal-mask/decimal-mask.directive.ts
+++ b/libs/designsystem/form-field/src/directives/decimal-mask/decimal-mask.directive.ts
@@ -1,5 +1,13 @@
 import { getLocaleNumberSymbol, NumberSymbol } from '@angular/common';
-import { Directive, ElementRef, Inject, Input, LOCALE_ID, OnInit } from '@angular/core';
+import {
+  Directive,
+  ElementRef,
+  HostListener,
+  Inject,
+  Input,
+  LOCALE_ID,
+  OnInit,
+} from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import 'inputmask/lib/extensions/inputmask.numeric.extensions';
 import Inputmask from 'inputmask/lib/inputmask';
@@ -53,8 +61,13 @@ export class DecimalMaskDirective implements ControlValueAccessor, OnInit {
   _maxlength: number;
   _groupSeperatorDisabled: boolean;
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  onChange = (_: string) => {};
+  _onChange = (_: string) => {};
+  _onTouched = () => {};
+
+  @HostListener('blur')
+  onTouched(): void {
+    this._onTouched();
+  }
 
   constructor(
     private elementRef: ElementRef,
@@ -78,11 +91,12 @@ export class DecimalMaskDirective implements ControlValueAccessor, OnInit {
   }
 
   registerOnChange(onChange: any): void {
-    this.onChange = onChange;
+    this._onChange = onChange;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  registerOnTouched(_: any): void {}
+  registerOnTouched(fn: any): void {
+    this._onTouched = fn;
+  }
 
   setDisabledState?(isDisabled: boolean): void {
     this.elementRef.nativeElement.disabled = isDisabled;
@@ -109,7 +123,7 @@ export class DecimalMaskDirective implements ControlValueAccessor, OnInit {
       onBeforeWrite: () => {
         if (!this.inputmask) return;
         const unmaskedValue = this.inputmask.unmaskedvalue();
-        this.onChange(unmaskedValue.replace(this.radixPoint, '.'));
+        this._onChange(unmaskedValue.replace(this.radixPoint, '.'));
       },
     }).mask(this.elementRef.nativeElement);
     this.inputmask = this.elementRef.nativeElement.inputmask;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4030 

## What is the new behavior?
Implemented the missing onTouched callback (from the ControlValueAccessor interface) for decimal mask, to make it usable with reactive forms.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

