### PR TITLE
Link Styles: Let text with trailing icon wrap to new line

### DIFF
--- a/libs/core/src/scss/base/_functions.scss
+++ b/libs/core/src/scss/base/_functions.scss
@@ -195,9 +195,9 @@
 }
 
 /*
-* This mixin is applied both in the section-header styles, for using 
-* headings and paragraphs directly, and in kirby-label styles, for 
-* wrapping them in a kirby-label within a section-header. 
+* This mixin is applied both in the section-header styles, for using
+* headings and paragraphs directly, and in kirby-label styles, for
+* wrapping them in a kirby-label within a section-header.
 */
 
 @mixin section-header-typography() {
@@ -245,7 +245,6 @@
     background-image: image-set('#{$icon-url}');
   }
 
-  white-space: nowrap;
   background-repeat: no-repeat;
   background-position: right 50%;
   background-size: $icon-scaling-factor;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4035 

## What is the new behavior?
Elements with "kirby-external-icon" now wrap to a new line if they are wider than the parent container:

<img width="203" height="68" alt="billede" src="https://github.com/user-attachments/assets/ce123ed2-58b4-494c-92e9-68f1a4c834ab" />

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

