### PR TITLE
Button: Reworked eventlistener to effectively block event bubbling when button is aria-disabled

### DIFF
--- a/libs/designsystem/button/src/button.component.spec.ts
+++ b/libs/designsystem/button/src/button.component.spec.ts
@@ -1,4 +1,4 @@
-import { createHostFactory, createKeyboardEvent, SpectatorHost } from '@ngneat/spectator';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator';
 import { MockComponent } from 'ng-mocks';
 
 import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
@@ -105,29 +105,48 @@ describe('ButtonComponent', () => {
       });
 
       it('should prevent activation on Enter', () => {
-        let eventReceived = false;
-        element.addEventListener('keydown.enter', () => (eventReceived = true));
+        element.ariaDisabled = 'false'; //First test that enter is allowed
+        let eventReceived = 0;
+        element.addEventListener('keydown', (event: KeyboardEvent) => {
+          if (event.key === 'enter') {
+            eventReceived++;
+            console.log('event');
+          }
+        });
 
-        element.dispatchEvent(createKeyboardEvent('keydown', 'enter', element));
-        expect(eventReceived).toBe(false);
+        spectator.dispatchKeyboardEvent(element, 'keydown', 'enter');
+        expect(eventReceived).toBe(1);
+        element.ariaDisabled = 'true';
+        spectator.dispatchKeyboardEvent(element, 'keydown', 'enter');
+        expect(eventReceived).toBe(1);
       });
 
       it('should prevent activation on Space', () => {
-        let eventReceived = false;
-        element.addEventListener('keydown.space', () => (eventReceived = true));
+        element.ariaDisabled = 'false'; //First test that space is allowed
+        let eventReceived = 0;
+        element.addEventListener('keydown', (event: KeyboardEvent) => {
+          if (event.key === 'space') {
+            eventReceived++;
+          }
+        });
 
-        element.dispatchEvent(createKeyboardEvent('keydown', 'space', element));
-        expect(eventReceived).toBe(false);
+        spectator.dispatchKeyboardEvent(element, 'keydown', 'space');
+        expect(eventReceived).toBe(1);
+        element.ariaDisabled = 'true';
+        spectator.dispatchKeyboardEvent(element, 'keydown', 'space');
+        expect(eventReceived).toBe(1);
       });
 
       it('should prevent activation on click', () => {
-        let eventReceived = false;
-        element.addEventListener('click', () => (eventReceived = true));
-        const clickEvent = new MouseEvent('click', { bubbles: true });
+        element.ariaDisabled = 'false'; //First test that click is allowed
+        let eventReceived = 0;
+        element.addEventListener('click', () => eventReceived++);
 
-        element.dispatchEvent(clickEvent);
-
-        expect(eventReceived).toBe(false);
+        spectator.click(element);
+        expect(eventReceived).toBe(1);
+        element.ariaDisabled = 'true';
+        spectator.click(element);
+        expect(eventReceived).toBe(1);
       });
     });
 

--- a/libs/designsystem/button/src/button.component.spec.ts
+++ b/libs/designsystem/button/src/button.component.spec.ts
@@ -110,7 +110,6 @@ describe('ButtonComponent', () => {
         element.addEventListener('keydown', (event: KeyboardEvent) => {
           if (event.key === 'enter') {
             eventReceived++;
-            console.log('event');
           }
         });
 

--- a/libs/designsystem/button/src/button.component.spec.ts
+++ b/libs/designsystem/button/src/button.component.spec.ts
@@ -105,25 +105,29 @@ describe('ButtonComponent', () => {
       });
 
       it('should prevent activation on Enter', () => {
-        const keyDownEvent = createKeyboardEvent('keydown', 'Enter', element);
-        const preventDefaultSpy = spyOn(keyDownEvent, 'preventDefault');
-        const stopImmediatePropagationSpy = spyOn(keyDownEvent, 'stopImmediatePropagation');
+        let eventReceived = false;
+        element.addEventListener('keydown.enter', () => (eventReceived = true));
 
-        element.dispatchEvent(keyDownEvent);
-
-        expect(preventDefaultSpy).toHaveBeenCalled();
-        expect(stopImmediatePropagationSpy).toHaveBeenCalled();
+        element.dispatchEvent(createKeyboardEvent('keydown', 'enter', element));
+        expect(eventReceived).toBe(false);
       });
 
       it('should prevent activation on Space', () => {
-        const keyDownEvent = createKeyboardEvent('keydown', 'Space', element);
-        const preventDefaultSpy = spyOn(keyDownEvent, 'preventDefault');
-        const stopImmediatePropagationSpy = spyOn(keyDownEvent, 'stopImmediatePropagation');
+        let eventReceived = false;
+        element.addEventListener('keydown.space', () => (eventReceived = true));
 
-        element.dispatchEvent(keyDownEvent);
+        element.dispatchEvent(createKeyboardEvent('keydown', 'space', element));
+        expect(eventReceived).toBe(false);
+      });
 
-        expect(preventDefaultSpy).toHaveBeenCalled();
-        expect(stopImmediatePropagationSpy).toHaveBeenCalled();
+      it('should prevent activation on click', () => {
+        let eventReceived = false;
+        element.addEventListener('click', () => (eventReceived = true));
+        const clickEvent = new MouseEvent('click', { bubbles: true });
+
+        element.dispatchEvent(clickEvent);
+
+        expect(eventReceived).toBe(false);
       });
     });
 

--- a/libs/designsystem/button/src/button.component.ts
+++ b/libs/designsystem/button/src/button.component.ts
@@ -93,7 +93,7 @@ export class ButtonComponent implements AfterContentInit, OnDestroy {
   @ContentChild(IconComponent, { read: ElementRef })
   iconElementRef?: ElementRef<HTMLElement>;
 
-  private eventUnlisteners: EventListenerDisposeFn[] = [];
+  private disposeAriaEvents: EventListenerDisposeFn[] = [];
 
   constructor(
     private elementRef: ElementRef<HTMLElement>,
@@ -112,7 +112,7 @@ export class ButtonComponent implements AfterContentInit, OnDestroy {
         this.blockEventOnAriaDisabled.bind(this),
         { capture: true }
       );
-      this.eventUnlisteners.push(removeEventListener);
+      this.disposeAriaEvents.push(removeEventListener);
     });
   }
 
@@ -180,6 +180,6 @@ export class ButtonComponent implements AfterContentInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.eventUnlisteners.forEach((unlistenEvent) => unlistenEvent());
+    this.disposeAriaEvents.forEach((unlistenEvent) => unlistenEvent());
   }
 }

--- a/libs/designsystem/button/src/button.component.ts
+++ b/libs/designsystem/button/src/button.component.ts
@@ -94,7 +94,6 @@ export class ButtonComponent implements AfterContentInit, OnDestroy {
   iconElementRef?: ElementRef<HTMLElement>;
 
   private removeListeners: (() => void)[] = [];
-  private abortListener = new AbortController();
 
   constructor(
     private elementRef: ElementRef<HTMLElement>,

--- a/libs/designsystem/button/src/button.component.ts
+++ b/libs/designsystem/button/src/button.component.ts
@@ -5,7 +5,6 @@ import {
   ContentChild,
   ElementRef,
   HostBinding,
-  HostListener,
   Input,
   OnDestroy,
   Renderer2,
@@ -93,7 +92,7 @@ export class ButtonComponent implements AfterContentInit, OnDestroy {
   @ContentChild(IconComponent, { read: ElementRef })
   iconElementRef?: ElementRef<HTMLElement>;
 
-  private removeListeners: (() => void)[] = [];
+  private removeEventListeners: (() => void)[] = [];
 
   constructor(
     private elementRef: ElementRef<HTMLElement>,
@@ -106,13 +105,13 @@ export class ButtonComponent implements AfterContentInit, OnDestroy {
     // Prevent event bubbling for aria-disabled buttons using a native event listener.
     // HostListener cannot block event bubbling, see: https://github.com/angular/angular/issues/9587
     ['click', 'keydown.enter', 'keydown.space'].forEach((evt) => {
-      const eventListener = this.renderer.listen(
+      const removeEventListener = this.renderer.listen(
         this.elementRef.nativeElement,
         evt,
         this.blockEventOnAriaDisabled.bind(this),
         { capture: true }
       );
-      this.removeListeners.push(eventListener);
+      this.removeEventListeners.push(removeEventListener);
     });
   }
 
@@ -172,13 +171,14 @@ export class ButtonComponent implements AfterContentInit, OnDestroy {
     }
   }
 
-  ngOnDestroy() {
-    this.removeListeners.forEach((removeListener) => removeListener());
-  }
   private blockEventOnAriaDisabled(event: Event) {
     if (this.elementRef.nativeElement.ariaDisabled === 'true') {
       event.preventDefault();
       event.stopImmediatePropagation();
     }
+  }
+
+  ngOnDestroy() {
+    this.removeEventListeners.forEach((removeEventListener) => removeEventListener());
   }
 }

--- a/libs/designsystem/button/src/button.component.ts
+++ b/libs/designsystem/button/src/button.component.ts
@@ -7,6 +7,7 @@ import {
   HostBinding,
   HostListener,
   Input,
+  OnDestroy,
   Renderer2,
 } from '@angular/core';
 
@@ -30,7 +31,7 @@ export type AttentionLevel = '1' | '2' | '3';
   styleUrls: ['./button.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ButtonComponent implements AfterContentInit {
+export class ButtonComponent implements AfterContentInit, OnDestroy {
   @Input() attentionLevel: AttentionLevel;
 
   @HostBinding('class.no-decoration')
@@ -92,10 +93,29 @@ export class ButtonComponent implements AfterContentInit {
   @ContentChild(IconComponent, { read: ElementRef })
   iconElementRef?: ElementRef<HTMLElement>;
 
+  private removeListeners: (() => void)[] = [];
+  private abortListener = new AbortController();
+
   constructor(
     private elementRef: ElementRef<HTMLElement>,
     private renderer: Renderer2
-  ) {}
+  ) {
+    this.setupEventListenerForAriaDisabledHandling();
+  }
+
+  setupEventListenerForAriaDisabledHandling() {
+    // Prevent event bubbling for aria-disabled buttons using a native event listener.
+    // HostListener cannot block event bubbling, see: https://github.com/angular/angular/issues/9587
+    ['click', 'keydown.enter', 'keydown.space'].forEach((evt) => {
+      const eventListener = this.renderer.listen(
+        this.elementRef.nativeElement,
+        evt,
+        this.blockEventOnAriaDisabled.bind(this),
+        { capture: true }
+      );
+      this.removeListeners.push(eventListener);
+    });
+  }
 
   private wrapTextNode(iconElement?: HTMLElement) {
     if (!iconElement) {
@@ -153,9 +173,10 @@ export class ButtonComponent implements AfterContentInit {
     }
   }
 
-  @HostListener('keydown.enter', ['$event'])
-  @HostListener('keydown.space', ['$event'])
-  _onEnterOrSpace(event: KeyboardEvent) {
+  ngOnDestroy() {
+    this.removeListeners.forEach((removeListener) => removeListener());
+  }
+  private blockEventOnAriaDisabled(event: Event) {
     if (this.elementRef.nativeElement.ariaDisabled === 'true') {
       event.preventDefault();
       event.stopImmediatePropagation();

--- a/libs/designsystem/button/src/button.component.ts
+++ b/libs/designsystem/button/src/button.component.ts
@@ -7,6 +7,7 @@ import {
   HostBinding,
   Input,
   OnDestroy,
+  OnInit,
   Renderer2,
 } from '@angular/core';
 
@@ -31,7 +32,7 @@ export type AttentionLevel = '1' | '2' | '3';
   styleUrls: ['./button.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ButtonComponent implements AfterContentInit, OnDestroy {
+export class ButtonComponent implements AfterContentInit, OnDestroy, OnInit {
   @Input() attentionLevel: AttentionLevel;
 
   @HostBinding('class.no-decoration')
@@ -93,12 +94,14 @@ export class ButtonComponent implements AfterContentInit, OnDestroy {
   @ContentChild(IconComponent, { read: ElementRef })
   iconElementRef?: ElementRef<HTMLElement>;
 
-  private disposeEvents: EventListenerDisposeFn[] = [];
+  private disposeEventListeners: EventListenerDisposeFn[] = [];
 
   constructor(
     private elementRef: ElementRef<HTMLElement>,
     private renderer: Renderer2
-  ) {
+  ) {}
+
+  ngOnInit(): void {
     this.setupEventListenerForAriaDisabledHandling();
   }
 
@@ -106,13 +109,13 @@ export class ButtonComponent implements AfterContentInit, OnDestroy {
     // Prevent event bubbling for aria-disabled buttons using a native event listener.
     // HostListener cannot block event bubbling, see: https://github.com/angular/angular/issues/9587
     ['click', 'keydown.enter', 'keydown.space'].forEach((evt) => {
-      const disposeEvent = this.renderer.listen(
+      const disposeEventListener = this.renderer.listen(
         this.elementRef.nativeElement,
         evt,
         this.blockEventIfAriaDisabled.bind(this),
         { capture: true }
       );
-      this.disposeEvents.push(disposeEvent);
+      this.disposeEventListeners.push(disposeEventListener);
     });
   }
 
@@ -180,6 +183,6 @@ export class ButtonComponent implements AfterContentInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.disposeEvents.forEach((unlistenEvent) => unlistenEvent());
+    this.disposeEventListeners.forEach((unlistenEvent) => unlistenEvent());
   }
 }

--- a/libs/designsystem/button/src/button.component.ts
+++ b/libs/designsystem/button/src/button.component.ts
@@ -11,6 +11,7 @@ import {
 } from '@angular/core';
 
 import { NotificationColor } from '@kirbydesign/core';
+import { EventListenerDisposeFn } from '@kirbydesign/designsystem';
 
 import { IconComponent } from '@kirbydesign/designsystem/icon';
 
@@ -92,7 +93,7 @@ export class ButtonComponent implements AfterContentInit, OnDestroy {
   @ContentChild(IconComponent, { read: ElementRef })
   iconElementRef?: ElementRef<HTMLElement>;
 
-  private removeEventListeners: (() => void)[] = [];
+  private eventUnlisteners: EventListenerDisposeFn[] = [];
 
   constructor(
     private elementRef: ElementRef<HTMLElement>,
@@ -111,7 +112,7 @@ export class ButtonComponent implements AfterContentInit, OnDestroy {
         this.blockEventOnAriaDisabled.bind(this),
         { capture: true }
       );
-      this.removeEventListeners.push(removeEventListener);
+      this.eventUnlisteners.push(removeEventListener);
     });
   }
 
@@ -179,6 +180,6 @@ export class ButtonComponent implements AfterContentInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.removeEventListeners.forEach((removeEventListener) => removeEventListener());
+    this.eventUnlisteners.forEach((unlistenEvent) => unlistenEvent());
   }
 }

--- a/libs/designsystem/button/src/button.component.ts
+++ b/libs/designsystem/button/src/button.component.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/core';
 
 import { NotificationColor } from '@kirbydesign/core';
-import { EventListenerDisposeFn } from '@kirbydesign/designsystem';
+import { EventListenerDisposeFn } from '@kirbydesign/designsystem/types';
 
 import { IconComponent } from '@kirbydesign/designsystem/icon';
 

--- a/libs/designsystem/button/src/button.component.ts
+++ b/libs/designsystem/button/src/button.component.ts
@@ -93,7 +93,7 @@ export class ButtonComponent implements AfterContentInit, OnDestroy {
   @ContentChild(IconComponent, { read: ElementRef })
   iconElementRef?: ElementRef<HTMLElement>;
 
-  private disposeAriaEvents: EventListenerDisposeFn[] = [];
+  private disposeEvents: EventListenerDisposeFn[] = [];
 
   constructor(
     private elementRef: ElementRef<HTMLElement>,
@@ -106,13 +106,13 @@ export class ButtonComponent implements AfterContentInit, OnDestroy {
     // Prevent event bubbling for aria-disabled buttons using a native event listener.
     // HostListener cannot block event bubbling, see: https://github.com/angular/angular/issues/9587
     ['click', 'keydown.enter', 'keydown.space'].forEach((evt) => {
-      const removeEventListener = this.renderer.listen(
+      const disposeEvent = this.renderer.listen(
         this.elementRef.nativeElement,
         evt,
-        this.blockEventOnAriaDisabled.bind(this),
+        this.blockEventIfAriaDisabled.bind(this),
         { capture: true }
       );
-      this.disposeAriaEvents.push(removeEventListener);
+      this.disposeEvents.push(disposeEvent);
     });
   }
 
@@ -172,7 +172,7 @@ export class ButtonComponent implements AfterContentInit, OnDestroy {
     }
   }
 
-  private blockEventOnAriaDisabled(event: Event) {
+  private blockEventIfAriaDisabled(event: Event) {
     if (this.elementRef.nativeElement.ariaDisabled === 'true') {
       event.preventDefault();
       event.stopImmediatePropagation();
@@ -180,6 +180,6 @@ export class ButtonComponent implements AfterContentInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.disposeAriaEvents.forEach((unlistenEvent) => unlistenEvent());
+    this.disposeEvents.forEach((unlistenEvent) => unlistenEvent());
   }
 }

--- a/libs/designsystem/dropdown/src/dropdown-popover.component.spec.ts
+++ b/libs/designsystem/dropdown/src/dropdown-popover.component.spec.ts
@@ -1003,9 +1003,9 @@ describe('DropdownComponent (popover version)', () => {
       });
     });
 
-    it('should set up click listernes for slotted items', () => {
+    it('should set up click listeners for slotted items', () => {
       spectator.detectChanges();
-      const clickListeners = spectator.component['disposeItemClicks'];
+      const clickListeners = spectator.component['disposeItemClickListeners'];
       expect(clickListeners).toHaveLength(items.length);
     });
 
@@ -1018,9 +1018,9 @@ describe('DropdownComponent (popover version)', () => {
         ];
         const unlistenMockArrayLength = unlistenMockArray.length;
         let unlistenCounter = 0;
-        spectator.component['disposeItemClicks'] = unlistenMockArray;
+        spectator.component['disposeItemClickListeners'] = unlistenMockArray;
         spectator.component.ngOnDestroy();
-        expect(spectator.component['disposeItemClicks']).toHaveLength(0);
+        expect(spectator.component['disposeItemClickListeners']).toHaveLength(0);
         expect(unlistenCounter).toEqual(unlistenMockArrayLength);
       });
     });

--- a/libs/designsystem/dropdown/src/dropdown-popover.component.spec.ts
+++ b/libs/designsystem/dropdown/src/dropdown-popover.component.spec.ts
@@ -1005,7 +1005,7 @@ describe('DropdownComponent (popover version)', () => {
 
     it('should set up click listernes for slotted items', () => {
       spectator.detectChanges();
-      const clickListeners = spectator.component['itemClickUnlisten'];
+      const clickListeners = spectator.component['disposeItemClicks'];
       expect(clickListeners).toHaveLength(items.length);
     });
 
@@ -1018,9 +1018,9 @@ describe('DropdownComponent (popover version)', () => {
         ];
         const unlistenMockArrayLength = unlistenMockArray.length;
         let unlistenCounter = 0;
-        spectator.component['itemClickUnlisten'] = unlistenMockArray;
+        spectator.component['disposeItemClicks'] = unlistenMockArray;
         spectator.component.ngOnDestroy();
-        expect(spectator.component['itemClickUnlisten']).toHaveLength(0);
+        expect(spectator.component['disposeItemClicks']).toHaveLength(0);
         expect(unlistenCounter).toEqual(unlistenMockArrayLength);
       });
     });

--- a/libs/designsystem/dropdown/src/dropdown.component.spec.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.spec.ts
@@ -1106,7 +1106,7 @@ describe('DropdownComponent', () => {
 
     it('should set up click listeners for slotted items', () => {
       spectator.detectChanges();
-      const clickListeners = spectator.component['disposeItemClicks'];
+      const clickListeners = spectator.component['disposeItemClickListeners'];
       expect(clickListeners).toHaveLength(items.length);
     });
 
@@ -1119,9 +1119,9 @@ describe('DropdownComponent', () => {
         ];
         const unlistenMockArrayLength = unlistenMockArray.length;
         let unlistenCounter = 0;
-        spectator.component['disposeItemClicks'] = unlistenMockArray;
+        spectator.component['disposeItemClickListeners'] = unlistenMockArray;
         spectator.component.ngOnDestroy();
-        expect(spectator.component['disposeItemClicks']).toHaveLength(0);
+        expect(spectator.component['disposeItemClickListeners']).toHaveLength(0);
         expect(unlistenCounter).toEqual(unlistenMockArrayLength);
       });
     });

--- a/libs/designsystem/dropdown/src/dropdown.component.spec.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.spec.ts
@@ -1104,9 +1104,9 @@ describe('DropdownComponent', () => {
       });
     });
 
-    it('should set up click listernes for slotted items', () => {
+    it('should set up click listeners for slotted items', () => {
       spectator.detectChanges();
-      const clickListeners = spectator.component['itemClickUnlisten'];
+      const clickListeners = spectator.component['disposeItemClicks'];
       expect(clickListeners).toHaveLength(items.length);
     });
 
@@ -1119,9 +1119,9 @@ describe('DropdownComponent', () => {
         ];
         const unlistenMockArrayLength = unlistenMockArray.length;
         let unlistenCounter = 0;
-        spectator.component['itemClickUnlisten'] = unlistenMockArray;
+        spectator.component['disposeItemClicks'] = unlistenMockArray;
         spectator.component.ngOnDestroy();
-        expect(spectator.component['itemClickUnlisten']).toHaveLength(0);
+        expect(spectator.component['disposeItemClicks']).toHaveLength(0);
         expect(unlistenCounter).toEqual(unlistenMockArrayLength);
       });
     });

--- a/libs/designsystem/dropdown/src/dropdown.component.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.ts
@@ -232,7 +232,7 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
     // Setup a click listener for each new slotted items
     kirbyItems.forEach((kirbyItem, index) => {
       this.renderer.setAttribute(kirbyItem.nativeElement, 'role', 'option');
-      const unlisten: EventListenerDisposeFn = this.renderer.listen(
+      const disposeClick: EventListenerDisposeFn = this.renderer.listen(
         kirbyItem.nativeElement,
         'click',
         () => {
@@ -240,7 +240,7 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
         }
       );
 
-      this.disposeItemClicks.push(unlisten);
+      this.disposeItemClicks.push(disposeClick);
     });
 
     this._kirbyItemsSlotted = kirbyItems;
@@ -648,9 +648,9 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
   }
 
   private unlistenAllSlottedItems() {
-    let unlistenItem: () => void;
-    while ((unlistenItem = this.itemClickUnlisten.pop()) !== undefined) {
-      unlistenItem();
+    let disposeClick: EventListenerDisposeFn;
+    while ((disposeClick = this.disposeItemClicks.pop()) !== undefined) {
+      disposeClick();
     }
   }
 

--- a/libs/designsystem/dropdown/src/dropdown.component.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.ts
@@ -224,7 +224,7 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
   _kirbyItemsSlotted: QueryList<ElementRef<HTMLElement>>;
   @ContentChildren(ItemComponent, { read: ElementRef })
   set kirbyItemsSlotted(kirbyItems: QueryList<ElementRef<HTMLElement>>) {
-    const hasSlottedItems = this.itemClickUnlisten?.length > 0;
+    const hasSlottedItems = this.disposeItemClicks?.length > 0;
     if (hasSlottedItems) {
       this.unlistenAllSlottedItems();
     }
@@ -240,7 +240,7 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
         }
       );
 
-      this.itemClickUnlisten.push(unlisten);
+      this.disposeItemClicks.push(unlisten);
     });
 
     this._kirbyItemsSlotted = kirbyItems;
@@ -250,7 +250,7 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
     return this._kirbyItemsSlotted;
   }
 
-  private itemClickUnlisten: EventListenerDisposeFn[] = [];
+  private disposeItemClicks: EventListenerDisposeFn[] = [];
   private intersectionObserverRef: IntersectionObserver;
   private showDropdownTimeoutId: ReturnType<typeof setTimeout>;
 

--- a/libs/designsystem/dropdown/src/dropdown.component.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.ts
@@ -224,7 +224,7 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
   _kirbyItemsSlotted: QueryList<ElementRef<HTMLElement>>;
   @ContentChildren(ItemComponent, { read: ElementRef })
   set kirbyItemsSlotted(kirbyItems: QueryList<ElementRef<HTMLElement>>) {
-    const hasSlottedItems = this.disposeItemClicks?.length > 0;
+    const hasSlottedItems = this.disposeItemClickListeners?.length > 0;
     if (hasSlottedItems) {
       this.unlistenAllSlottedItems();
     }
@@ -232,7 +232,7 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
     // Setup a click listener for each new slotted items
     kirbyItems.forEach((kirbyItem, index) => {
       this.renderer.setAttribute(kirbyItem.nativeElement, 'role', 'option');
-      const disposeClick: EventListenerDisposeFn = this.renderer.listen(
+      const disposeClickListener: EventListenerDisposeFn = this.renderer.listen(
         kirbyItem.nativeElement,
         'click',
         () => {
@@ -240,7 +240,7 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
         }
       );
 
-      this.disposeItemClicks.push(disposeClick);
+      this.disposeItemClickListeners.push(disposeClickListener);
     });
 
     this._kirbyItemsSlotted = kirbyItems;
@@ -250,7 +250,7 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
     return this._kirbyItemsSlotted;
   }
 
-  private disposeItemClicks: EventListenerDisposeFn[] = [];
+  private disposeItemClickListeners: EventListenerDisposeFn[] = [];
   private intersectionObserverRef: IntersectionObserver;
   private showDropdownTimeoutId: ReturnType<typeof setTimeout>;
 
@@ -648,9 +648,9 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
   }
 
   private unlistenAllSlottedItems() {
-    let disposeClick: EventListenerDisposeFn;
-    while ((disposeClick = this.disposeItemClicks.pop()) !== undefined) {
-      disposeClick();
+    let disposeClickListener: EventListenerDisposeFn;
+    while ((disposeClickListener = this.disposeItemClickListeners.pop()) !== undefined) {
+      disposeClickListener();
     }
   }
 

--- a/libs/designsystem/menu/src/menu.component.ts
+++ b/libs/designsystem/menu/src/menu.component.ts
@@ -101,7 +101,7 @@ export class MenuComponent implements AfterViewInit, AfterContentInit, OnDestroy
 
   public floatingMenuIsShown: boolean = false;
   public FloatingOffset: typeof FloatingOffset = FloatingOffset;
-  private disposeIonScroll: EventListenerDisposeFn;
+  private disposeIonScrollListener: EventListenerDisposeFn;
   private focusedIndex = -1;
 
   @HostListener('keydown', ['$event'])
@@ -283,7 +283,7 @@ export class MenuComponent implements AfterViewInit, AfterContentInit, OnDestroy
        * Listen for ionScroll outside of Angular's change detection to
        * avoid a change detection cycle for every scroll-event fired
        */
-      this.disposeIonScroll = this.renderer.listen(document, 'ionScroll', () => {
+      this.disposeIonScrollListener = this.renderer.listen(document, 'ionScroll', () => {
         this.floatingMenu.hide();
       });
     });
@@ -359,6 +359,6 @@ export class MenuComponent implements AfterViewInit, AfterContentInit, OnDestroy
   }
 
   ngOnDestroy(): void {
-    this.disposeIonScroll?.();
+    this.disposeIonScrollListener?.();
   }
 }

--- a/libs/designsystem/menu/src/menu.component.ts
+++ b/libs/designsystem/menu/src/menu.component.ts
@@ -101,7 +101,7 @@ export class MenuComponent implements AfterViewInit, AfterContentInit, OnDestroy
 
   public floatingMenuIsShown: boolean = false;
   public FloatingOffset: typeof FloatingOffset = FloatingOffset;
-  private scrollListenerDisposeFn: EventListenerDisposeFn;
+  private disposeIonScroll: EventListenerDisposeFn;
   private focusedIndex = -1;
 
   @HostListener('keydown', ['$event'])
@@ -283,7 +283,7 @@ export class MenuComponent implements AfterViewInit, AfterContentInit, OnDestroy
        * Listen for ionScroll outside of Angular's change detection to
        * avoid a change detection cycle for every scroll-event fired
        */
-      this.scrollListenerDisposeFn = this.renderer.listen(document, 'ionScroll', () => {
+      this.disposeIonScroll = this.renderer.listen(document, 'ionScroll', () => {
         this.floatingMenu.hide();
       });
     });
@@ -359,6 +359,6 @@ export class MenuComponent implements AfterViewInit, AfterContentInit, OnDestroy
   }
 
   ngOnDestroy(): void {
-    this.scrollListenerDisposeFn?.();
+    this.disposeIonScroll?.();
   }
 }

--- a/libs/designsystem/popover/src/popover.component.ts
+++ b/libs/designsystem/popover/src/popover.component.ts
@@ -10,6 +10,7 @@ import {
   Renderer2,
   ViewChild,
 } from '@angular/core';
+import { EventListenerDisposeFn } from '@kirbydesign/designsystem';
 import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
 
 export enum HorizontalDirection {
@@ -62,6 +63,8 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
     this.hide();
   }
 
+  private unlistenScrollEventListener: EventListenerDisposeFn;
+
   constructor(
     private elementRef: ElementRef<HTMLElement>,
     private renderer: Renderer2
@@ -91,7 +94,6 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
     }
   }
 
-  // document.removeEventListener needs the exact same event handler & options reference:
   private static preventEventOutsidePopover(event: TouchEvent) {
     if (event.target instanceof HTMLElement) {
       const targetIsInPopover = !!event.target.closest('kirby-popover');
@@ -107,8 +109,8 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
       this.renderer.addClass(this.document.body, 'backdrop-no-scroll');
     }
 
-    // preventDefault does not work with Renderer2.listen method; add event listener directly to document instead
-    this.document.addEventListener(
+    this.unlistenScrollEventListener = this.renderer.listen(
+      this.document,
       'touchmove',
       PopoverComponent.preventEventOutsidePopover,
       this.preventScrollEventListenerOptions
@@ -120,11 +122,7 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
       this.renderer.removeClass(this.document.body, 'backdrop-no-scroll');
     }
 
-    this.document.removeEventListener(
-      'touchmove',
-      PopoverComponent.preventEventOutsidePopover,
-      this.preventScrollEventListenerOptions
-    );
+    this.unlistenScrollEventListener?.();
   }
 
   show() {

--- a/libs/designsystem/popover/src/popover.component.ts
+++ b/libs/designsystem/popover/src/popover.component.ts
@@ -63,7 +63,7 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
     this.hide();
   }
 
-  private disposeTouchmove: EventListenerDisposeFn;
+  private disposeTouchMoveListener: EventListenerDisposeFn;
 
   constructor(
     private elementRef: ElementRef<HTMLElement>,
@@ -109,7 +109,7 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
       this.renderer.addClass(this.document.body, 'backdrop-no-scroll');
     }
 
-    this.disposeTouchmove = this.renderer.listen(
+    this.disposeTouchMoveListener = this.renderer.listen(
       this.document,
       'touchmove',
       PopoverComponent.preventEventOutsidePopover,
@@ -122,7 +122,7 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
       this.renderer.removeClass(this.document.body, 'backdrop-no-scroll');
     }
 
-    this.disposeTouchmove?.();
+    this.disposeTouchMoveListener?.();
   }
 
   show() {

--- a/libs/designsystem/popover/src/popover.component.ts
+++ b/libs/designsystem/popover/src/popover.component.ts
@@ -63,7 +63,7 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
     this.hide();
   }
 
-  private unlistenScrollEventListener: EventListenerDisposeFn;
+  private disposeTouchmove: EventListenerDisposeFn;
 
   constructor(
     private elementRef: ElementRef<HTMLElement>,
@@ -109,7 +109,7 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
       this.renderer.addClass(this.document.body, 'backdrop-no-scroll');
     }
 
-    this.unlistenScrollEventListener = this.renderer.listen(
+    this.disposeTouchmove = this.renderer.listen(
       this.document,
       'touchmove',
       PopoverComponent.preventEventOutsidePopover,
@@ -122,7 +122,7 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
       this.renderer.removeClass(this.document.body, 'backdrop-no-scroll');
     }
 
-    this.unlistenScrollEventListener?.();
+    this.disposeTouchmove?.();
   }
 
   show() {

--- a/libs/designsystem/popover/src/popover.component.ts
+++ b/libs/designsystem/popover/src/popover.component.ts
@@ -10,7 +10,7 @@ import {
   Renderer2,
   ViewChild,
 } from '@angular/core';
-import { EventListenerDisposeFn } from '@kirbydesign/designsystem';
+import { EventListenerDisposeFn } from '@kirbydesign/designsystem/types';
 import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
 
 export enum HorizontalDirection {

--- a/libs/designsystem/shared/floating/src/floating.directive.spec.ts
+++ b/libs/designsystem/shared/floating/src/floating.directive.spec.ts
@@ -124,7 +124,7 @@ describe('FloatingDirective', () => {
       it('should not add event listeners when only reference is set without triggers', () => {
         directive.triggers = null;
         directive.reference = component.floatingElementRef;
-        expect(directive['disposeTriggerEvents']).toHaveLength(0);
+        expect(directive['disposeTriggerEventListeners']).toHaveLength(0);
       });
     });
 
@@ -206,25 +206,25 @@ describe('FloatingDirective', () => {
       it('should not add event listeners when only triggers is set without reference', () => {
         directive.reference = null;
         directive.triggers = ['hover'];
-        expect(directive['disposeTriggerEvents']).toHaveLength(0);
+        expect(directive['disposeTriggerEventListeners']).toHaveLength(0);
       });
 
       it('should add event listeners for click event when reference and triggers is set', () => {
         directive.triggers = ['click'];
         directive.reference = component.floatingElementRef;
-        expect(directive['disposeTriggerEvents']).toHaveLength(1);
+        expect(directive['disposeTriggerEventListeners']).toHaveLength(1);
       });
 
       it('should add event listeners for hover event when reference and triggers is set', () => {
         directive.triggers = ['hover'];
         directive.reference = component.floatingElementRef;
-        expect(directive['disposeTriggerEvents']).toHaveLength(2);
+        expect(directive['disposeTriggerEventListeners']).toHaveLength(2);
       });
 
       it('should add event listeners for click event when reference and triggers is set', () => {
         directive.triggers = ['focus'];
         directive.reference = component.floatingElementRef;
-        expect(directive['disposeTriggerEvents']).toHaveLength(2);
+        expect(directive['disposeTriggerEventListeners']).toHaveLength(2);
       });
     });
 

--- a/libs/designsystem/shared/floating/src/floating.directive.spec.ts
+++ b/libs/designsystem/shared/floating/src/floating.directive.spec.ts
@@ -124,7 +124,7 @@ describe('FloatingDirective', () => {
       it('should not add event listeners when only reference is set without triggers', () => {
         directive.triggers = null;
         directive.reference = component.floatingElementRef;
-        expect(directive['referenceEventListenerDisposeFns']).toHaveLength(0);
+        expect(directive['disposeTriggerEvents']).toHaveLength(0);
       });
     });
 
@@ -206,25 +206,25 @@ describe('FloatingDirective', () => {
       it('should not add event listeners when only triggers is set without reference', () => {
         directive.reference = null;
         directive.triggers = ['hover'];
-        expect(directive['referenceEventListenerDisposeFns']).toHaveLength(0);
+        expect(directive['disposeTriggerEvents']).toHaveLength(0);
       });
 
       it('should add event listeners for click event when reference and triggers is set', () => {
         directive.triggers = ['click'];
         directive.reference = component.floatingElementRef;
-        expect(directive['referenceEventListenerDisposeFns']).toHaveLength(1);
+        expect(directive['disposeTriggerEvents']).toHaveLength(1);
       });
 
       it('should add event listeners for hover event when reference and triggers is set', () => {
         directive.triggers = ['hover'];
         directive.reference = component.floatingElementRef;
-        expect(directive['referenceEventListenerDisposeFns']).toHaveLength(2);
+        expect(directive['disposeTriggerEvents']).toHaveLength(2);
       });
 
       it('should add event listeners for click event when reference and triggers is set', () => {
         directive.triggers = ['focus'];
         directive.reference = component.floatingElementRef;
-        expect(directive['referenceEventListenerDisposeFns']).toHaveLength(2);
+        expect(directive['disposeTriggerEvents']).toHaveLength(2);
       });
     });
 

--- a/libs/designsystem/shared/floating/src/floating.directive.ts
+++ b/libs/designsystem/shared/floating/src/floating.directive.ts
@@ -210,9 +210,9 @@ export class FloatingDirective implements OnInit, OnDestroy {
 
   private autoUpdaterRef: () => void;
   private isShown: boolean = false;
-  private disposeTriggerEvents: EventListenerDisposeFn[] = [];
-  private disposeDocumentClick: EventListenerDisposeFn;
-  private disposeHostClick: EventListenerDisposeFn;
+  private disposeTriggerEventListeners: EventListenerDisposeFn[] = [];
+  private disposeDocumentClickListener: EventListenerDisposeFn;
+  private disposeHostClickListener: EventListenerDisposeFn;
   private triggerEventMap: Map<TriggerEvent, EventMethods[]> = new Map([
     ['click', [{ event: 'click', method: this.toggleShow.bind(this) }]],
     [
@@ -370,22 +370,24 @@ export class FloatingDirective implements OnInit, OnDestroy {
   }
 
   private attachDocumentClickEventHandler(): void {
-    if (this.disposeDocumentClick) {
+    if (this.disposeDocumentClickListener) {
       return;
     }
 
-    this.disposeDocumentClick = this.renderer.listen('document', 'mousedown', (event) =>
+    this.disposeDocumentClickListener = this.renderer.listen('document', 'mousedown', (event) =>
       this.handleClickOutsideHostElement(event)
     );
   }
 
   private attachHostClickEventHandler(): void {
-    if (this.disposeHostClick || !this.closeOnSelect) {
+    if (this.disposeHostClickListener || !this.closeOnSelect) {
       return;
     }
 
-    this.disposeHostClick = this.renderer.listen(this.elementRef.nativeElement, 'click', () =>
-      this.handleClickInsideHostElement()
+    this.disposeHostClickListener = this.renderer.listen(
+      this.elementRef.nativeElement,
+      'click',
+      () => this.handleClickInsideHostElement()
     );
   }
 
@@ -397,12 +399,12 @@ export class FloatingDirective implements OnInit, OnDestroy {
     }
 
     events.forEach((event: EventMethods) => {
-      const eventListenerDisposeFn: EventListenerDisposeFn = this.renderer.listen(
+      const disposeTriggerEventListener: EventListenerDisposeFn = this.renderer.listen(
         this.reference?.nativeElement,
         event.event,
         event.method
       );
-      this.disposeTriggerEvents.push(eventListenerDisposeFn);
+      this.disposeTriggerEventListeners.push(disposeTriggerEventListener);
     });
   }
 
@@ -454,23 +456,21 @@ export class FloatingDirective implements OnInit, OnDestroy {
   }
 
   private tearDownReferenceElementEventHandling(): void {
-    this.disposeTriggerEvents.forEach((eventListenerDisposeFunction: EventListenerDisposeFn) => {
-      if (eventListenerDisposeFunction != null) {
-        eventListenerDisposeFunction();
-      }
-    });
-    this.disposeTriggerEvents = [];
+    this.disposeTriggerEventListeners.forEach((disposeTriggerEventListener) =>
+      disposeTriggerEventListener?.()
+    );
+    this.disposeTriggerEventListeners = [];
   }
 
   private tearDownDocumentClickEventHandling(): void {
-    if (this.disposeDocumentClick) {
-      this.disposeDocumentClick();
-      this.disposeDocumentClick = null;
+    if (this.disposeDocumentClickListener) {
+      this.disposeDocumentClickListener();
+      this.disposeDocumentClickListener = null;
     }
 
-    if (this.disposeHostClick) {
-      this.disposeHostClick();
-      this.disposeHostClick = null;
+    if (this.disposeHostClickListener) {
+      this.disposeHostClickListener();
+      this.disposeHostClickListener = null;
     }
   }
 

--- a/libs/designsystem/shared/floating/src/floating.directive.ts
+++ b/libs/designsystem/shared/floating/src/floating.directive.ts
@@ -24,6 +24,7 @@ import {
 import { DesignTokenHelper } from '@kirbydesign/core';
 import { from } from 'rxjs';
 import { PortalDirective } from '@kirbydesign/designsystem/shared/portal';
+import { EventListenerDisposeFn } from '@kirbydesign/designsystem/types';
 
 export type TriggerEvent = 'hover' | 'click' | 'focus';
 
@@ -49,8 +50,6 @@ interface EventMethods {
   event: string;
   method: () => void;
 }
-
-type EventListenerDisposeFn = () => void;
 
 /**
  * @summary FloatingDirective is a utility that lets you declarative anchor "popup" containers to another element.
@@ -211,9 +210,9 @@ export class FloatingDirective implements OnInit, OnDestroy {
 
   private autoUpdaterRef: () => void;
   private isShown: boolean = false;
-  private referenceEventListenerDisposeFns: EventListenerDisposeFn[] = [];
-  private documentClickEventListenerDisposeFn: EventListenerDisposeFn;
-  private hostClickEventListenerDisposeFn: EventListenerDisposeFn;
+  private disposeTriggerEvents: EventListenerDisposeFn[] = [];
+  private disposeDocumentClick: EventListenerDisposeFn;
+  private disposeHostClick: EventListenerDisposeFn;
   private triggerEventMap: Map<TriggerEvent, EventMethods[]> = new Map([
     ['click', [{ event: 'click', method: this.toggleShow.bind(this) }]],
     [
@@ -371,26 +370,22 @@ export class FloatingDirective implements OnInit, OnDestroy {
   }
 
   private attachDocumentClickEventHandler(): void {
-    if (this.documentClickEventListenerDisposeFn) {
+    if (this.disposeDocumentClick) {
       return;
     }
 
-    this.documentClickEventListenerDisposeFn = this.renderer.listen(
-      'document',
-      'mousedown',
-      (event) => this.handleClickOutsideHostElement(event)
+    this.disposeDocumentClick = this.renderer.listen('document', 'mousedown', (event) =>
+      this.handleClickOutsideHostElement(event)
     );
   }
 
   private attachHostClickEventHandler(): void {
-    if (this.hostClickEventListenerDisposeFn || !this.closeOnSelect) {
+    if (this.disposeHostClick || !this.closeOnSelect) {
       return;
     }
 
-    this.hostClickEventListenerDisposeFn = this.renderer.listen(
-      this.elementRef.nativeElement,
-      'click',
-      () => this.handleClickInsideHostElement()
+    this.disposeHostClick = this.renderer.listen(this.elementRef.nativeElement, 'click', () =>
+      this.handleClickInsideHostElement()
     );
   }
 
@@ -407,7 +402,7 @@ export class FloatingDirective implements OnInit, OnDestroy {
         event.event,
         event.method
       );
-      this.referenceEventListenerDisposeFns.push(eventListenerDisposeFn);
+      this.disposeTriggerEvents.push(eventListenerDisposeFn);
     });
   }
 
@@ -459,25 +454,23 @@ export class FloatingDirective implements OnInit, OnDestroy {
   }
 
   private tearDownReferenceElementEventHandling(): void {
-    this.referenceEventListenerDisposeFns.forEach(
-      (eventListenerDisposeFunction: EventListenerDisposeFn) => {
-        if (eventListenerDisposeFunction != null) {
-          eventListenerDisposeFunction();
-        }
+    this.disposeTriggerEvents.forEach((eventListenerDisposeFunction: EventListenerDisposeFn) => {
+      if (eventListenerDisposeFunction != null) {
+        eventListenerDisposeFunction();
       }
-    );
-    this.referenceEventListenerDisposeFns = [];
+    });
+    this.disposeTriggerEvents = [];
   }
 
   private tearDownDocumentClickEventHandling(): void {
-    if (this.documentClickEventListenerDisposeFn) {
-      this.documentClickEventListenerDisposeFn();
-      this.documentClickEventListenerDisposeFn = null;
+    if (this.disposeDocumentClick) {
+      this.disposeDocumentClick();
+      this.disposeDocumentClick = null;
     }
 
-    if (this.hostClickEventListenerDisposeFn) {
-      this.hostClickEventListenerDisposeFn();
-      this.hostClickEventListenerDisposeFn = null;
+    if (this.disposeHostClick) {
+      this.disposeHostClick();
+      this.disposeHostClick = null;
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3807 

## What is the new behavior?
It is not possible to block events when using the angular hostlistener on click and keydown events (see https://github.com/angular/angular/issues/9587), thus the blocking of event-bubbling when the button is aria-disabled, is now handled by registering eventlisteners using the renderer of angular. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] ~~Request that the changes are [UX reviewed]~~ (https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

