### PR TITLE
Modal: Ensure font-family is specified for modals

### DIFF
--- a/libs/core/src/scss/_global-styles.scss
+++ b/libs/core/src/scss/_global-styles.scss
@@ -83,6 +83,7 @@ ion-modal::part(backdrop) {
 
 ion-modal.kirby-overlay {
   position: fixed;
+  font-family: var(--kirby-font-family);
 
   &.kirby-modal {
     --border-radius: 0;


### PR DESCRIPTION
## Which issue does this PR close?

This PR is a quick fix primarily related to alerts. 

## What is the new behavior?
Since alerts and other modals are shown outside of kirby-page-content (and thus ion-content, where the font-family is explicitly defined) other styles with higher specificity (e.g. font family set on the body element with a class) will end up overwriting the one defined in global styles. 

Now, font family is better encapsulated for the modal, and users will have to explicitly set a different font if needed.

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

