### PR TITLE
Deps: Loosen inputmask dependency version requirement

### DIFF
--- a/libs/designsystem/package.json
+++ b/libs/designsystem/package.json
@@ -34,7 +34,7 @@
     "chartjs-plugin-datalabels": "^2.0.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
-    "inputmask": "5.0.8",
+    "inputmask": "^5.0.8",
     "rxjs": "^7.0.0",
     "swiper": "^9.2.0",
     "zone.js": "^0.14.3 || ~0.15.0"


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue, but follows up on #4046

## What is the new behavior?
Allows projects to define and install versions of inputmask within the same major as required by Kirby. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

