### PR TITLE
Deps: fix inputmask imports to preserve existing form field functionality

### DIFF
--- a/libs/designsystem/form-field/src/directives/date/date-input.directive.ts
+++ b/libs/designsystem/form-field/src/directives/date/date-input.directive.ts
@@ -9,7 +9,7 @@ import {
   LOCALE_ID,
   Renderer2,
 } from '@angular/core';
-import Inputmask from 'inputmask';
+import Inputmask from 'inputmask/dist/inputmask.es6.js';
 
 @Directive({
   standalone: true,

--- a/libs/designsystem/form-field/src/directives/date/date-input.directive.ts
+++ b/libs/designsystem/form-field/src/directives/date/date-input.directive.ts
@@ -9,8 +9,7 @@ import {
   LOCALE_ID,
   Renderer2,
 } from '@angular/core';
-import 'inputmask/lib/extensions/inputmask.date.extensions';
-import Inputmask from 'inputmask/lib/inputmask';
+import Inputmask from 'inputmask';
 
 @Directive({
   standalone: true,

--- a/libs/designsystem/form-field/src/directives/decimal-mask/decimal-mask.directive.ts
+++ b/libs/designsystem/form-field/src/directives/decimal-mask/decimal-mask.directive.ts
@@ -9,8 +9,7 @@ import {
   OnInit,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import 'inputmask/lib/extensions/inputmask.numeric.extensions';
-import Inputmask from 'inputmask/lib/inputmask';
+import Inputmask from 'inputmask';
 
 interface InputMask {
   unmaskedvalue: () => string;

--- a/libs/designsystem/form-field/src/directives/decimal-mask/decimal-mask.directive.ts
+++ b/libs/designsystem/form-field/src/directives/decimal-mask/decimal-mask.directive.ts
@@ -9,7 +9,7 @@ import {
   OnInit,
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import Inputmask from 'inputmask';
+import Inputmask from 'inputmask/dist/inputmask.es6.js';
 
 interface InputMask {
   unmaskedvalue: () => string;

--- a/libs/designsystem/package.json
+++ b/libs/designsystem/package.json
@@ -34,7 +34,7 @@
     "chartjs-plugin-datalabels": "^2.0.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
-    "inputmask": "5.0.8",
+    "inputmask": "^5.0.9",
     "rxjs": "^7.0.0",
     "swiper": "^9.2.0",
     "zone.js": "^0.14.3 || ~0.15.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -499,7 +499,7 @@
         "chartjs-plugin-datalabels": "^2.0.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
-        "inputmask": "5.0.8",
+        "inputmask": "^5.0.8",
         "rxjs": "^7.0.0",
         "swiper": "^9.2.0",
         "zone.js": "^0.14.3 || ~0.15.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -499,7 +499,7 @@
         "chartjs-plugin-datalabels": "^2.0.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
-        "inputmask": "^5.0.8",
+        "inputmask": "^5.0.9",
         "rxjs": "^7.0.0",
         "swiper": "^9.2.0",
         "zone.js": "^0.14.3 || ~0.15.0"
@@ -27671,9 +27671,9 @@
       }
     },
     "node_modules/inputmask": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.8.tgz",
-      "integrity": "sha512-1WcbyudPTXP1B28ozWWyFa6QRIUG4KiLoyR6LFHlpT4OfTzRqFfWgHFadNvRuMN1S9XNVz9CdNvCGjJi+uAMqQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.bankdata.dev/artifactory/api/npm/rel-npm/inputmask/-/inputmask-5.0.9.tgz",
+      "integrity": "sha512-s0lUfqcEbel+EQXtehXqwCJGShutgieOaIImFKC/r4reYNvX3foyrChl6LOEvaEgxEbesePIrw1Zi2jhZaDZbQ==",
       "license": "MIT",
       "peer": true
     },


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4070

## What is the new behavior?
Fixed imports to support version 5.0.9 of inputmask, as a follow up to #4069 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

