### PR TITLE
Feature: add sidebar menu to Kirby Extensions

### DIFF
--- a/libs/extensions/angular/sidebar-menu/ng-package.json
+++ b/libs/extensions/angular/sidebar-menu/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/extensions/angular/sidebar-menu/src/animations/drop-down.animation.ts
+++ b/libs/extensions/angular/sidebar-menu/src/animations/drop-down.animation.ts
@@ -1,0 +1,13 @@
+import { animate, AUTO_STYLE, style, transition, trigger } from '@angular/animations';
+
+export const DropDownAnimation = trigger('dropDownMenu', [
+  transition(':enter', [
+    style({ height: 0, overflow: 'hidden' }),
+    animate('300ms ease', style({ height: AUTO_STYLE })),
+  ]),
+
+  transition(':leave', [
+    style({ height: AUTO_STYLE, overflow: 'hidden' }),
+    animate('300ms ease', style({ height: 0 })),
+  ]),
+]);

--- a/libs/extensions/angular/sidebar-menu/src/animations/index.ts
+++ b/libs/extensions/angular/sidebar-menu/src/animations/index.ts
@@ -1,0 +1,1 @@
+export * from './drop-down.animation';

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-container/index.ts
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-container/index.ts
@@ -1,0 +1,1 @@
+export * from './menu-container.component';

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-container/menu-container.component.ts
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-container/menu-container.component.ts
@@ -1,0 +1,54 @@
+import {
+  afterNextRender,
+  Component,
+  ElementRef,
+  inject,
+  input,
+  Signal,
+  signal,
+} from '@angular/core';
+
+import { scrollIntoViewIfNecessary } from '../../functions/scroll-into-view-if-necessary';
+import { SidebarMenuItem } from '../../models';
+import { MenuItemListComponent } from '../menu-item-list';
+
+type ViewModel<T> = {
+  items: Signal<T[]>;
+  disableAnimations: Signal<boolean>;
+};
+
+@Component({
+  selector: 'kirby-x-menu-container',
+  template:
+    '<kirby-x-menu-item-list [items]="vm.items()" [disableAnimations]="vm.disableAnimations()"></kirby-x-menu-item-list>',
+  imports: [MenuItemListComponent],
+})
+export class MenuContainerComponent<T extends SidebarMenuItem> {
+  readonly items = input.required<T[]>();
+
+  readonly #element = inject(ElementRef).nativeElement;
+
+  readonly #disableAnimations = signal<boolean>(true);
+
+  constructor() {
+    afterNextRender({
+      read: () => {
+        this.#scrollSelectedItemIntoView();
+        this.#disableAnimations.set(false);
+      },
+    });
+  }
+
+  #scrollSelectedItemIntoView() {
+    const selectedItem = this.#element.querySelector('.menu-item.selected');
+    const scrollContainer = this.#element.closest('.sidebar-content');
+    if (selectedItem && scrollContainer) {
+      scrollIntoViewIfNecessary(scrollContainer, selectedItem);
+    }
+  }
+
+  readonly vm: ViewModel<T> = {
+    items: this.items,
+    disableAnimations: this.#disableAnimations.asReadonly(),
+  };
+}

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-item-content/index.ts
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-item-content/index.ts
@@ -1,0 +1,1 @@
+export * from './menu-item-content.component';

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-item-content/menu-item-content.component.html
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-item-content/menu-item-content.component.html
@@ -1,0 +1,17 @@
+<div class="menu-item-start">
+  @if (icon(); as icon) {
+    <kirby-icon class="item-icon" size="sm" [name]="icon"></kirby-icon>
+  }
+</div>
+
+<div class="menu-item-content">{{ title() }}</div>
+
+<div class="menu-item-end">
+  @if (badge(); as badge) {
+    <kirby-badge [themeColor]="badge.themeColor ?? 'primary'">{{ badge.value }}</kirby-badge>
+  }
+
+  @if (isExpanded() !== undefined) {
+    <kirby-icon [class.expanded-icon]="isExpanded()" size="sm" name="arrow-more"></kirby-icon>
+  }
+</div>

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-item-content/menu-item-content.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-item-content/menu-item-content.component.scss
@@ -1,0 +1,32 @@
+@use '@kirbydesign/core/src/scss/utils' as utils;
+
+:host {
+  display: flex;
+  width: 100%;
+}
+
+.menu-item-start {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: utils.icon-font-size('sm');
+  height: utils.icon-font-size('sm');
+}
+
+.menu-item-content {
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
+  margin-inline-start: utils.size('xs');
+  font-size: inherit;
+}
+
+.menu-item-end {
+  display: inline-flex;
+  align-items: center;
+  height: utils.icon-font-size('sm');
+}
+
+.expanded-icon {
+  transform: rotate(90deg) !important;
+}

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-item-content/menu-item-content.component.ts
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-item-content/menu-item-content.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { IconModule } from '@kirbydesign/designsystem/icon';
+import { BadgeComponent } from '@kirbydesign/designsystem/badge';
+
+import { Badge } from '../../models';
+
+@Component({
+  selector: 'kirby-x-menu-item-content',
+  templateUrl: './menu-item-content.component.html',
+  styleUrls: ['./menu-item-content.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [IconModule, BadgeComponent],
+})
+export class MenuItemContentComponent {
+  readonly title = input.required<string>();
+  readonly icon = input<string>();
+  readonly badge = input<Badge>();
+  readonly isExpanded = input<boolean>();
+}

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-item-list/index.ts
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-item-list/index.ts
@@ -1,0 +1,1 @@
+export * from './menu-item-list.component';

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-item-list/menu-item-list.component.html
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-item-list/menu-item-list.component.html
@@ -1,0 +1,85 @@
+@let level = vm.level();
+<div class="menu-item-list menu-item-list-{{ level }}" [attr.id]="vm.id()">
+  @for (item of vm.items(); track item.id) {
+    @if (item.isDivider) {
+      <kirby-divider></kirby-divider>
+    } @else if (item.children) {
+      @let submenuId = `item-${item.id}-content`;
+      <button
+        type="button"
+        class="menu-item menu-item-{{ level }} togglable-menu-item"
+        [attr.id]="'item' + item.id"
+        [attr.aria-controls]="submenuId"
+        [attr.aria-expanded]="item.isExpanded"
+        (click)="vm.toggleSubmenu(item)"
+      >
+        <kirby-x-menu-item-content
+          [title]="item.title ?? ''"
+          [icon]="item.icon"
+          [badge]="item.badge"
+          [isExpanded]="item.isExpanded ?? false"
+        ></kirby-x-menu-item-content>
+      </button>
+      @if (item.isExpanded) {
+        <div [@dropDownMenu] [@.disabled]="vm.disableAnimations()">
+          <kirby-x-menu-item-list
+            [items]="item.children"
+            [level]="level + 1"
+            [id]="submenuId"
+            [disableAnimations]="disableAnimations()"
+          ></kirby-x-menu-item-list>
+        </div>
+      }
+    } @else if (item.isAction) {
+      <a
+        class="menu-item menu-item-{{ level }} clickable-menu-item"
+        [class.selected]="item.selected ?? false"
+        [attr.id]="'item' + item.id"
+        [attr.href]="item.link?.url ?? ''"
+        (click)="$event.preventDefault(); vm.selectItem(item)"
+        (keydown.enter)="$event.preventDefault(); vm.selectItem(item)"
+      >
+        <kirby-x-menu-item-content
+          [title]="item.title ?? ''"
+          [icon]="item.icon"
+          [badge]="item.badge"
+        ></kirby-x-menu-item-content>
+      </a>
+    } @else if (item.link?.relativeLink) {
+      <a
+        class="menu-item menu-item-{{ level }} clickable-menu-item"
+        [class.selected]="item.selected ?? false"
+        [attr.id]="'item' + item.id"
+        [target]="item.link?.target ?? '_self'"
+        [routerLink]="item.link?.relativeLink"
+        [queryParams]="item.link?.queryParams"
+        [skipLocationChange]="item.skipLocationChange ?? false"
+        [replaceUrl]="item.replaceUrl ?? false"
+        (click)="vm.selectItem(item)"
+        (keydown.enter)="vm.selectItem(item)"
+      >
+        <kirby-x-menu-item-content
+          [title]="item.title ?? ''"
+          [icon]="item.icon"
+          [badge]="item.badge"
+        ></kirby-x-menu-item-content>
+      </a>
+    } @else if (item.link?.url) {
+      <a
+        class="menu-item menu-item-{{ level }} clickable-menu-item"
+        [class.selected]="item.selected ?? false"
+        [attr.id]="'item' + item.id"
+        [attr.href]="item.link?.url"
+        [attr.target]="item.link?.target"
+        (click)="vm.selectItem(item)"
+        (keydown.enter)="vm.selectItem(item)"
+      >
+        <kirby-x-menu-item-content
+          [title]="item.title ?? ''"
+          [icon]="item.icon"
+          [badge]="item.badge"
+        ></kirby-x-menu-item-content>
+      </a>
+    }
+  }
+</div>

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-item-list/menu-item-list.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-item-list/menu-item-list.component.scss
@@ -1,0 +1,66 @@
+@use '@kirbydesign/core/src/scss/utils' as utils;
+
+.menu-item-list-0 {
+  padding-left: 8px;
+  padding-right: 8px;
+}
+
+.menu-item-list-1 {
+  font-size: utils.font-size('s');
+}
+
+.menu-item {
+  display: flex;
+  align-items: center;
+  padding: utils.size('xxs') utils.size('s');
+  border-radius: utils.border-radius('s');
+  color: inherit;
+  outline: none;
+
+  &:hover {
+    background-color: var(--menuitem-hover-background-color, utils.get-color('tertiary-tint'));
+  }
+
+  &:focus-visible {
+    --kirby-background-color: var(
+      --menuitem-hover-background-color,
+      #{utils.get-color('tertiary')}
+    );
+
+    box-shadow: inset 0 0 0 utils.size('xxxxs') utils.$focus-ring-color;
+  }
+}
+
+.clickable-menu-item {
+  text-decoration: none;
+
+  &:focus-visible:not(.selected) {
+    background-color: var(--menuitem-hover-background-color, utils.get-color('tertiary-tint'));
+  }
+
+  &.selected {
+    background-color: var(--menuitem-selected-background-color, utils.get-color('primary'));
+    color: var(--menuitem-selected-color, utils.get-color('primary-contrast'));
+    font-weight: utils.font-weight('bold');
+  }
+}
+
+.togglable-menu-item {
+  width: 100%;
+  border: none;
+  background-color: transparent;
+  font-size: inherit;
+  font-family: inherit;
+  text-align: left;
+
+  &[aria-expanded='true'] {
+    font-weight: utils.font-weight('bold');
+  }
+}
+
+kirby-divider {
+  display: block;
+  width: 100%;
+  opacity: 0.2;
+  margin: 8px -8px;
+}

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-item-list/menu-item-list.component.ts
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-item-list/menu-item-list.component.ts
@@ -1,0 +1,56 @@
+import { ChangeDetectionStrategy, Component, computed, inject, input, Signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { DividerComponent } from '@kirbydesign/designsystem/divider';
+import { DropDownAnimation } from '../../animations';
+import { ensureInView } from '../../functions/ensure-in-view';
+import { SidebarMenuItem } from '../../models';
+import { MenuStateService } from '../../services/menu-state';
+import { MenuItemContentComponent } from '../menu-item-content';
+
+type ViewModel<T> = {
+  id: Signal<string | undefined>;
+  items: Signal<T[]>;
+  level: Signal<number>;
+  disableAnimations: Signal<boolean>;
+  toggleSubmenu: (item: T) => void;
+  selectItem: (item: T) => void;
+};
+
+@Component({
+  selector: 'kirby-x-menu-item-list',
+  templateUrl: './menu-item-list.component.html',
+  styleUrls: ['./menu-item-list.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  animations: [DropDownAnimation],
+  imports: [DividerComponent, MenuItemContentComponent, RouterLink],
+})
+export class MenuItemListComponent<T extends SidebarMenuItem> {
+  readonly items = input.required<T[]>();
+  readonly level = input<number>(0);
+  readonly id = input<string>();
+  readonly disableAnimations = input<boolean>(false);
+
+  readonly #menuStateService = inject(MenuStateService);
+
+  #toggleSubmenu(item: T) {
+    const itemElement = document.getElementById(`item${item.id}`);
+    const scrollContainer: HTMLElement | null = itemElement?.closest('.sidebar-content') ?? null;
+    if (itemElement && scrollContainer) {
+      ensureInView(scrollContainer, itemElement, 400);
+    }
+    this.#menuStateService.toggledSubmenu = item;
+  }
+
+  #selectItem(item: T) {
+    this.#menuStateService.selectedItem = item;
+  }
+
+  readonly vm: ViewModel<T> = {
+    id: this.id,
+    items: computed(() => this.items().filter((item) => !item.hidden)),
+    level: this.level,
+    disableAnimations: this.disableAnimations,
+    toggleSubmenu: this.#toggleSubmenu.bind(this),
+    selectItem: this.#selectItem.bind(this),
+  };
+}

--- a/libs/extensions/angular/sidebar-menu/src/directives/height-observer/height-observer.directive.ts
+++ b/libs/extensions/angular/sidebar-menu/src/directives/height-observer/height-observer.directive.ts
@@ -1,0 +1,29 @@
+import { Directive, ElementRef, inject, OnDestroy, output } from '@angular/core';
+import { debounceTime, Subject } from 'rxjs';
+import { distinctUntilChanged } from 'rxjs/operators';
+
+@Directive({
+  selector: '[kirbyXHeightObserver]',
+})
+export class HeightObserverDirective implements OnDestroy {
+  readonly heightChange = output<number>();
+
+  readonly #element = inject(ElementRef).nativeElement;
+  readonly #heightChanges = new Subject<number>();
+
+  readonly #observer = new ResizeObserver((entries) => {
+    this.#heightChanges.next(entries[0].contentRect.height);
+  });
+
+  constructor() {
+    this.#observer.observe(this.#element, { box: 'content-box' });
+    this.#heightChanges
+      .pipe(debounceTime(50), distinctUntilChanged())
+      .subscribe(this.heightChange.emit.bind(this.heightChange));
+  }
+
+  ngOnDestroy() {
+    this.#observer.unobserve(this.#element);
+    this.#observer.disconnect();
+  }
+}

--- a/libs/extensions/angular/sidebar-menu/src/directives/height-observer/index.ts
+++ b/libs/extensions/angular/sidebar-menu/src/directives/height-observer/index.ts
@@ -1,0 +1,1 @@
+export * from './height-observer.directive';

--- a/libs/extensions/angular/sidebar-menu/src/functions/ensure-in-view/ensure-in-view.function.ts
+++ b/libs/extensions/angular/sidebar-menu/src/functions/ensure-in-view/ensure-in-view.function.ts
@@ -1,0 +1,27 @@
+import { scrollIntoViewIfNecessary } from '../scroll-into-view-if-necessary';
+
+/**
+ * Ensures the element top is not smaller than the scroll container top.
+ */
+export function ensureInView(
+  scrollContainer: HTMLElement,
+  element: HTMLElement,
+  durationMs: number
+): void {
+  let startTime: number | null = null;
+
+  const updatePosition = (timestamp: number) => {
+    if (!startTime) {
+      startTime = timestamp;
+    }
+
+    const elapsedTime = timestamp - startTime;
+
+    if (elapsedTime < durationMs) {
+      scrollIntoViewIfNecessary(scrollContainer, element, 'start');
+      requestAnimationFrame(updatePosition);
+    }
+  };
+
+  requestAnimationFrame(updatePosition);
+}

--- a/libs/extensions/angular/sidebar-menu/src/functions/ensure-in-view/index.ts
+++ b/libs/extensions/angular/sidebar-menu/src/functions/ensure-in-view/index.ts
@@ -1,0 +1,1 @@
+export * from './ensure-in-view.function';

--- a/libs/extensions/angular/sidebar-menu/src/functions/scroll-into-view-if-necessary/index.ts
+++ b/libs/extensions/angular/sidebar-menu/src/functions/scroll-into-view-if-necessary/index.ts
@@ -1,0 +1,1 @@
+export * from './scroll-into-view-if-necessary.function';

--- a/libs/extensions/angular/sidebar-menu/src/functions/scroll-into-view-if-necessary/scroll-into-view-if-necessary.function.ts
+++ b/libs/extensions/angular/sidebar-menu/src/functions/scroll-into-view-if-necessary/scroll-into-view-if-necessary.function.ts
@@ -1,0 +1,19 @@
+/**
+ * the HTMLElement.scrollIntoViewIfNecessary is non-standard and not supported in all browsers (e.g. firefox),
+ * so we implement a version based on standard
+ */
+export function scrollIntoViewIfNecessary(
+  scrollContainer: HTMLElement,
+  child: HTMLElement,
+  position: ScrollLogicalPosition = 'center'
+) {
+  const containerRect = scrollContainer.getBoundingClientRect();
+  const elementRect = child.getBoundingClientRect();
+  if (containerRect.top > elementRect.top || containerRect.bottom < elementRect.bottom) {
+    child.scrollIntoView({
+      behavior: 'instant',
+      block: position,
+      inline: position,
+    });
+  }
+}

--- a/libs/extensions/angular/sidebar-menu/src/functions/select-menu-item/index.ts
+++ b/libs/extensions/angular/sidebar-menu/src/functions/select-menu-item/index.ts
@@ -1,0 +1,1 @@
+export * from './select-menu-item.function';

--- a/libs/extensions/angular/sidebar-menu/src/functions/select-menu-item/select-menu-item.function.spec.ts
+++ b/libs/extensions/angular/sidebar-menu/src/functions/select-menu-item/select-menu-item.function.spec.ts
@@ -1,0 +1,61 @@
+import { SidebarMenuItem } from '../../models';
+import { selectMenuItem } from './select-menu-item.function';
+
+const menuItemsMock: SidebarMenuItem[] = [
+  {
+    id: 'home',
+    title: 'Home',
+    selected: false,
+  },
+  {
+    id: 'products',
+    title: 'Products',
+    isExpanded: false,
+    children: [
+      {
+        id: 'product-1',
+        title: 'Product 1',
+        selected: false,
+      },
+    ],
+  },
+  {
+    id: 'settings',
+    title: 'Settings',
+    isExpanded: true,
+    children: [
+      {
+        id: 'advanced',
+        title: 'Advanced',
+        isExpanded: true,
+        children: [
+          {
+            id: 'nested-setting',
+            title: 'Nested Setting',
+            selected: true,
+          },
+        ],
+      },
+    ],
+  },
+];
+
+describe('Function: selectMenuItem', () => {
+  it('should select the item with the given id', () => {
+    const result = selectMenuItem('home', menuItemsMock);
+
+    expect(result[0].selected).toBe(true);
+  });
+
+  it('should deselect any previously selected item', () => {
+    const result = selectMenuItem('home', menuItemsMock);
+
+    expect(result[2].children?.[0].children?.[0].selected).toBe(false);
+  });
+
+  it('should NOT select nested item when parent is collapsed', () => {
+    const result = selectMenuItem('product-1', menuItemsMock);
+
+    expect(result[1].children?.[0].selected).toBe(false);
+  });
+});

--- a/libs/extensions/angular/sidebar-menu/src/functions/select-menu-item/select-menu-item.function.ts
+++ b/libs/extensions/angular/sidebar-menu/src/functions/select-menu-item/select-menu-item.function.ts
@@ -1,0 +1,13 @@
+import { SidebarMenuItem } from '../../models';
+
+export function selectMenuItem<T extends SidebarMenuItem>(itemId: string, items: T[]): T[] {
+  return items.map((item) => {
+    if (item.id === itemId) {
+      return { ...item, selected: true };
+    }
+    if (item.children) {
+      return item.isExpanded ? { ...item, children: selectMenuItem(itemId, item.children) } : item;
+    }
+    return { ...item, selected: false };
+  });
+}

--- a/libs/extensions/angular/sidebar-menu/src/functions/toggle-submenu-auto-collapsed/index.ts
+++ b/libs/extensions/angular/sidebar-menu/src/functions/toggle-submenu-auto-collapsed/index.ts
@@ -1,0 +1,1 @@
+export * from './toggle-submenu-auto-collapsed.function';

--- a/libs/extensions/angular/sidebar-menu/src/functions/toggle-submenu-auto-collapsed/toggle-submenu-auto-collapsed.function.spec.ts
+++ b/libs/extensions/angular/sidebar-menu/src/functions/toggle-submenu-auto-collapsed/toggle-submenu-auto-collapsed.function.spec.ts
@@ -1,0 +1,95 @@
+import { SidebarMenuItem } from '../../models';
+import { toggleSubmenuAutoCollapsed } from './toggle-submenu-auto-collapsed.function';
+
+const menuItemsMock: SidebarMenuItem[] = [
+  {
+    id: 'products',
+    title: 'Products',
+    isExpanded: true,
+    children: [
+      {
+        id: 'product-1',
+        title: 'Product 1',
+        isExpanded: true,
+        children: [
+          {
+            id: 'sub-product-1',
+            title: 'Sub Product 1',
+            isExpanded: false,
+            children: [{ id: 'deep-sub-product-1', title: 'Deep Sub Product 1' }],
+          },
+          {
+            id: 'sub-product-2',
+            title: 'Sub Product 2',
+            isExpanded: true,
+            children: [{ id: 'deep-sub-product-2', title: 'Deep Sub Product 2' }],
+          },
+        ],
+      },
+      {
+        id: 'product-2',
+        title: 'Product 2',
+        isExpanded: false,
+        children: [{ id: 'sub-product-2', title: 'Sub Product 2' }],
+      },
+    ],
+  },
+  {
+    id: 'settings',
+    title: 'Settings',
+    isExpanded: false,
+    children: [
+      {
+        id: 'general',
+        title: 'General',
+        isExpanded: false,
+        children: [
+          {
+            id: 'profile',
+            title: 'Profile',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+describe('Function: toggleSubmenuAutoCollapsed', () => {
+  it('should expand collapsed submenu and collapse all siblings and their children', () => {
+    const result = toggleSubmenuAutoCollapsed('product-2', menuItemsMock);
+
+    expect(result[0].children?.[1].isExpanded).toBe(true);
+    expect(result[0].children?.[0].isExpanded).toBe(false);
+    expect(result[0].children?.[0].children?.[1].isExpanded).toBe(false);
+  });
+
+  it('should collapse expanded submenu and its children', () => {
+    const result = toggleSubmenuAutoCollapsed('products', menuItemsMock);
+
+    expect(result[0].isExpanded).toBe(false);
+    expect(result[0].children?.[0].isExpanded).toBe(false);
+    expect(result[0].children?.[0].children?.[1].isExpanded).toBe(false);
+  });
+
+  it('should not collapse ancestors when expanding nested submenu', () => {
+    const result = toggleSubmenuAutoCollapsed('sub-product-1', menuItemsMock);
+
+    expect(result[0].isExpanded).toBe(true);
+    expect(result[0].children?.[0].isExpanded).toBe(true);
+    expect(result[0].children?.[0].children?.[0].isExpanded).toBe(true);
+  });
+
+  it('should not collapse ancestors when collapsing nested submenu', () => {
+    const result = toggleSubmenuAutoCollapsed('sub-product-2', menuItemsMock);
+
+    expect(result[0].isExpanded).toBe(true);
+    expect(result[0].children?.[0].isExpanded).toBe(true);
+    expect(result[0].children?.[0].children?.[1].isExpanded).toBe(false);
+  });
+
+  it('should NOT toggle nested submenu when parent is collapsed', () => {
+    const result = toggleSubmenuAutoCollapsed('general', menuItemsMock);
+
+    expect(result[1].children?.[0].isExpanded).toBe(false);
+  });
+});

--- a/libs/extensions/angular/sidebar-menu/src/functions/toggle-submenu-auto-collapsed/toggle-submenu-auto-collapsed.function.ts
+++ b/libs/extensions/angular/sidebar-menu/src/functions/toggle-submenu-auto-collapsed/toggle-submenu-auto-collapsed.function.ts
@@ -1,0 +1,41 @@
+import { SidebarMenuItem } from '../../models';
+
+export function toggleSubmenuAutoCollapsed<T extends SidebarMenuItem>(
+  itemId: string,
+  items: T[]
+): T[] {
+  return toggleSubmenuAndCollapseNonAncestors(itemId, items).updatedItems;
+}
+
+function toggleSubmenuAndCollapseNonAncestors<T extends SidebarMenuItem>(
+  itemId: string,
+  items: T[]
+): { updatedItems: T[]; isAncestor: boolean } {
+  let found = false;
+  const updatedItems = items.map((item) => {
+    if (found) {
+      return collapse(item);
+    }
+    if (item.id === itemId) {
+      found = true;
+      return item.isExpanded ? collapse(item) : { ...item, isExpanded: true };
+    }
+    if (item.children && item.isExpanded) {
+      const { updatedItems, isAncestor } = toggleSubmenuAndCollapseNonAncestors(
+        itemId,
+        item.children
+      );
+      found = isAncestor;
+      return { ...item, isExpanded: isAncestor, children: updatedItems };
+    }
+    return item;
+  });
+  return { updatedItems, isAncestor: found };
+}
+
+function collapse<T extends SidebarMenuItem>(item: T): T {
+  if (item.children && item.isExpanded) {
+    return { ...item, isExpanded: false, children: item.children.map(collapse) };
+  }
+  return item;
+}

--- a/libs/extensions/angular/sidebar-menu/src/functions/toggle-submenu/index.ts
+++ b/libs/extensions/angular/sidebar-menu/src/functions/toggle-submenu/index.ts
@@ -1,0 +1,1 @@
+export * from './toggle-submenu.function';

--- a/libs/extensions/angular/sidebar-menu/src/functions/toggle-submenu/toggle-submenu.function.spec.ts
+++ b/libs/extensions/angular/sidebar-menu/src/functions/toggle-submenu/toggle-submenu.function.spec.ts
@@ -1,0 +1,75 @@
+import { SidebarMenuItem } from '../../models';
+import { toggleSubmenu } from './toggle-submenu.function';
+
+const menuItemsMock: SidebarMenuItem[] = [
+  {
+    id: 'home',
+    title: 'Home',
+  },
+  {
+    id: 'products',
+    title: 'Products',
+    isExpanded: true,
+    children: [
+      {
+        id: 'product-1',
+        title: 'Product 1',
+      },
+      {
+        id: 'nested-parent',
+        title: 'Nested Parent',
+        isExpanded: false,
+        children: [
+          {
+            id: 'nested-child',
+            title: 'Nested Child',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'settings',
+    title: 'Settings',
+    isExpanded: false,
+    children: [
+      {
+        id: 'general',
+        title: 'General',
+        isExpanded: false,
+        children: [
+          {
+            id: 'profile',
+            title: 'Profile',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+describe('Function: toggleSubmenu', () => {
+  it('should expand collapsed menu', () => {
+    const result = toggleSubmenu('home', menuItemsMock);
+
+    expect(result[0].isExpanded).toBe(true);
+  });
+
+  it('should collapse expanded menu', () => {
+    const result = toggleSubmenu('products', menuItemsMock);
+
+    expect(result[1].isExpanded).toBe(false);
+  });
+
+  it('should toggle nested submenu', () => {
+    const result = toggleSubmenu('product-1', menuItemsMock);
+
+    expect(result[1].children?.[0].isExpanded).toBe(true);
+  });
+
+  it('should NOT toggle nested submenu when parent is collapsed', () => {
+    const result = toggleSubmenu('general', menuItemsMock);
+
+    expect(result[2].children?.[0].isExpanded).toBe(false);
+  });
+});

--- a/libs/extensions/angular/sidebar-menu/src/functions/toggle-submenu/toggle-submenu.function.ts
+++ b/libs/extensions/angular/sidebar-menu/src/functions/toggle-submenu/toggle-submenu.function.ts
@@ -1,0 +1,13 @@
+import { SidebarMenuItem } from '../../models';
+
+export function toggleSubmenu<T extends SidebarMenuItem>(itemId: string, items: T[]): T[] {
+  return items.map((item) => {
+    if (item.id === itemId) {
+      return { ...item, isExpanded: !item.isExpanded };
+    }
+    if (item.children && item.isExpanded) {
+      return { ...item, children: toggleSubmenu(itemId, item.children) };
+    }
+    return item;
+  });
+}

--- a/libs/extensions/angular/sidebar-menu/src/index.ts
+++ b/libs/extensions/angular/sidebar-menu/src/index.ts
@@ -1,0 +1,4 @@
+export * from './models';
+export * from './public-components/sidebar';
+export * from './public-components/sidebar-footer';
+export * from './public-components/sidebar-header';

--- a/libs/extensions/angular/sidebar-menu/src/models/index.ts
+++ b/libs/extensions/angular/sidebar-menu/src/models/index.ts
@@ -1,0 +1,1 @@
+export * from './menu-item';

--- a/libs/extensions/angular/sidebar-menu/src/models/menu-item.ts
+++ b/libs/extensions/angular/sidebar-menu/src/models/menu-item.ts
@@ -1,0 +1,36 @@
+import type { ThemeColor } from '@kirbydesign/designsystem';
+
+export type Params = {
+  [key: string]: any;
+};
+
+export interface SidebarMenuItem {
+  id: string;
+  title?: string;
+  link?: Link;
+  icon?: string;
+  iconEnd?: string;
+  selected?: boolean;
+  selectable?: boolean;
+  isAction?: boolean;
+  isExpanded?: boolean;
+  isDivider?: boolean;
+  skipLocationChange?: boolean;
+  replaceUrl?: boolean;
+  hidden?: boolean;
+  badge?: Badge;
+  children?: this[];
+}
+
+export interface Badge {
+  value: string;
+  themeColor?: ThemeColor;
+  slot?: string;
+}
+
+export interface Link {
+  url?: string;
+  target?: string;
+  relativeLink?: string;
+  queryParams?: Params;
+}

--- a/libs/extensions/angular/sidebar-menu/src/public-components/sidebar-footer/index.ts
+++ b/libs/extensions/angular/sidebar-menu/src/public-components/sidebar-footer/index.ts
@@ -1,0 +1,1 @@
+export * from './sidebar-footer.component';

--- a/libs/extensions/angular/sidebar-menu/src/public-components/sidebar-footer/sidebar-footer.component.ts
+++ b/libs/extensions/angular/sidebar-menu/src/public-components/sidebar-footer/sidebar-footer.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'kirby-x-sidebar-footer',
+  template: '<ng-content></ng-content>',
+})
+export class SidebarFooterComponent {}

--- a/libs/extensions/angular/sidebar-menu/src/public-components/sidebar-header/index.ts
+++ b/libs/extensions/angular/sidebar-menu/src/public-components/sidebar-header/index.ts
@@ -1,0 +1,1 @@
+export * from './sidebar-header.component';

--- a/libs/extensions/angular/sidebar-menu/src/public-components/sidebar-header/sidebar-header.component.ts
+++ b/libs/extensions/angular/sidebar-menu/src/public-components/sidebar-header/sidebar-header.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'kirby-x-sidebar-header',
+  template: '<span class="sidebar-logo"><ng-content></ng-content></span>',
+  styles: [
+    `
+      .sidebar-logo {
+        display: flex;
+        align-items: center;
+        margin: 32px 0;
+        height: 50px;
+      }
+    `,
+  ],
+})
+export class SidebarHeaderComponent {}

--- a/libs/extensions/angular/sidebar-menu/src/public-components/sidebar/index.ts
+++ b/libs/extensions/angular/sidebar-menu/src/public-components/sidebar/index.ts
@@ -1,0 +1,1 @@
+export * from './sidebar.component';

--- a/libs/extensions/angular/sidebar-menu/src/public-components/sidebar/sidebar.component.html
+++ b/libs/extensions/angular/sidebar-menu/src/public-components/sidebar/sidebar.component.html
@@ -1,0 +1,20 @@
+<nav class="sidebar">
+  <div class="sidebar-header" [class.bottom-border]="vm.showHeaderBottomBorder()">
+    <ng-content select="kirby-x-sidebar-header"></ng-content>
+  </div>
+  <div
+    kirbyXHeightObserver
+    class="sidebar-content"
+    (scroll)="vm.setScroll($event)"
+    (heightChange)="vm.setContainerHeight($event)"
+  >
+    <kirby-x-menu-container
+      kirbyXHeightObserver
+      [items]="vm.items()"
+      (heightChange)="vm.setMenuHeight($event)"
+    ></kirby-x-menu-container>
+  </div>
+  <div class="sidebar-footer" [class.top-border]="vm.showFooterTopBorder()">
+    <ng-content select="kirby-x-sidebar-footer"></ng-content>
+  </div>
+</nav>

--- a/libs/extensions/angular/sidebar-menu/src/public-components/sidebar/sidebar.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/public-components/sidebar/sidebar.component.scss
@@ -1,0 +1,74 @@
+@use '@kirbydesign/core/src/scss/utils' as utils;
+@use 'sass:color';
+
+.sidebar {
+  height: 100%; // Fallback for browsers that do not support dynamic viewport units
+  height: 100dvh;
+  background-color: var(--sidebar-background-color, utils.get-color('tertiary'));
+  color: var(--sidebar-color, utils.get-color('tertiary-contrast'));
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: utils.get-color('semi-dark') utils.get-color('tertiary');
+  }
+
+  /* Works on Chrome, Edge, and Safari */
+  *::-webkit-scrollbar {
+    width: 16px;
+  }
+
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  /* get kirby color with 50% opacity */
+  *::-webkit-scrollbar-thumb {
+    background-color: color.adjust(utils.get-color('semi-dark', $getValueOnly: true), $alpha: -0.5);
+    border-radius: 20px;
+    border: 4px solid transparent;
+    background-clip: content-box;
+  }
+}
+
+.sidebar-content {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+
+  @supports (scrollbar-gutter: stable) {
+    overflow: hidden auto;
+    scrollbar-gutter: auto;
+  }
+}
+
+.sidebar-header,
+.sidebar-footer {
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  position: sticky;
+}
+
+.sidebar-header {
+  padding: 0 24px;
+
+  &.bottom-border {
+    box-shadow: 0 4px 10px 2px rgb(28 28 28 / 30%);
+    transition: opacity 0.3s;
+  }
+}
+
+.sidebar-footer {
+  min-height: 80px;
+
+  &.top-border {
+    box-shadow: 0 -4px 10px 2px rgb(28 28 28 / 30%);
+    transition: opacity 0.3s;
+  }
+}

--- a/libs/extensions/angular/sidebar-menu/src/public-components/sidebar/sidebar.component.spec.ts
+++ b/libs/extensions/angular/sidebar-menu/src/public-components/sidebar/sidebar.component.spec.ts
@@ -1,0 +1,140 @@
+import { createHostFactory } from '@ngneat/spectator/jest';
+import { SidebarService } from '../../services/sidebar';
+import { MenuStateService } from '../../services/menu-state';
+import { SidebarMenuItem } from '../../models';
+import { SidebarComponent } from './sidebar.component';
+
+const menuItemMock1 = { id: '1', children: [], isExpanded: false };
+const menuItemMock2 = { id: '2' };
+const menuItemMock3 = { id: '3', children: [{ id: '3.1', selected: true }], isExpanded: true };
+const menuItemsMock: SidebarMenuItem[] = [menuItemMock1, menuItemMock2, menuItemMock3];
+
+type HostProps = {
+  menuItems: SidebarMenuItem[];
+  autoCollapse: boolean;
+};
+
+describe(SidebarComponent.name, () => {
+  const createHost = createHostFactory({
+    component: SidebarComponent,
+    providers: [SidebarService, MenuStateService],
+  });
+
+  const render = (propOverrides: Partial<HostProps> = {}) =>
+    createHost(
+      `<kirby-x-sidebar [menuItems]="menuItems" [autoCollapse]="autoCollapse"></kirby-x-sidebar>`,
+      {
+        hostProps: {
+          menuItems: menuItemsMock,
+          ...propOverrides,
+        },
+      }
+    );
+
+  beforeAll(() => {
+    global.ResizeObserver = jest.fn().mockImplementation(() => ({
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+      disconnect: jest.fn(),
+    }));
+  });
+
+  describe('Effect : submenu toggled', () => {
+    it('should emit the toggled submenu', async () => {
+      const spectator = render();
+      const stateService = spectator.inject(MenuStateService);
+      const emitSpy = jest.spyOn(spectator.component.afterMenuToggled, 'emit');
+
+      stateService.toggledSubmenu = menuItemMock1;
+
+      spectator.detectChanges();
+      await spectator.fixture.whenStable();
+
+      expect(emitSpy).toHaveBeenCalledWith(menuItemMock1);
+    });
+
+    it('should expand the submenu if it was previously collapsed', async () => {
+      const spectator = render();
+      const stateService = spectator.inject(MenuStateService);
+
+      stateService.toggledSubmenu = menuItemMock1;
+
+      spectator.detectChanges();
+      await spectator.fixture.whenStable();
+
+      expect(spectator.component.menuItems()[0]).toEqual({ ...menuItemMock1, isExpanded: true });
+      expect(spectator.component.menuItems()[2]).toEqual({ ...menuItemMock3, isExpanded: true });
+    });
+
+    it('should collapse the submenu if it was previously expanded', async () => {
+      const spectator = render();
+      const stateService = spectator.inject(MenuStateService);
+
+      stateService.toggledSubmenu = menuItemMock3;
+
+      spectator.detectChanges();
+      await spectator.fixture.whenStable();
+
+      expect(spectator.component.menuItems()[0]).toEqual({ ...menuItemMock1, isExpanded: false });
+      expect(spectator.component.menuItems()[2]).toEqual({ ...menuItemMock3, isExpanded: false });
+    });
+
+    it('should expand the submenu and collapse others when autoCollapse is true', async () => {
+      const spectator = render({ autoCollapse: true });
+      const stateService = spectator.inject(MenuStateService);
+
+      stateService.toggledSubmenu = menuItemMock1;
+
+      spectator.detectChanges();
+      await spectator.fixture.whenStable();
+
+      expect(spectator.component.menuItems()[0]).toEqual({ ...menuItemMock1, isExpanded: true });
+      expect(spectator.component.menuItems()[2]).toEqual({ ...menuItemMock3, isExpanded: false });
+    });
+  });
+
+  describe('Effect : menu item selected', () => {
+    it('should emit the selected menu item', async () => {
+      const spectator = render();
+      const stateService = spectator.inject(MenuStateService);
+      const emitSpy = jest.spyOn(spectator.component.afterMenuClicked, 'emit');
+
+      stateService.selectedItem = menuItemMock2;
+
+      spectator.detectChanges();
+      await spectator.fixture.whenStable();
+
+      expect(emitSpy).toHaveBeenCalledWith(menuItemMock2);
+    });
+
+    it('should update the selected status of the menu items', async () => {
+      const spectator = render();
+      const stateService = spectator.inject(MenuStateService);
+
+      stateService.selectedItem = menuItemMock2;
+
+      spectator.detectChanges();
+      await spectator.fixture.whenStable();
+
+      expect(spectator.component.menuItems()[1]).toEqual({ ...menuItemMock2, selected: true });
+      expect(spectator.component.menuItems()[2].children?.[0]).toEqual({
+        ...menuItemMock3.children[0],
+        selected: false,
+      });
+    });
+  });
+
+  describe('Effect : menuItemsChanged backwards compatability', () => {
+    it('should emit menuItemsChanged when menu items changes', async () => {
+      const spectator = render();
+      const emitSpy = jest.spyOn(spectator.component.menuItemsChanged, 'emit');
+
+      spectator.component.menuItems.set([{ id: 'new', children: [] }]);
+
+      spectator.detectChanges();
+      await spectator.fixture.whenStable();
+
+      expect(emitSpy).toHaveBeenCalledWith([{ id: 'new', children: [] }]);
+    });
+  });
+});

--- a/libs/extensions/angular/sidebar-menu/src/public-components/sidebar/sidebar.component.stories.ts
+++ b/libs/extensions/angular/sidebar-menu/src/public-components/sidebar/sidebar.component.stories.ts
@@ -1,0 +1,212 @@
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import {
+  SidebarComponent,
+  SidebarFooterComponent,
+  SidebarHeaderComponent,
+  SidebarMenuItem,
+} from '@kirbydesign/extensions-angular/sidebar-menu';
+import { provideRouter } from '@angular/router';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { IconModule } from '@kirbydesign/designsystem/icon';
+
+const menuItemsMock: SidebarMenuItem[] = [
+  {
+    id: 'dashboard',
+    title: 'Dashboard',
+    icon: 'home',
+    selected: true,
+    link: { relativeLink: '/dashboard' },
+  },
+  {
+    id: 'inbox',
+    title: 'Inbox',
+    icon: 'inbox-outline',
+    badge: { value: '5', themeColor: 'danger' },
+    link: { relativeLink: '/inbox' },
+  },
+  {
+    id: 'accounts',
+    title: 'Accounts',
+    icon: 'accounts-outline',
+    isExpanded: false,
+    children: [],
+  },
+  {
+    id: 'investments',
+    title: 'Investments',
+    icon: 'investment',
+    link: { relativeLink: '/investments' },
+  },
+  {
+    id: 'divider-1',
+    isDivider: true,
+  },
+  {
+    id: 'administration',
+    title: 'Administration',
+    icon: 'person-outline',
+    isExpanded: true,
+    children: [
+      {
+        id: 'users',
+        title: 'Users',
+        link: { relativeLink: '/users' },
+      },
+      {
+        id: 'roles',
+        title: 'Roles',
+        link: { relativeLink: '/roles' },
+      },
+      {
+        id: 'permissions',
+        title: 'Permissions',
+        link: { relativeLink: '/permissions' },
+      },
+    ],
+  },
+  {
+    id: 'divider-2',
+    isDivider: true,
+  },
+  {
+    id: 'settings',
+    title: 'Settings',
+    icon: 'cog',
+    isAction: true,
+  },
+  {
+    id: 'help',
+    title: 'Help',
+    icon: 'support',
+    link: { url: 'https://cookbook.kirby.design', target: '_blank' },
+  },
+];
+
+/**
+ * The sidebar menu is meant to be used as the main navigation in an application.
+ * While designed with the intention of being used as a vertical sidebar, it is up to the user to provide the correct styling and layout to fit their use case.
+ *
+ * ## Header and Footer
+ * The sidebar component provides slots for a header and footer, allowing for easy customization and branding.
+ *
+ * ## Menu Items
+ * The menu structure is defined by providing a list of items, where each item should be defined as either a submenu, action, router link, external link, or divider.
+ *
+ * - *Submenus* can be expanded or collapsed, and can contain nested menu items.
+ * - *Actions* are menu items that do not navigate but instead trigger an action when clicked.
+ * - *Router links* navigate within the application using Angular's Router.
+ * - *External links* navigate to an external URL in a new tab or the same tab based on the specified target.
+ * - *Dividers* are used to separate groups of menu items visually.
+ *
+ * ## Auto-Collapse
+ * The sidebar menu supports an `autoCollapse` feature, which, when enabled, ensures that only one submenu is expanded at a time.
+ * When enabled, expanding a submenu will automatically collapse any other expanded submenus that aren't a direct parent of the chosen submenu.
+ */
+const meta: Meta<SidebarComponent<SidebarMenuItem>> = {
+  title: 'Components/Sidebar/Sidebar Menu',
+  component: SidebarComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [SidebarHeaderComponent, SidebarFooterComponent, IconModule],
+    }),
+    applicationConfig({
+      providers: [provideRouter([]), provideAnimations()],
+    }),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+    controls: {
+      exclude: [
+        'expandIconOnHover',
+        'menuItemsChanged',
+        'vm',
+        '#sidebarService',
+        '#menuStateService',
+        '#setContainerHeight',
+        '#setMenuHeight',
+        '#setScrollDistance',
+      ],
+    },
+  },
+  argTypes: {
+    menuItems: {
+      description: 'Array of menu items to display in the sidebar',
+      control: { type: 'object' },
+    },
+    autoCollapse: {
+      description: 'Whether to auto-collapse other submenus when one is opened',
+      control: { type: 'boolean' },
+    },
+    afterMenuToggled: {
+      description: 'Event emitted when a submenu is toggled',
+      control: false,
+    },
+    afterMenuClicked: {
+      description: 'Event emitted when a menu item is clicked',
+      control: false,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<SidebarComponent<SidebarMenuItem>>;
+
+/**
+ * Using the sidebar menu on its own.
+ */
+export const Default: Story = {
+  args: {
+    menuItems: menuItemsMock,
+    autoCollapse: false,
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <kirby-x-sidebar [(menuItems)]="menuItems" [autoCollapse]="autoCollapse" (afterMenuClicked)="afterMenuClicked($event)" (afterMenuToggled)="afterMenuToggled($event)">
+        <kirby-x-sidebar-header>
+          <div style="display: flex; align-items: center; padding: 16px;">
+            <kirby-icon name="overview-outline"></kirby-icon>
+            <span style="font-weight: bold; font-size: 24px; margin-left: 10px;">Kirby_</span>
+          </div>
+        </kirby-x-sidebar-header>
+        <kirby-x-sidebar-footer>
+          <div style="padding: 16px; text-align: center; font-size: 12px; color: #666;">
+            &copy; 2025 Kirby Design
+          </div>
+        </kirby-x-sidebar-footer>
+      </kirby-x-sidebar>`,
+  }),
+};
+
+/**
+ * Using the sidebar menu alongside a main content area.
+ */
+export const WithContent: Story = {
+  args: {
+    menuItems: menuItemsMock,
+    autoCollapse: true,
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <div style="display: grid; grid-template-columns: minmax(252px, 328px) minmax(85%, auto);">
+        <kirby-x-sidebar [(menuItems)]="menuItems" [autoCollapse]="autoCollapse" (afterMenuClicked)="afterMenuClicked($event)" (afterMenuToggled)="afterMenuToggled($event)">
+          <kirby-x-sidebar-header>
+            <div style="display: flex; align-items: center; padding: 16px;">
+              <kirby-icon name="overview-outline"></kirby-icon>
+              <span style="font-weight: bold; font-size: 24px; margin-left: 10px;">Kirby_</span>
+            </div>
+          </kirby-x-sidebar-header>
+          <kirby-x-sidebar-footer>
+            <div style="padding: 16px; text-align: center; font-size: 12px; color: #666;">
+              &copy; 2025 Kirby Design
+            </div>
+          </kirby-x-sidebar-footer>
+        </kirby-x-sidebar>
+        <div style="padding: 16px;">
+          <h1>Welcome to the main content area</h1>
+          <p>This is where your main application content would go.</p>
+        </div>
+      </div>`,
+  }),
+};

--- a/libs/extensions/angular/sidebar-menu/src/public-components/sidebar/sidebar.component.ts
+++ b/libs/extensions/angular/sidebar-menu/src/public-components/sidebar/sidebar.component.ts
@@ -1,0 +1,95 @@
+import { Component, effect, inject, input, model, output, Signal } from '@angular/core';
+
+import { MenuContainerComponent } from '../../components/menu-container';
+import { HeightObserverDirective } from '../../directives/height-observer';
+import { selectMenuItem } from '../../functions/select-menu-item';
+import { toggleSubmenu } from '../../functions/toggle-submenu';
+import { toggleSubmenuAutoCollapsed } from '../../functions/toggle-submenu-auto-collapsed';
+import { SidebarMenuItem } from '../../models';
+import { MenuStateService } from '../../services/menu-state';
+import { SidebarService } from '../../services/sidebar';
+
+type ViewModel<T> = {
+  items: Signal<T[]>;
+  showHeaderBottomBorder: Signal<boolean>;
+  showFooterTopBorder: Signal<boolean>;
+  setContainerHeight: (height: number) => void;
+  setMenuHeight: (height: number) => void;
+  setScroll: (scroll: Event) => void;
+};
+
+@Component({
+  selector: 'kirby-x-sidebar',
+  templateUrl: './sidebar.component.html',
+  styleUrls: ['./sidebar.component.scss'],
+  imports: [HeightObserverDirective, MenuContainerComponent],
+})
+export class SidebarComponent<T extends SidebarMenuItem> {
+  readonly menuItems = model.required<T[]>();
+  readonly autoCollapse = input<boolean>(false);
+  readonly afterMenuToggled = output<T>();
+  readonly afterMenuClicked = output<T>();
+
+  /**
+   * @deprecated has not had an effect for a long time
+   */
+  readonly expandIconOnHover = input<boolean>(false);
+
+  /**
+   * @deprecated should use menuItemsChange or two-way binding on menuItems instead
+   */
+  readonly menuItemsChanged = output<T[]>();
+
+  readonly #sidebarService = inject(SidebarService);
+  readonly #menuStateService = inject(MenuStateService<T>);
+
+  constructor() {
+    effect(() => {
+      const toggledSubmenu = this.#menuStateService.toggledSubmenu();
+      if (toggledSubmenu) {
+        this.afterMenuToggled.emit(toggledSubmenu);
+        this.menuItems.update((items) =>
+          this.autoCollapse()
+            ? toggleSubmenuAutoCollapsed(toggledSubmenu.id, items)
+            : toggleSubmenu(toggledSubmenu.id, items)
+        );
+      }
+    });
+
+    effect(() => {
+      const selectedItem = this.#menuStateService.selectedItem();
+      if (selectedItem) {
+        this.afterMenuClicked.emit(selectedItem);
+        this.menuItems.update((items) => selectMenuItem(selectedItem.id, items));
+      }
+    });
+
+    effect(() => {
+      this.menuItemsChanged.emit(this.menuItems());
+    });
+  }
+
+  #setContainerHeight(height: number): void {
+    this.#sidebarService.containerHeight = height;
+  }
+
+  #setMenuHeight(height: number): void {
+    this.#sidebarService.menuHeight = height;
+  }
+
+  #setScrollDistance(event: Event): void {
+    const target = event.target as HTMLElement | null;
+    if (target) {
+      this.#sidebarService.scrollDistance = target.scrollTop;
+    }
+  }
+
+  readonly vm: ViewModel<T> = {
+    items: this.menuItems.asReadonly(),
+    showHeaderBottomBorder: this.#sidebarService.showHeaderBottomBorder,
+    showFooterTopBorder: this.#sidebarService.showFooterTopBorder,
+    setContainerHeight: this.#setContainerHeight.bind(this),
+    setMenuHeight: this.#setMenuHeight.bind(this),
+    setScroll: this.#setScrollDistance.bind(this),
+  };
+}

--- a/libs/extensions/angular/sidebar-menu/src/services/menu-state/index.ts
+++ b/libs/extensions/angular/sidebar-menu/src/services/menu-state/index.ts
@@ -1,0 +1,1 @@
+export * from './menu-state.service';

--- a/libs/extensions/angular/sidebar-menu/src/services/menu-state/menu-state.service.ts
+++ b/libs/extensions/angular/sidebar-menu/src/services/menu-state/menu-state.service.ts
@@ -1,0 +1,27 @@
+import { Injectable, Signal, signal } from '@angular/core';
+
+import { SidebarMenuItem } from '../../models';
+
+@Injectable({ providedIn: 'root' })
+export class MenuStateService<T extends SidebarMenuItem> {
+  readonly #toggledSubmenu = signal<T | undefined>(undefined);
+  readonly #selectedItem = signal<T | undefined>(undefined);
+
+  get toggledSubmenu(): Signal<T | undefined> {
+    return this.#toggledSubmenu;
+  }
+
+  set toggledSubmenu(item: T) {
+    this.#toggledSubmenu.set(item);
+  }
+
+  get selectedItem(): Signal<T | undefined> {
+    return this.#selectedItem;
+  }
+
+  set selectedItem(item: T) {
+    if (item.selectable ?? true) {
+      this.#selectedItem.set(item);
+    }
+  }
+}

--- a/libs/extensions/angular/sidebar-menu/src/services/sidebar/index.ts
+++ b/libs/extensions/angular/sidebar-menu/src/services/sidebar/index.ts
@@ -1,0 +1,1 @@
+export * from './sidebar.service';

--- a/libs/extensions/angular/sidebar-menu/src/services/sidebar/sidebar.service.spec.ts
+++ b/libs/extensions/angular/sidebar-menu/src/services/sidebar/sidebar.service.spec.ts
@@ -1,0 +1,77 @@
+import { createServiceFactory } from '@ngneat/spectator/jest';
+import { fakeAsync, tick } from '@angular/core/testing';
+import { SidebarService } from './sidebar.service';
+
+describe(SidebarService.name, () => {
+  const render = createServiceFactory({ service: SidebarService });
+
+  describe('Computed : showHeaderBottomBorder', () => {
+    it('should be false by default', () => {
+      const spectator = render();
+
+      expect(spectator.service.showHeaderBottomBorder()).toBe(false);
+    });
+
+    it('should be false when scroll distance is 0', fakeAsync(() => {
+      const spectator = render();
+
+      spectator.service.scrollDistance = 0;
+      tick();
+
+      expect(spectator.service.showHeaderBottomBorder()).toBe(false);
+    }));
+
+    it('should be true when scroll distance is greater than 0', fakeAsync(() => {
+      const spectator = render();
+
+      spectator.service.scrollDistance = 1;
+      tick();
+
+      expect(spectator.service.showHeaderBottomBorder()).toBe(true);
+    }));
+  });
+
+  describe('Computed : showFooterTopBorder', () => {
+    it('should be false by default', () => {
+      const spectator = render();
+
+      expect(spectator.service.showFooterTopBorder()).toBe(false);
+    });
+
+    it('should be false when the menu height is not greater than the container height', fakeAsync(() => {
+      const spectator = render();
+
+      spectator.service.menuHeight = 50;
+      spectator.service.containerHeight = 50;
+      tick();
+
+      expect(spectator.service.showFooterTopBorder()).toBe(false);
+    }));
+
+    it('should be false when scrolled to the bottom', fakeAsync(() => {
+      const spectator = render();
+
+      spectator.service.menuHeight = 100;
+      spectator.service.containerHeight = 50;
+      spectator.service.scrollDistance = 50;
+      tick();
+
+      expect(spectator.service.showFooterTopBorder()).toBe(false);
+    }));
+
+    it('should be true while not scrolled to the bottom', fakeAsync(() => {
+      const spectator = render();
+
+      spectator.service.menuHeight = 100;
+      spectator.service.containerHeight = 50;
+      tick();
+
+      expect(spectator.service.showFooterTopBorder()).toBe(true);
+
+      spectator.service.scrollDistance = 49;
+      tick();
+
+      expect(spectator.service.showFooterTopBorder()).toBe(true);
+    }));
+  });
+});

--- a/libs/extensions/angular/sidebar-menu/src/services/sidebar/sidebar.service.ts
+++ b/libs/extensions/angular/sidebar-menu/src/services/sidebar/sidebar.service.ts
@@ -1,0 +1,36 @@
+import { computed, Injectable, Signal, signal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class SidebarService {
+  readonly #menuHeight = signal<number>(0);
+  readonly #containerHeight = signal<number>(0);
+  readonly #scrollDistance = signal<number>(0);
+
+  readonly #scrollableDistance = computed(() =>
+    Math.max(0, this.#menuHeight() - this.#containerHeight())
+  );
+  readonly #hasScrollbar = computed(() => this.#scrollableDistance() > 0);
+  readonly #notAtBottom = computed(() => this.#scrollDistance() < this.#scrollableDistance());
+  readonly #showHeaderBottomBorder = computed(() => this.#scrollDistance() > 0);
+  readonly #showFooterTopBorder = computed(() => this.#hasScrollbar() && this.#notAtBottom());
+
+  get showHeaderBottomBorder(): Signal<boolean> {
+    return this.#showHeaderBottomBorder;
+  }
+
+  get showFooterTopBorder(): Signal<boolean> {
+    return this.#showFooterTopBorder;
+  }
+
+  set menuHeight(height: number) {
+    this.#menuHeight.set(height);
+  }
+
+  set containerHeight(height: number) {
+    this.#containerHeight.set(height);
+  }
+
+  set scrollDistance(distance: number) {
+    this.#scrollDistance.set(distance);
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -72,6 +72,7 @@
       "@kirbydesign/designsystem/types": ["libs/designsystem/dist/types"],
       "@kirbydesign/extensions-angular/image-banner": ["libs/extensions/angular/dist/image-banner"],
       "@kirbydesign/extensions-angular/localization": ["libs/extensions/angular/dist/localization"],
+      "@kirbydesign/extensions-angular/sidebar-menu": ["libs/extensions/angular/dist/sidebar-menu"],
       "@kirbydesign/extensions-angular/spot-illustration": [
         "libs/extensions/angular/dist/spot-illustration"
       ],


### PR DESCRIPTION
Hi Kirby,

I have tried to add the sidebar menu to kirby extensions with as few changes as possible, only adding some tests and a storybook, but let me know if there is anything you want changed before it can be merged in.

Also it seems like storybooks don't work that well with the new input/output API that the sidebar component uses, especially the model method, but maybe there is a way to mitigate that?