### PR TITLE
Form Field: fix hover background color of native date input icon on hover

### DIFF
--- a/libs/designsystem/form-field/src/form-field.component.scss
+++ b/libs/designsystem/form-field/src/form-field.component.scss
@@ -71,7 +71,7 @@ label {
 
 // Background color needs to be synchronized with input.component
 // Background color must be fully opaque to cover native icon
-.affix-container:has(input[type='date']) {
+label:has(input[type='date']) {
   --date-input-background-color: var(--kirby-inputs-background-color);
 
   @include interaction-state.apply-hover {

--- a/libs/designsystem/form-field/src/form-field.component.scss
+++ b/libs/designsystem/form-field/src/form-field.component.scss
@@ -71,7 +71,8 @@ label {
 
 // Background color needs to be synchronized with input.component
 // Background color must be fully opaque to cover native icon
-label:has(input[type='date']) {
+:host:not(.wrap-content-in-label) .affix-container:has(input[type='date']),
+:host(.wrap-content-in-label) label:has(input[type='date']) {
   --date-input-background-color: var(--kirby-inputs-background-color);
 
   @include interaction-state.apply-hover {

--- a/libs/designsystem/form-field/src/form-field.component.ts
+++ b/libs/designsystem/form-field/src/form-field.component.ts
@@ -7,6 +7,7 @@ import {
   ContentChild,
   ContentChildren,
   ElementRef,
+  HostBinding,
   HostListener,
   Input,
   OnDestroy,
@@ -90,6 +91,7 @@ export class FormFieldComponent
     this.element = elementRef.nativeElement;
   }
 
+  @HostBinding('class.wrap-content-in-label')
   get _wrapContentInLabel(): boolean {
     return !!this.label && (!!this.input || !!this.textarea);
   }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4080

## What is the new behavior?
When a label is present in form-field, it should be the target of the hover-styles. This ensures that when the label-text is hovered, the suffixed icon get the correct hover styles. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?


## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

