### PR TITLE
Button, Card, Accordion: Update state layer pseudo element to be same dimensions as host element

### DIFF
--- a/libs/core/src/scss/interaction-state/_layer.scss
+++ b/libs/core/src/scss/interaction-state/_layer.scss
@@ -48,7 +48,8 @@ $_light: utils.get-color('black-contrast');
       content: '';
       position: absolute;
       pointer-events: none;
-      inset: -50%;
+      inset: 0;
+      border-radius: inherit;
       opacity: var(--state-layer-opacity, 0);
       background-color: var(--state-layer-background-color, $_dark);
     }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4084

## What is the new behavior?
The pseudo-element for the state layer that gives the dimmed effect on hover is now the same dimensions as the host element, to avoid flickering in Safari on hover.

I have been thinking about how to unit-test this, but have come up short because theres no good way to get the dimensions of the pseudo element in javascript.

So I think manual testing of the following will have to do:
- Accordion
- Card
- Button

I have already done some thorough testing in Safari, but would be good for a couple of people to verify 👌 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

