### PR TITLE
Image Banner: do not show focus outline on click

### DIFF
--- a/libs/extensions/angular/image-banner/src/image-banner.component.scss
+++ b/libs/extensions/angular/image-banner/src/image-banner.component.scss
@@ -105,7 +105,7 @@ kirby-card {
   height: 100%;
 
   // Apply focus styles to the card when any child element (except those inside .dismiss) is focused
-  &:focus-within {
+  &:focus-within:has(:focus-visible) {
     &:not(:has(.dismiss :focus)) {
       @include interaction-state.apply-focus-ring($shadow: utils.get-elevation(2));
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?
Make sure to only show focus-outline when the browser determines it is most useful, e.g. when receiving focus via keyboard but not mouse-interaction.  

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

