### PR TITLE
Modal: fix focus being lost when component in outlet changes

### DIFF
--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
@@ -673,7 +673,7 @@
 
 <h3 #focusManagement>Focus Management</h3>
 <p>
-  When opened, focus is moved to the title unless any element in the content area is focused already
+  When opened, focus is moved to the title unless any element in the content area is already
   focused. Focus becomes trapped within the modal while it is open, preventing users from navigating
   to elements outside the modal. Upon closing, focus is moved back to where it was before showing
   the modal. Pressing

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.html
@@ -670,14 +670,26 @@
   <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role">dialog</a>
   role and implement focus management and keyboard support accordingly.
 </p>
+
+<h3 #focusManagement>Focus Management</h3>
 <p>
-  When opened, focus is moved into the modal. Focus is trapped within the modal while it is open,
-  preventing users from navigating to elements outside the modal. Upon closing, focus is moved back
-  to where it was before showing the modal. Pressing
+  When opened, focus is moved to the title unless any element in the content area is focused already
+  focused. Focus becomes trapped within the modal while it is open, preventing users from navigating
+  to elements outside the modal. Upon closing, focus is moved back to where it was before showing
+  the modal. Pressing
   <kbd>Esc</kbd>
   dismisses the modal.
 </p>
 
+<p>
+  If the component inside the modal is dynamically changed or replaced in a way that renders a new
+  title in the modal, it is highly recommended to re-focus the title to improve keyboard navigation
+  and inform screen reader users of the change. Focusing the title can be done by injecting
+  <code>Modal</code>
+  in the embedded component and call its
+  <code>focusTitle</code>
+  method.
+</p>
 <h3>Labeling</h3>
 <p>
   The provided

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
@@ -1,5 +1,7 @@
 import { fakeAsync, tick } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
 import { IonContent } from '@ionic/angular/standalone';
+import { Observable, Subject } from 'rxjs';
 import { WindowRef } from '@kirbydesign/designsystem/types';
 import { createComponentFactory, Spectator } from '@ngneat/spectator';
 import { MockComponents } from 'ng-mocks';
@@ -167,6 +169,23 @@ describe('ModalWrapperComponent', () => {
 
       spectator.component['ionModalDidPresent'].next();
       spectator.component['ionModalDidPresent'].complete();
+
+      await TestHelper.whenTrue(() => document.activeElement !== document.body);
+
+      expect(document.activeElement).toEqual(ionTitle);
+    });
+
+    it('should have focus on ion-title after onSiblingModalRouteActivated is called', async () => {
+      const ionTitle = spectator.query('ion-title');
+      await TestHelper.ionComponentOnReady(ionTitle);
+      const siblingModalRouteActivated$ = new Subject<ActivatedRoute>();
+      const mockRoute = {} as ActivatedRoute;
+
+      spyOn(spectator.component['routerOutlet'], 'deactivate');
+      spyOn(spectator.component['routerOutlet'], 'activateWith');
+      spectator.component['onSiblingModalRouteActivated'](siblingModalRouteActivated$);
+
+      siblingModalRouteActivated$.next(mockRoute);
 
       await TestHelper.whenTrue(() => document.activeElement !== document.body);
 

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
@@ -314,7 +314,7 @@ export class ModalWrapperComponent
         this.routerOutlet.deactivate();
       }
       this.routerOutlet.activateWith(route, this.environmentInjector);
-      this.focusTitleElement();
+      this.focusTitle();
     });
   }
 
@@ -434,11 +434,11 @@ export class ModalWrapperComponent
 
   private focusTitleOnDidPresent() {
     this.ionModalDidPresent.pipe(takeUntil(this.willClose$)).subscribe(() => {
-      this.focusTitleElement();
+      this.focusTitle();
     });
   }
 
-  focusTitleElement() {
+  focusTitle() {
     // Use queueMicrotask to defer our focus until after Ionic has saved a reference
     // to the element that should have focus restored when modal is closed.
     // https://github.com/ionic-team/ionic-framework/blob/v8.6.1/core/src/utils/overlays.ts#L592

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
@@ -191,7 +191,7 @@ export class ModalWrapperComponent
     this.listenForIonModalWillDismiss();
     this.listenForScroll();
     this.initializeResizeModalToModalWrapper();
-    this.focusModalTitle();
+    this.focusTitleOnDidPresent();
     this.componentPropsInjector = Injector.create({
       providers: [{ provide: COMPONENT_PROPS, useValue: this.config.componentProps }],
       parent: this.injector,
@@ -314,6 +314,7 @@ export class ModalWrapperComponent
         this.routerOutlet.deactivate();
       }
       this.routerOutlet.activateWith(route, this.environmentInjector);
+      this.focusTitleElement();
     });
   }
 
@@ -431,17 +432,23 @@ export class ModalWrapperComponent
     }
   }
 
-  private focusModalTitle() {
+  private focusTitleOnDidPresent() {
     this.ionModalDidPresent.pipe(takeUntil(this.willClose$)).subscribe(() => {
-      // Use queueMicrotask to defer our focus until after Ionic has saved a reference
-      // to the element that should have focus restored when modal is closed.
-      // https://github.com/ionic-team/ionic-framework/blob/v8.6.1/core/src/utils/overlays.ts#L592
-      queueMicrotask(() => {
-        const focusAlreadyInModal = this.ionModalElement?.contains(document.activeElement);
-        if (focusAlreadyInModal) return;
+      this.focusTitleElement();
+    });
+  }
 
-        this.ionTitleElement?.nativeElement.focus();
-      });
+  focusTitleElement() {
+    // Use queueMicrotask to defer our focus until after Ionic has saved a reference
+    // to the element that should have focus restored when modal is closed.
+    // https://github.com/ionic-team/ionic-framework/blob/v8.6.1/core/src/utils/overlays.ts#L592
+    queueMicrotask(() => {
+      const focusAlreadyInModalContent = this.ionContentElement?.nativeElement.contains(
+        document.activeElement
+      );
+      if (focusAlreadyInModalContent) return;
+
+      this.ionTitleElement?.nativeElement.focus();
     });
   }
 

--- a/libs/designsystem/modal/src/modal.interfaces.ts
+++ b/libs/designsystem/modal/src/modal.interfaces.ts
@@ -28,6 +28,7 @@ export abstract class Modal {
   scrollToBottom: (scrollDuration?: KirbyAnimation.Duration) => void;
   scrollDisabled: boolean;
   canDismiss: ShowAlertCallback;
+  focusTitle?: () => void;
 }
 /**
  * WARNING: This is for internal use only and should not be used outside of Kirby.


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3896

## What is the new behavior?
Focus is placed in the title area when a sibling route is activated in the modals router outlet, and a new component is shown. This is to aid screen reader users and let them know that content has changed and a new 'page' in the modal is present.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

