### PR TITLE
Accordion: border-box added to styling

### DIFF
--- a/libs/designsystem/accordion/src/accordion-item.component.scss
+++ b/libs/designsystem/accordion/src/accordion-item.component.scss
@@ -43,6 +43,7 @@ $padding: utils.size('s');
     box-shadow: none;
     font-family: var(--kirby-font-family);
     text-align: start;
+    box-sizing: border-box;
   }
 }
 

--- a/libs/designsystem/accordion/src/accordion-item.component.scss
+++ b/libs/designsystem/accordion/src/accordion-item.component.scss
@@ -14,6 +14,7 @@ $padding: utils.size('s');
     display: block;
     border-top: 1px solid $divider-color;
     border-bottom: 1px solid $divider-color;
+    box-sizing: border-box;
   }
 }
 
@@ -43,7 +44,6 @@ $padding: utils.size('s');
     box-shadow: none;
     font-family: var(--kirby-font-family);
     text-align: start;
-    box-sizing: border-box;
   }
 }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?

Added border-box to `kirby-accordion-item`. This should be normal practice "reset" practice for most of our components. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

