### PR TITLE
Housekeeping: Added type and url for repository in package.json for core and extensions

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -2,6 +2,11 @@
   "name": "@kirbydesign/core",
   "version": "0.0.79",
   "description": "Core styles and helpers for the Kirby Design System.",
+  "author": "kirby@bankdata.dk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kirbydesign/designsystem.git"
+  },
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/libs/extensions/angular/package.json
+++ b/libs/extensions/angular/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@kirbydesign/extensions-angular",
   "version": "3.3.0",
+  "author": "kirby@bankdata.dk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kirbydesign/designsystem.git"
+  },
   "peerDependencies": {
     "@angular/common": "^18.0.0 || ^19.0.0 || ^20.0.0",
     "@angular/compiler": "^18.0.0 || ^19.0.0 || ^20.0.0",


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?
The core and extensions/angular package are missing a repository url which is needed for publishing new versions. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?
Needed after updating our publish script in #4104 

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

