### PR TITLE
List: Added fallback to index of sectionTrackBy method if name is not present 

### DIFF
--- a/libs/designsystem/list/src/list.component.ts
+++ b/libs/designsystem/list/src/list.component.ts
@@ -231,8 +231,8 @@ export class ListComponent implements OnInit, OnChanges, AfterViewInit {
     this.listHelper.onLoadOnDemand(this);
   }
 
-  sectionTrackBy(_: number, section: { name: string }): string {
-    return section.name;
+  sectionTrackBy(index: number, section: { name: string }): string | number {
+    return section?.name ?? index;
   }
 
   onItemSelect(item: any) {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes  #4110

## What is the new behavior?
When a list contains both sections and standalone items, sections are tracked by name.
If the list contains only standalone items, they’re tracked by $index.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

