### PR TITLE
Checkbox: detect state when disabled via value accessor interface

### DIFF
--- a/libs/designsystem/checkbox/src/checkbox.component.ts
+++ b/libs/designsystem/checkbox/src/checkbox.component.ts
@@ -146,7 +146,7 @@ export class CheckboxComponent
    */
   writeValue(value: boolean): void {
     this.checked = value;
-    this.cdr.detectChanges();
+    this.cdr.markForCheck();
   }
 
   /**
@@ -179,6 +179,6 @@ export class CheckboxComponent
    */
   setDisabledState?(isDisabled: boolean): void {
     this.disabled = isDisabled;
-    this.cdr.detectChanges();
+    this.cdr.markForCheck();
   }
 }

--- a/libs/designsystem/checkbox/src/checkbox.component.ts
+++ b/libs/designsystem/checkbox/src/checkbox.component.ts
@@ -179,5 +179,6 @@ export class CheckboxComponent
    */
   setDisabledState?(isDisabled: boolean): void {
     this.disabled = isDisabled;
+    this.cdr.detectChanges();
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4118 

## What is the new behavior?
Disabled state is synced to DOM when set via Value Accessor API.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

