### PR TITLE
Housekeeping: added fixed max-width to card in dropdown attention level example

### DIFF
--- a/apps/cookbook/src/app/examples/dropdown-example/examples/attention-level.ts
+++ b/apps/cookbook/src/app/examples/dropdown-example/examples/attention-level.ts
@@ -5,7 +5,7 @@ import { DropdownComponent } from '@kirbydesign/designsystem/dropdown';
 
 const config = {
   selector: 'cookbook-dropdown-example-attention-level',
-  template: `<kirby-card hasPadding="true" class="constrain-width" [themeColor]="themeColor">
+  template: `<kirby-card hasPadding="true" class="attention-levels" [themeColor]="themeColor">
   <kirby-dropdown
     placeholder="Dropdown with attention level 2"
     aria-label="Choose your favorite fruit"

--- a/apps/cookbook/src/app/examples/dropdown-example/examples/dropdown-examples.shared.scss
+++ b/apps/cookbook/src/app/examples/dropdown-example/examples/dropdown-examples.shared.scss
@@ -8,6 +8,10 @@ kirby-card {
   kirby-dropdown + kirby-dropdown {
     margin-top: utils.size('s');
   }
+
+  &.attention-levels {
+    max-width: 320px;
+  }
 }
 
 p {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?
Fixed the attention-level example in the dropdown showcase, where the dropdown would shrink to fit the size of the selected option, causing a very narrow folded-out dropdown. The problem occurs since the dropdowns in the example use popover, which follows the width of the dropdown.
The sequence in what happens is:
1. The dropdowns use popover which follows the width of the dropdown itself
2. The dropdowns have a longer initial value due to its placeholder text: `placeholder="Dropdown with attention level 2"`
3. The surrounding card has a `width: fit-content`
4. When both dropdowns have an option selected (the options have a smaller text than the longer placeholder text) then the surrounding card shrinks to fit the content, which also shrinks the popover when opening the dropdown, and then most of the options are cut off. See screenshot.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

Initial:
<img width="1102" height="529" alt="image" src="https://github.com/user-attachments/assets/97e2d1ee-4465-4950-92c2-e95e2b6daaed" />

After selecting an option in each dropdown:
<img width="1066" height="503" alt="image" src="https://github.com/user-attachments/assets/9ba769dc-cbe7-4b24-9d3c-2f4ca370c8d0" />


## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

