### PR TITLE
List: Light theme support for inputs

### DIFF
--- a/libs/designsystem/list/src/list.component.scss
+++ b/libs/designsystem/list/src/list.component.scss
@@ -8,6 +8,7 @@ $item-height: utils.size('xxxl');
 
 :host {
   display: block;
+  @include themes.apply-white-theme;
 }
 
 .list {
@@ -50,6 +51,8 @@ ion-item {
 }
 
 ion-item-sliding {
+  @include themes.apply-white-theme;
+
   &.item-sliding-active-slide {
     // backface-visibility and transform, to fix clipping issue on iOS see https://stackoverflow.com/a/16681137 and https://github.com/kirbydesign/designsystem/issues/863
     backface-visibility: hidden;
@@ -59,6 +62,8 @@ ion-item-sliding {
   $list-colors: ('light'); // add supported list item theme colors here
   @each $color-name, $color-value in $list-colors {
     &.#{$color-name} {
+      @include themes.apply-light-theme;
+
       --kirby-item-background: #{utils.get-color($color-name)};
       --kirby-item-background-activated: #{utils.get-color($color-name + '-shade')};
       --kirby-item-background-focused: #{utils.get-color($color-name + '-shade')};

--- a/libs/designsystem/list/src/list.component.scss
+++ b/libs/designsystem/list/src/list.component.scss
@@ -8,7 +8,6 @@ $item-height: utils.size('xxxl');
 
 :host {
   display: block;
-  @include themes.apply-white-theme;
 }
 
 .list {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4124 

## What is the new behavior?

List now probably updates input colors based on the supported white or light theme.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

