### PR TITLE
Menu: Items added after creation of menu also gets selected set to true

### DIFF
--- a/libs/designsystem/item/src/item.component.ts
+++ b/libs/designsystem/item/src/item.component.ts
@@ -1,6 +1,7 @@
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ContentChild,
   ElementRef,
@@ -43,7 +44,14 @@ export class ItemComponent implements AfterViewInit {
   @HostBinding('class.disclosure')
   @Input()
   disclosure: 'link' | 'arrow-more' | 'arrow-down' | 'arrow-up' | null;
-  @Input() selectable: boolean;
+  @Input() set selectable(value: boolean) {
+    this._selectable = value;
+    this.cdr.markForCheck();
+  }
+  get selectable(): boolean {
+    return this._selectable;
+  }
+  private _selectable: boolean;
 
   @Input()
   reorderable: boolean;
@@ -69,7 +77,8 @@ export class ItemComponent implements AfterViewInit {
 
   constructor(
     private elementRef: ElementRef<HTMLElement>,
-    private renderer: Renderer2
+    private renderer: Renderer2,
+    private cdr: ChangeDetectorRef
   ) {}
 
   ngAfterViewInit(): void {

--- a/libs/designsystem/item/src/item.component.ts
+++ b/libs/designsystem/item/src/item.component.ts
@@ -44,14 +44,16 @@ export class ItemComponent implements AfterViewInit {
   @HostBinding('class.disclosure')
   @Input()
   disclosure: 'link' | 'arrow-more' | 'arrow-down' | 'arrow-up' | null;
+
+  private _selectable: boolean;
+  get selectable(): boolean {
+    return this._selectable;
+  }
+  
   @Input() set selectable(value: boolean) {
     this._selectable = value;
     this.cdr.markForCheck();
   }
-  get selectable(): boolean {
-    return this._selectable;
-  }
-  private _selectable: boolean;
 
   @Input()
   reorderable: boolean;

--- a/libs/designsystem/menu/src/menu.component.spec.ts
+++ b/libs/designsystem/menu/src/menu.component.spec.ts
@@ -11,7 +11,7 @@ import { MenuComponent } from './menu.component';
 
 describe('MenuComponent', () => {
   let spectator: SpectatorHost<MenuComponent>;
-  let buttonElement: HTMLButtonElement;
+  let triggerButton: HTMLButtonElement;
   let card: Element;
   let buttonIcon: IconComponent;
   let items: NodeListOf<Element>;
@@ -34,7 +34,7 @@ describe('MenuComponent', () => {
         `<kirby-menu [isDisabled]="isDisabled" [minWidth]="minWidth"></kirby-menu>`,
         {}
       );
-      buttonElement = spectator.query('button');
+      triggerButton = spectator.query('button');
       card = spectator.query('kirby-card');
       buttonIcon = spectator.query(IconComponent);
     });
@@ -75,33 +75,33 @@ describe('MenuComponent', () => {
 
     describe('button', () => {
       it('should render', () => {
-        expect(buttonElement).toBeTruthy();
+        expect(triggerButton).toBeTruthy();
       });
 
       it('should not render button as disabled ', () => {
-        expect(buttonElement.disabled).toBeFalsy();
+        expect(triggerButton.disabled).toBeFalsy();
       });
 
       it('should not render disabled attribute on button', () => {
-        expect(buttonElement.attributes['disabled']).toBeUndefined();
+        expect(triggerButton.attributes['disabled']).toBeUndefined();
       });
 
       it('should have type="button" attribute', () => {
-        expect(buttonElement).toHaveAttribute('type', 'button');
+        expect(triggerButton).toHaveAttribute('type', 'button');
       });
 
-      it('should add aria attributes to default button', () => {
-        expect(buttonElement.getAttribute('aria-controls')).toEqual(card.id);
-        expect(buttonElement.getAttribute('aria-haspopup')).toEqual('true');
-        expect(buttonElement.getAttribute('aria-label')).toEqual('More');
+      it('should add aria attributes to trigger button', () => {
+        expect(triggerButton.getAttribute('aria-controls')).toEqual(card.id);
+        expect(triggerButton.getAttribute('aria-haspopup')).toEqual('true');
+        expect(triggerButton.getAttribute('aria-label')).toEqual('More');
       });
 
-      it('should add aria attributes to menu for default button', () => {
-        expect(card.getAttribute('aria-labelledby')).toEqual(buttonElement.id);
+      it('should add aria attributes to menu for trigger button', () => {
+        expect(card.getAttribute('aria-labelledby')).toEqual(triggerButton.id);
       });
 
-      it('should add aria attributes to menu for default button', () => {
-        expect(card.getAttribute('aria-labelledby')).toEqual(buttonElement.id);
+      it('should add aria attributes to menu for trigger button', () => {
+        expect(card.getAttribute('aria-labelledby')).toEqual(triggerButton.id);
       });
     });
 
@@ -132,11 +132,11 @@ describe('MenuComponent', () => {
         });
 
         it('should render button as disabled ', () => {
-          expect(buttonElement.disabled).toBeTruthy();
+          expect(triggerButton.disabled).toBeTruthy();
         });
 
         it('should render disabled attribute on button', () => {
-          expect(buttonElement.attributes['disabled']).toBeDefined();
+          expect(triggerButton.attributes['disabled']).toBeDefined();
         });
       });
     });
@@ -154,22 +154,22 @@ describe('MenuComponent', () => {
   });
 
   describe('button with custom aria', () => {
-    it('should overwrite aria-label on default button if aria-label is set on menu', () => {
+    it('should overwrite aria-label on trigger button if aria-label is set on menu', () => {
       spectator = createHost<MenuComponent>(
         `<kirby-menu aria-label='Custom aria label'></kirby-menu>`,
         {}
       );
-      buttonElement = spectator.query('button');
-      expect(buttonElement.getAttribute('aria-label')).toEqual('Custom aria label');
+      triggerButton = spectator.query('button');
+      expect(triggerButton.getAttribute('aria-label')).toEqual('Custom aria label');
       expect(spectator.hostElement.getAttribute('aria-label')).toEqual(null);
     });
-    it('should overwrite aria-labelledby on default button if aria-labelledby is set on menu', () => {
+    it('should overwrite aria-labelledby on trigger button if aria-labelledby is set on menu', () => {
       spectator = createHost<MenuComponent>(
         `<kirby-menu aria-labelledby='Custom labelledBy'></kirby-menu>`,
         {}
       );
-      buttonElement = spectator.query('button');
-      expect(buttonElement.getAttribute('aria-labelledby')).toEqual('Custom labelledBy');
+      triggerButton = spectator.query('button');
+      expect(triggerButton.getAttribute('aria-labelledby')).toEqual('Custom labelledBy');
       expect(spectator.hostElement.getAttribute('aria-labelledBy')).toEqual(null);
     });
     it('should overwrite aria-label on custom button if aria-label is set on menu', () => {
@@ -181,8 +181,8 @@ describe('MenuComponent', () => {
         </kirby-menu>`,
         {}
       );
-      buttonElement = spectator.query('button');
-      expect(buttonElement.getAttribute('aria-label')).toEqual('Custom aria label');
+      triggerButton = spectator.query('button');
+      expect(triggerButton.getAttribute('aria-label')).toEqual('Custom aria label');
       expect(spectator.hostElement.getAttribute('aria-label')).toEqual(null);
     });
   });
@@ -219,7 +219,7 @@ describe('MenuComponent', () => {
           </kirby-menu>`,
         { hostProps: { closeOnEscapeKey: true, closeOnSelect: true, isDisabled: false } }
       );
-      buttonElement = spectator.query('button');
+      triggerButton = spectator.query('button');
       card = spectator.query('kirby-card');
       buttonIcon = spectator.query(IconComponent);
     });
@@ -227,7 +227,7 @@ describe('MenuComponent', () => {
     it('should open menu when button is clicked', async () => {
       expect(card).toHaveComputedStyle({ display: 'none' });
 
-      await spectator.click(buttonElement);
+      await spectator.click(triggerButton);
 
       expect(card).toHaveComputedStyle({ display: 'block' });
     });
@@ -235,10 +235,10 @@ describe('MenuComponent', () => {
     it('should open and then close menu when button is clicked twice', async () => {
       expect(card).toHaveComputedStyle({ display: 'none' });
 
-      await spectator.click(buttonElement);
+      await spectator.click(triggerButton);
       expect(card).toHaveComputedStyle({ display: 'block' });
 
-      await spectator.click(buttonElement);
+      await spectator.click(triggerButton);
 
       expect(card).toHaveComputedStyle({ display: 'none' });
     });
@@ -246,18 +246,18 @@ describe('MenuComponent', () => {
     it('should not open when the menu is disabled', async () => {
       spectator.setHostInput('isDisabled', true);
 
-      await spectator.click(buttonElement);
+      await spectator.click(triggerButton);
 
       expect(card).toHaveComputedStyle({ display: 'none' });
     });
 
     it('should close the menu when pressing escape', async () => {
       spectator.setHostInput('closeOnEscapeKey', true);
-      await spectator.click(buttonElement);
+      await spectator.click(triggerButton);
 
       expect(card).toHaveComputedStyle({ display: 'block' });
 
-      spectator.dispatchKeyboardEvent(buttonElement, 'keydown', 'Escape');
+      spectator.dispatchKeyboardEvent(triggerButton, 'keydown', 'Escape');
 
       expect(card).toHaveComputedStyle({ display: 'none' });
     });
@@ -265,11 +265,11 @@ describe('MenuComponent', () => {
     it('should not close the menu when pressing escape and closeOnEscapeKey is false', async () => {
       spectator.setHostInput('closeOnEscapeKey', false);
 
-      await spectator.click(buttonElement);
+      await spectator.click(triggerButton);
 
       expect(card).toHaveComputedStyle({ display: 'block' });
 
-      spectator.dispatchKeyboardEvent(buttonElement, 'keydown', 'Escape');
+      spectator.dispatchKeyboardEvent(triggerButton, 'keydown', 'Escape');
 
       expect(card).toHaveComputedStyle({ display: 'block' });
     });
@@ -278,7 +278,7 @@ describe('MenuComponent', () => {
       spectator.setHostInput('closeOnSelect', false);
       expect(card).toHaveComputedStyle({ display: 'none' });
 
-      await spectator.click(buttonElement);
+      await spectator.click(triggerButton);
       expect(card).toHaveComputedStyle({ display: 'block' });
 
       await spectator.click(spectator.query('kirby-item'));
@@ -298,16 +298,16 @@ describe('MenuComponent', () => {
         </kirby-menu>`,
         { hostProps: { show: false } }
       );
-      buttonElement = spectator.query('button');
+      triggerButton = spectator.query('button');
       spectator.setHostInput({ show: true });
-      
-      await spectator.click(buttonElement);
+
+      await spectator.click(triggerButton);
       spectator.detectChanges();
-      
+
       const ionItem = spectator.query('ion-item');
       await TestHelper.whenReady(ionItem);
       const selectableIonItem = ionItem.shadowRoot.querySelector('button'); //"button" only exist if item is selectable
-      
+
       expect(selectableIonItem).toBeTruthy();
     });
 
@@ -324,17 +324,17 @@ describe('MenuComponent', () => {
         </kirby-menu>`,
         { hostProps: { items } }
       );
-      buttonElement = spectator.query('button');
+      triggerButton = spectator.query('button');
       spectator.setHostInput({ show: true });
-      
-      await spectator.click(buttonElement);
+
+      await spectator.click(triggerButton);
       spectator.detectChanges();
-      
+
       const ionItems = spectator.queryAll('ion-item');
       const firstIonItem = ionItems[0];
       await TestHelper.whenReady(firstIonItem);
       const selectableIonItem = firstIonItem.shadowRoot.querySelector('button'); //"button" only exist if item is selectable
-      
+
       expect(selectableIonItem).toBeTruthy();
     });
   });
@@ -351,7 +351,7 @@ describe('MenuComponent', () => {
         {}
       );
       buttonIcon = spectator.query(IconComponent);
-      buttonElement = spectator.query('button');
+      triggerButton = spectator.query('button');
       card = spectator.query('kirby-card');
     });
 
@@ -360,13 +360,13 @@ describe('MenuComponent', () => {
     });
 
     it('should add aria attributes to custom button', () => {
-      expect(buttonElement.getAttribute('aria-controls')).toEqual(card.id);
-      expect(buttonElement.getAttribute('aria-haspopup')).toEqual('true');
-      expect(buttonElement.getAttribute('aria-label')).toEqual('More');
+      expect(triggerButton.getAttribute('aria-controls')).toEqual(card.id);
+      expect(triggerButton.getAttribute('aria-haspopup')).toEqual('true');
+      expect(triggerButton.getAttribute('aria-label')).toEqual('More');
     });
 
     it('should add aria attributes to menu for custom button', () => {
-      expect(card.getAttribute('aria-labelledby')).toEqual(buttonElement.id);
+      expect(card.getAttribute('aria-labelledby')).toEqual(triggerButton.id);
     });
   });
 
@@ -380,7 +380,7 @@ describe('MenuComponent', () => {
           </kirby-menu>`,
         {}
       );
-      buttonElement = spectator.query('button');
+      triggerButton = spectator.query('button');
       card = spectator.query('kirby-card');
       buttonIcon = spectator.query(IconComponent);
       items = card.querySelectorAll('ion-item');
@@ -390,13 +390,13 @@ describe('MenuComponent', () => {
     it('should open menu when button is clicked', async () => {
       expect(card).toHaveComputedStyle({ display: 'none' });
 
-      await spectator.click(buttonElement);
+      await spectator.click(triggerButton);
 
       expect(card).toHaveComputedStyle({ display: 'block' });
     });
 
     it('should set focus on first item when button is clicked', async () => {
-      await spectator.click(buttonElement);
+      await spectator.click(triggerButton);
 
       expect(document.activeElement).toEqual(items[0]);
     });
@@ -413,7 +413,7 @@ describe('MenuComponent', () => {
         {}
       );
 
-      buttonElement = spectator.query('button');
+      triggerButton = spectator.query('button');
       card = spectator.query('kirby-card');
       buttonIcon = spectator.query(IconComponent);
     });
@@ -421,7 +421,7 @@ describe('MenuComponent', () => {
     it('should open menu when button is hovered', () => {
       expect(card).toHaveComputedStyle({ display: 'none' });
 
-      spectator.dispatchMouseEvent(buttonElement, 'mouseenter');
+      spectator.dispatchMouseEvent(triggerButton, 'mouseenter');
 
       expect(card).toHaveComputedStyle({ display: 'block' });
     });
@@ -447,7 +447,7 @@ describe('MenuComponent', () => {
           </kirby-menu>`,
           {}
         );
-        buttonElement = spectator.query('button');
+        triggerButton = spectator.query('button');
         card = spectator.query('kirby-card');
         items = card.querySelectorAll('ion-item');
         await TestHelper.whenReady(items);
@@ -458,13 +458,13 @@ describe('MenuComponent', () => {
       });
 
       it('should set focus on first item when opened by enter', async () => {
-        spectator.keyboard.pressKey('Enter', buttonElement, 'keydown');
+        spectator.keyboard.pressKey('Enter', triggerButton, 'keydown');
 
         expect(document.activeElement).toEqual(items[0]);
       });
 
       it('should set focus to native button within item', () => {
-        spectator.keyboard.pressKey('Enter', buttonElement, 'keydown');
+        spectator.keyboard.pressKey('Enter', triggerButton, 'keydown');
 
         expect(document.activeElement.shadowRoot.activeElement).toEqual(
           items[0].shadowRoot.querySelector('button')
@@ -472,32 +472,32 @@ describe('MenuComponent', () => {
       });
 
       it('should set focus on first item when opened by arrow down', () => {
-        spectator.keyboard.pressKey('ArrowDown', buttonElement, 'keydown');
+        spectator.keyboard.pressKey('ArrowDown', triggerButton, 'keydown');
 
         expect(document.activeElement).toEqual(items[0]);
       });
 
       it('should set focus on first item when opened by space', async () => {
-        spectator.keyboard.pressKey(' ', buttonElement, 'keydown');
+        spectator.keyboard.pressKey(' ', triggerButton, 'keydown');
 
         expect(document.activeElement).toEqual(items[0]);
       });
 
       it('should set focus on last item when opened by arrow up', async () => {
-        spectator.keyboard.pressKey('ArrowUp', buttonElement, 'keydown');
+        spectator.keyboard.pressKey('ArrowUp', triggerButton, 'keydown');
 
         expect(document.activeElement).toEqual(items[items.length - 1]);
       });
 
       it('should set focus to next item when navigating by arrow down', async () => {
-        spectator.keyboard.pressKey('Enter', buttonElement, 'keydown');
+        spectator.keyboard.pressKey('Enter', triggerButton, 'keydown');
         spectator.keyboard.pressKey('ArrowDown', card, 'keydown');
 
         expect(document.activeElement).toEqual(items[1]);
       });
 
       it('should set focus to previous item when navigating by arrow up', async () => {
-        spectator.keyboard.pressKey('Enter', buttonElement, 'keydown');
+        spectator.keyboard.pressKey('Enter', triggerButton, 'keydown');
         spectator.keyboard.pressKey('ArrowDown', card, 'keydown');
         spectator.keyboard.pressKey('ArrowUp', card, 'keydown');
 
@@ -505,7 +505,7 @@ describe('MenuComponent', () => {
       });
 
       it('should set focus to first item when focus is on the last item and navigating by arrow down', async () => {
-        spectator.keyboard.pressKey('ArrowUp', buttonElement, 'keydown');
+        spectator.keyboard.pressKey('ArrowUp', triggerButton, 'keydown');
         expect(document.activeElement).toEqual(items[items.length - 1]);
 
         spectator.keyboard.pressKey('ArrowDown', card, 'keydown');
@@ -514,7 +514,7 @@ describe('MenuComponent', () => {
       });
 
       it('should set focus to last item when focus is on the first item and navigating by arrow up', async () => {
-        spectator.keyboard.pressKey('ArrowDown', buttonElement, 'keydown');
+        spectator.keyboard.pressKey('ArrowDown', triggerButton, 'keydown');
         expect(document.activeElement).toEqual(items[0]);
 
         spectator.keyboard.pressKey('ArrowUp', card, 'keydown');
@@ -523,51 +523,51 @@ describe('MenuComponent', () => {
       });
 
       it('should set focus to last item when navigating by end', async () => {
-        spectator.keyboard.pressKey('ArrowDown', buttonElement, 'keydown');
+        spectator.keyboard.pressKey('ArrowDown', triggerButton, 'keydown');
         spectator.keyboard.pressKey('End', card, 'keydown');
 
         expect(document.activeElement).toEqual(items[items.length - 1]);
       });
 
       it('should set focus to first item when navigating by home', async () => {
-        spectator.keyboard.pressKey('ArrowUp', buttonElement, 'keydown');
+        spectator.keyboard.pressKey('ArrowUp', triggerButton, 'keydown');
         spectator.keyboard.pressKey('Home', card, 'keydown');
 
         expect(document.activeElement).toEqual(items[0]);
       });
 
       it('should set focus to trigger button when selecting item', async () => {
-        spectator.keyboard.pressKey('Enter', buttonElement, 'keydown');
+        spectator.keyboard.pressKey('Enter', triggerButton, 'keydown');
 
         const focusedNativeButton = document.activeElement.shadowRoot.activeElement;
 
         spectator.click(focusedNativeButton); //Using click instead of enter here since browsers natively interprete enter as a click event
-        expect(document.activeElement).toEqual(buttonElement);
+        expect(document.activeElement).toEqual(triggerButton);
       });
 
       it('should set focus to trigger button when pressing escape', async () => {
-        spectator.keyboard.pressKey('Enter', buttonElement, 'keydown');
+        spectator.keyboard.pressKey('Enter', triggerButton, 'keydown');
 
         spectator.keyboard.pressKey('Escape', card, 'keydown'); //Using click instead of enter here since browsers natively interprete enter as a click event
-        expect(document.activeElement).toEqual(buttonElement);
+        expect(document.activeElement).toEqual(triggerButton);
       });
 
       it('should set focus to "third action" when pressing "t"', () => {
-        spectator.keyboard.pressKey('Enter', buttonElement, 'keydown');
+        spectator.keyboard.pressKey('Enter', triggerButton, 'keydown');
         spectator.keyboard.pressKey('t', card, 'keydown');
 
         expect(document.activeElement).toEqual(items[3]);
       });
 
       it('should set focus to "second action" when pressing "s"', () => {
-        spectator.keyboard.pressKey('Enter', buttonElement, 'keydown');
+        spectator.keyboard.pressKey('Enter', triggerButton, 'keydown');
         spectator.keyboard.pressKey('s', card, 'keydown');
 
         expect(document.activeElement).toEqual(items[1]);
       });
 
       it('should set focus to "second action 2" when pressing "s" twice', () => {
-        spectator.keyboard.pressKey('Enter', buttonElement, 'keydown');
+        spectator.keyboard.pressKey('Enter', triggerButton, 'keydown');
         spectator.keyboard.pressKey('s', card, 'keydown');
         spectator.keyboard.pressKey('s', card, 'keydown');
 
@@ -575,7 +575,7 @@ describe('MenuComponent', () => {
       });
 
       it('should return focus to "second action" when pressing "s" three times', () => {
-        spectator.keyboard.pressKey('Enter', buttonElement, 'keydown');
+        spectator.keyboard.pressKey('Enter', triggerButton, 'keydown');
         spectator.keyboard.pressKey('s', card, 'keydown');
         spectator.keyboard.pressKey('s', card, 'keydown');
         spectator.keyboard.pressKey('s', card, 'keydown');
@@ -597,26 +597,26 @@ describe('MenuComponent', () => {
             </kirby-menu>`,
             {}
           );
-          buttonElement = spectator.query('button');
+          triggerButton = spectator.query('button');
           card = spectator.query('kirby-card');
           items = card.querySelectorAll('ion-item');
           await TestHelper.whenReady(items);
         });
 
         it('should set focus on first interactive element inside item when opened by enter', async () => {
-          spectator.keyboard.pressKey('Enter', buttonElement, 'keydown');
+          spectator.keyboard.pressKey('Enter', triggerButton, 'keydown');
 
           expect(document.activeElement).toEqual(items[0].querySelector('ion-checkbox'));
         });
 
         it('should set focus on last interactive element inside item when opened by arrow up', async () => {
-          spectator.keyboard.pressKey('ArrowUp', buttonElement, 'keydown');
+          spectator.keyboard.pressKey('ArrowUp', triggerButton, 'keydown');
 
           expect(document.activeElement).toEqual(items[1].querySelector('ion-toggle'));
         });
 
         it('should set focus on next interactive element inside item when navigating by arrow down', async () => {
-          spectator.keyboard.pressKey('ArrowDown', buttonElement, 'keydown');
+          spectator.keyboard.pressKey('ArrowDown', triggerButton, 'keydown');
           spectator.keyboard.pressKey('ArrowDown', card, 'keydown');
 
           expect(document.activeElement).toEqual(items[1].querySelector('ion-toggle'));

--- a/libs/designsystem/menu/src/menu.component.spec.ts
+++ b/libs/designsystem/menu/src/menu.component.spec.ts
@@ -286,8 +286,8 @@ describe('MenuComponent', () => {
     });
   });
 
-  describe('interaction with items in condition', () => {
-    it('should select item when clicked when wrapped in if statement', async () => {
+  describe('interaction with items that are conditionally shown', () => {
+    it('should select item inside if statement', async () => {
       spectator = createHost(
         `<kirby-menu>
           @if (show) {

--- a/libs/designsystem/menu/src/menu.component.spec.ts
+++ b/libs/designsystem/menu/src/menu.component.spec.ts
@@ -286,6 +286,53 @@ describe('MenuComponent', () => {
     });
   });
 
+  describe('interaction with items in condition', () => {
+    it('should select item when clicked when wrapped in if statement', async () => {
+      spectator = createHost(
+        `<kirby-menu>
+          @if (show) {
+            <kirby-item>
+              <p>Action 1</p>
+            </kirby-item>
+          }
+        </kirby-menu>`,
+        { hostProps: { show: false } }
+      );
+      buttonElement = spectator.query('button');
+      spectator.setHostInput({ show: true });
+      await spectator.click(buttonElement);
+      spectator.detectChanges();
+      const ionItem = spectator.query('ion-item');
+      await TestHelper.whenReady(ionItem);
+      const selectableIonItem = ionItem.shadowRoot.querySelector('button'); //"button" only exist if item is selectable
+      expect(selectableIonItem).toBeTruthy();
+    });
+
+    it('should select item when clicked when wrapped in for loop', async () => {
+      const items = ['Item 1', 'Item 2', 'Item 3'];
+      spectator = createHost(
+        `<kirby-menu>
+          @for(item of items; track item) {
+            <kirby-item>            
+              <kirby-icon name="add" slot="start" />
+              {{item}}                               
+            </kirby-item>
+          }
+        </kirby-menu>`,
+        { hostProps: { items } }
+      );
+      buttonElement = spectator.query('button');
+      spectator.setHostInput({ show: true });
+      await spectator.click(buttonElement);
+      spectator.detectChanges();
+      const ionItems = spectator.queryAll('ion-item');
+      const firstIonItem = ionItems[0];
+      await TestHelper.whenReady(firstIonItem);
+      const selectableIonItem = firstIonItem.shadowRoot.querySelector('button'); //"button" only exist if item is selectable
+      expect(selectableIonItem).toBeTruthy();
+    });
+  });
+
   describe('custom button', () => {
     beforeEach(() => {
       spectator = createHost<MenuComponent>(

--- a/libs/designsystem/menu/src/menu.component.spec.ts
+++ b/libs/designsystem/menu/src/menu.component.spec.ts
@@ -300,15 +300,18 @@ describe('MenuComponent', () => {
       );
       buttonElement = spectator.query('button');
       spectator.setHostInput({ show: true });
+      
       await spectator.click(buttonElement);
       spectator.detectChanges();
+      
       const ionItem = spectator.query('ion-item');
       await TestHelper.whenReady(ionItem);
       const selectableIonItem = ionItem.shadowRoot.querySelector('button'); //"button" only exist if item is selectable
+      
       expect(selectableIonItem).toBeTruthy();
     });
 
-    it('should select item when clicked when wrapped in for loop', async () => {
+    it('should select item in for loop', async () => {
       const items = ['Item 1', 'Item 2', 'Item 3'];
       spectator = createHost(
         `<kirby-menu>
@@ -323,12 +326,15 @@ describe('MenuComponent', () => {
       );
       buttonElement = spectator.query('button');
       spectator.setHostInput({ show: true });
+      
       await spectator.click(buttonElement);
       spectator.detectChanges();
+      
       const ionItems = spectator.queryAll('ion-item');
       const firstIonItem = ionItems[0];
       await TestHelper.whenReady(firstIonItem);
       const selectableIonItem = firstIonItem.shadowRoot.querySelector('button'); //"button" only exist if item is selectable
+      
       expect(selectableIonItem).toBeTruthy();
     });
   });

--- a/libs/designsystem/menu/src/menu.component.ts
+++ b/libs/designsystem/menu/src/menu.component.ts
@@ -9,7 +9,6 @@ import {
   DestroyRef,
   ElementRef,
   HostListener,
-  inject,
   Input,
   NgZone,
   OnDestroy,
@@ -47,14 +46,13 @@ export class MenuComponent implements AfterViewInit, AfterContentInit, OnDestroy
   triggerButtonId: string = UniqueIdGenerator.scopedTo('kirby-menu-trigger-button').next();
   private _attributesToForward = ['aria-label', 'aria-labelledby'];
 
-  private destroyRef = inject(DestroyRef);
-
   constructor(
     private cdr: ChangeDetectorRef,
     private elementRef: ElementRef<HTMLElement>,
     private zone: NgZone,
     private renderer: Renderer2,
-    public translations: TranslationService
+    public translations: TranslationService,
+    private destroyRef: DestroyRef
   ) {}
 
   @Input() public isDisabled: boolean = false;

--- a/libs/designsystem/menu/src/menu.component.ts
+++ b/libs/designsystem/menu/src/menu.component.ts
@@ -6,8 +6,10 @@ import {
   Component,
   ContentChild,
   ContentChildren,
+  DestroyRef,
   ElementRef,
   HostListener,
+  inject,
   Input,
   NgZone,
   OnDestroy,
@@ -30,6 +32,8 @@ import {
 import { EventListenerDisposeFn } from '@kirbydesign/designsystem/types';
 import { StringSearchHelper, UniqueIdGenerator } from '@kirbydesign/designsystem/helpers';
 import { forwardAttributes, TranslationService } from '@kirbydesign/designsystem/shared';
+import { startWith } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'kirby-menu',
@@ -42,6 +46,8 @@ export class MenuComponent implements AfterViewInit, AfterContentInit, OnDestroy
   readonly menuId: string = UniqueIdGenerator.scopedTo('kirby-menu').next();
   triggerButtonId: string = UniqueIdGenerator.scopedTo('kirby-menu-trigger-button').next();
   private _attributesToForward = ['aria-label', 'aria-labelledby'];
+
+  private destroyRef = inject(DestroyRef);
 
   constructor(
     private cdr: ChangeDetectorRef,
@@ -117,7 +123,7 @@ export class MenuComponent implements AfterViewInit, AfterContentInit, OnDestroy
     }
   }
 
-  @HostListener('click', ['$event'])
+  @HostListener('click')
   _onClick() {
     if (!this.floatingMenuIsShown) return;
     this.focusedIndex = 0;
@@ -264,7 +270,11 @@ export class MenuComponent implements AfterViewInit, AfterContentInit, OnDestroy
   ngAfterContentInit(): void {
     this.setRoleAttributeForAllItems();
     this.setUserProvidedButtonAriaAttributes();
-    this.ensureSelectableOnItems();
+    this.kirbyItemComponents.changes
+      .pipe(startWith(null), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.ensureSelectableItems();
+      });
   }
 
   private forwardAriaLabelToTriggerButton() {
@@ -276,7 +286,7 @@ export class MenuComponent implements AfterViewInit, AfterContentInit, OnDestroy
     );
   }
 
-  ensureSelectableOnItems() {
+  ensureSelectableItems() {
     this.kirbyItemComponents.forEach((itemComponent) => {
       if (itemComponent.selectable === undefined) {
         itemComponent.selectable = true;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4168 

## What is the new behavior?
Subscribing to changes from the `ContentChildren` for kirby items, and if there are changes, then re-run a function that adds the `selectable=true` input on `kirby-item`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

