### PR TITLE
Housekeeping: Added missing "/browser" part to the cp step in the build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
           mkdir -p designsystem_web/branch
           if [ $HOSTNAME == "cookbook" ]; then
             sed -i -E "s,<base href=\"[^\"]*\".*>,<base href=\"/\">,g" dist/apps/cookbook/browser/index.html
-            cp -R dist/apps/cookbook/* designsystem_web/
+            cp -R dist/apps/cookbook/browser/* designsystem_web/
             cp designsystem_web/index.html designsystem_web/404.html
           else
             mkdir -p designsystem_web/branch/$HOSTNAME


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4175 

In #4126 we updated our environment to use the new angular builder, which changed the dist-output when building the cookbook to have "/browser" added to the path - however there was a single copy-step in the build github action where we missed this addition and thus whenever we released, the new dist was not copied, resulting in reuse of the old dist. 