### PR TITLE
Extension Peer Deps: specify minimum version of designsystem

### DIFF
--- a/libs/extensions/angular/package.json
+++ b/libs/extensions/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kirbydesign/extensions-angular",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "author": "kirby@bankdata.dk",
   "repository": {
     "type": "git",
@@ -15,7 +15,7 @@
     "@angular/platform-browser": "^18.0.0 || ^19.0.0 || ^20.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0 || ^19.0.0 || ^20.0.0",
     "@angular/router": "^18.0.0 || ^19.0.0 || ^20.0.0",
-    "@kirbydesign/designsystem": "^10.0.0 || ^11.0.0",
+    "@kirbydesign/designsystem": "^11.4.0",
     "rxjs": "~7.8.0",
     "zone.js": "^0.14.3 || ~0.15.0"
   },


### PR DESCRIPTION
## Which issue does this PR close?

This PR solves an issue where extensions can accidentally be installed alongside a version of the core package where the  `.visually-hidden` class that is used in image banner is not yet implemented.

## What is the new behavior?
Ensure that 11.4.0 is installed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

