### PR TITLE
Housekeeping: removed lint_and_unittest requirement for Deploy Cookbook step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
 
   deploy_to_cookbook:
     name: Deploy cookbook
-    needs: [lint_and_unittest, build_kirby, build_kirby_cookbook]
+    needs: [build_kirby, build_kirby_cookbook]
     runs-on: ubuntu-latest
     env:
       DOMAIN: 'kirby.design'


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?

Currently if there are failing unit tests in a PR-build, the cookbook is never deployed. This is annoying when a PR is being used for manual testing purposes. This PR removes the requirement of having no lint and unit test errors before the cookbook is deployed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



