### PR TITLE
Sidebar: fix header logo slot assignment and image sizing

### DIFF
--- a/libs/extensions/angular/package.json
+++ b/libs/extensions/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kirbydesign/extensions-angular",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "kirby@bankdata.dk",
   "repository": {
     "type": "git",

--- a/libs/extensions/angular/sidebar-menu/src/public-components/sidebar-header/sidebar-header.component.ts
+++ b/libs/extensions/angular/sidebar-menu/src/public-components/sidebar-header/sidebar-header.component.ts
@@ -28,14 +28,14 @@ import { Component } from '@angular/core';
     }
 
     :host::ng-deep [slot='logo'] {
-      height: inherit;
+      display: inline-flex;
     }
 
     :host::ng-deep [slot='logo'] img,
     :host::ng-deep img[slot='logo'] {
       object-fit: contain;
-      width: 100%;
-      height: 100%;
+      max-width: 100%;
+      max-height: 100%;
     }
 
     .sidebar-logo {

--- a/libs/extensions/angular/sidebar-menu/src/public-components/sidebar-header/sidebar-header.component.ts
+++ b/libs/extensions/angular/sidebar-menu/src/public-components/sidebar-header/sidebar-header.component.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
   selector: 'kirby-x-sidebar-header',
   template: `
     <header>
-      <span class="sidebar-logo"><ng-content slot="logo"></ng-content></span>
+      <span class="sidebar-logo"><ng-content select="[slot='logo']"></ng-content></span>
       <div class="action-bar">
         <ng-content select="[slot='action']"></ng-content>
       </div>
@@ -31,7 +31,8 @@ import { Component } from '@angular/core';
       height: inherit;
     }
 
-    :host::ng-deep [slot='logo'] img {
+    :host::ng-deep [slot='logo'] img,
+    :host::ng-deep img[slot='logo'] {
       object-fit: contain;
       width: 100%;
       height: 100%;

--- a/libs/extensions/angular/sidebar-menu/src/public-components/sidebar/sidebar.component.stories.ts
+++ b/libs/extensions/angular/sidebar-menu/src/public-components/sidebar/sidebar.component.stories.ts
@@ -356,7 +356,7 @@ export const AutoCollapse: Story = {
 };
 
 /**
- * A sidebar with extra action buttons in the header.
+ * A sidebar with extra action buttons in the header but no logo link.
  */
 export const WithActions: Story = {
   ...Default,
@@ -366,7 +366,7 @@ export const WithActions: Story = {
       <div style="display: grid; grid-template-columns: minmax(252px, 328px) minmax(85%, auto);">
         <kirby-x-sidebar ${argsToTemplate(args)}>
           <kirby-x-sidebar-header>
-            <a href="/" slot="logo"><img src="assets/images/kirby-logo.svg" alt="Kirby Design System"/></a>
+            <img slot="logo" src="assets/images/kirby-logo.svg" alt="Kirby Design System"/>
             <button kirby-button size="sm" attentionLevel="3" slot="action" style="display: flex; flex-grow: 1; justify-content: flex-start;">
               <kirby-icon name="search"></kirby-icon>
               <span>Search...</span>

--- a/libs/extensions/angular/sidebar-menu/src/public-components/sidebar/sidebar.component.stories.ts
+++ b/libs/extensions/angular/sidebar-menu/src/public-components/sidebar/sidebar.component.stories.ts
@@ -383,7 +383,7 @@ export const WithActions: Story = {
   }),
   args: {
     ...Default.args,
-    mainAreaContent: '<h1>Sidebar with extra action buttons in the header</h1>',
+    mainAreaContent: '<h1>Sidebar with extra action buttons in the header but no logo link</h1>',
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -181,7 +181,7 @@
     },
     "libs/extensions/angular": {
       "name": "@kirbydesign/extensions-angular",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "dependencies": {
         "tslib": "^2.3.0"
       },


### PR DESCRIPTION
## Which issue does this PR close?

None

## What is the new behavior?

You now actually have to use `slot="logo"` on the element you want to project into the sidebar logo slot, and it now also works correctly when slotting an `img` directly.

Also, previously we would force the image in the logo slot to either take up all available space on the X or Y axis, that is no longer the case.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

