### PR TITLE
Tests: await navigation in router integration spec

### DIFF
--- a/libs/designsystem/router-outlet/src/router-outlet.integration.spec.ts
+++ b/libs/designsystem/router-outlet/src/router-outlet.integration.spec.ts
@@ -98,7 +98,7 @@ describe('RouterOutlet when config provided for focusManager + setHtmlDocTitle',
 
   it('should focus the h1 element after navigation', async () => {
     // Go to first page
-    router.navigateByUrl(firstPageUrl);
+    await router.navigateByUrl(firstPageUrl);
     await spectator.fixture.whenStable();
 
     await TestHelper.whenTrue(() => document.activeElement !== document.body); // Wait for focus to be set by Ionic
@@ -121,7 +121,7 @@ describe('RouterOutlet when config provided for focusManager + setHtmlDocTitle',
 
   it('should update the HTML document title to match page title after navigation', async () => {
     // Go to first page
-    router.navigateByUrl('');
+    await router.navigateByUrl('');
     await spectator.fixture.whenStable();
 
     expect(document.title).toBe(firstPageTitle);

--- a/libs/designsystem/router-outlet/src/router-outlet.integration.spec.ts
+++ b/libs/designsystem/router-outlet/src/router-outlet.integration.spec.ts
@@ -101,9 +101,9 @@ describe('RouterOutlet when config provided for focusManager + setHtmlDocTitle',
     await router.navigateByUrl(firstPageUrl);
     await spectator.fixture.whenStable();
 
-    await TestHelper.whenTrue(() => document.activeElement !== document.body); // Wait for focus to be set by Ionic
-
     const firstPageH1 = spectator.query('first-page h1');
+
+    await TestHelper.whenTrue(() => document.activeElement === firstPageH1); // Wait for focus to be set by Ionic
 
     expect(document.activeElement.tagName).toBe(firstPageH1.tagName);
     expect(document.activeElement.textContent).toBe(firstPageH1.textContent);
@@ -111,11 +111,11 @@ describe('RouterOutlet when config provided for focusManager + setHtmlDocTitle',
     // Navigate to second page via link
     spectator.click('a');
     await spectator.fixture.whenStable();
-    await TestHelper.whenTrue(() => document.activeElement !== document.body); // Wait for focus to be set by Ionic
-
     const secondPageH1 = spectator.query('second-page h1');
 
-    expect(document.activeElement.tagName).toBe(firstPageH1.tagName);
+    await TestHelper.whenTrue(() => document.activeElement === secondPageH1); // Wait for focus to be set by Ionic
+
+    expect(document.activeElement.tagName).toBe(secondPageH1.tagName);
     expect(document.activeElement.textContent).toBe(secondPageH1.textContent);
   });
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4205

## What is the new behavior?
Hopefully stabilize flaky test 🤞 
Heres 25 successful test runs (one error - but unrelated to this test) of this https://github.com/kirbydesign/designsystem/actions/runs/20956855197/job/60341978992

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

