### PR TITLE
Controls: use focus visible for checkbox, radio, toggle, slide-button and segmented control

### DIFF
--- a/libs/core/src/scss/interaction-state/_focus.scss
+++ b/libs/core/src/scss/interaction-state/_focus.scss
@@ -61,10 +61,8 @@
 
 // ---------------------------------------------------------------------------
 // The apply-focus-part mixin is used where ionics components do not allow
-// us to apply styling directly to the tabbed element, as it is hidden inside
-// a shadow root and not exposed as a part. In some of these cases, we are
-// unable to provide focus-visible like functionality, and thus the focus ring
-// will always show.
+// us to apply styling directly to the focussed element, as it is hidden inside
+// a shadow root and exposed as a part.
 
 /// @param {string} $part
 ///    Add focus styles to a specific CSS Shadow Part.
@@ -77,7 +75,14 @@
   @include utils.not-touch {
     @content;
 
-    &:focus-within::part(#{$part}) {
+    //  This semi-repeated functionality is to support two mutually exclusive patterns
+    //   - One where the part is also the focusable element (e.g., ion-segment-button) in segmented-control
+    //   - Another where the host delegates focus (e.g., ion-checkbox, ion-radio, ion-toggle)
+    &:focus-within::part(#{$part}):focus-visible {
+      @include _focus-ring($shadow, $gap);
+    }
+
+    &:focus-visible:focus-within::part(#{$part}) {
       @include _focus-ring($shadow, $gap);
     }
   }

--- a/libs/designsystem/slide-button/src/slide-button.component.scss
+++ b/libs/designsystem/slide-button/src/slide-button.component.scss
@@ -61,8 +61,8 @@ $slide-button-text-padding: 0 $slide-button-container-radius 0 $total-slider-thu
     height: $slide-button-container-height;
     border-radius: $slide-button-container-radius;
 
-    &:focus-within {
-      @include utils.not-touch {
+    @include utils.not-touch {
+      &:has(:focus-visible) {
         @include interaction-state.apply-focus-ring($shadow: utils.get-elevation(2));
       }
     }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4094, with the exception of fixing it for range, as the markup structure from Ionic currently does not permit this, as far as I can tell.

## What is the new behavior?
Make sure to only show focus-outline when the browser determines it is most useful, e.g. when receiving focus via keyboard but not mouse-interaction.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

