### PR TITLE
Segmented Control: Cap text size to avoid truncation when text is resized

### DIFF
--- a/libs/core/src/scss/base/_functions.scss
+++ b/libs/core/src/scss/base/_functions.scss
@@ -39,6 +39,10 @@
   @return _get-map-prop(variables.$font-sizes, $key);
 }
 
+@function font-size-base($key: 'n') {
+  @return _get-map-prop(variables.$font-sizes-base, $key);
+}
+
 @function line-height($key: 'm') {
   @return _get-map-prop(variables.$line-height, $key);
 }

--- a/libs/core/src/scss/base/_variables.scss
+++ b/libs/core/src/scss/base/_variables.scss
@@ -33,21 +33,36 @@ $relative-sizes: (
 /*
   FONT SETTINGS
 ****************************************************************************/
+// Base font sizes in rem for use in calculations
+// These are the preferred values used in $font-sizes clamps
+$font-sizes-base: (
+  xxxxl: 4.5rem,
+  xxxl: 3.5rem,
+  xxl: 2.5rem,
+  xl: 2rem,
+  l: 1.375rem,
+  m: 1.125rem,
+  n: 1rem,
+  s: 0.875rem,
+  xs: 0.75rem,
+  xxs: 0.625rem,
+) !default;
+
 // Non-linear font scaling: Display, Heading and body text use clamp()
 // to prioritize user preferences but maintain hierarchy with:
 // - minimum values that enforce a minimum font size of 10px
 // - maximum values that provide a maximum font resize of 200%
 $font-sizes: (
-  xxxxl: clamp(56px, 4.5rem, 72px),
-  xxxl: clamp(45px, 3.5rem, 56px),
-  xxl: clamp(32px, 2.5rem, 46px),
-  xl: clamp(26px, 2rem, 41px),
-  l: clamp(19px, 1.375rem, 38px),
-  m: clamp(14px, 1.125rem, 35px),
-  n: clamp(13px, 1rem, 32px),
-  s: clamp(12px, 0.875rem, 28px),
-  xs: clamp(11px, 0.75rem, 24px),
-  xxs: clamp(10px, 0.625rem, 20px),
+  xxxxl: clamp(56px, map.get($font-sizes-base, xxxxl), 72px),
+  xxxl: clamp(45px, map.get($font-sizes-base, xxxl), 56px),
+  xxl: clamp(32px, map.get($font-sizes-base, xxl), 46px),
+  xl: clamp(26px, map.get($font-sizes-base, xl), 41px),
+  l: clamp(19px, map.get($font-sizes-base, l), 38px),
+  m: clamp(14px, map.get($font-sizes-base, m), 35px),
+  n: clamp(13px, map.get($font-sizes-base, n), 32px),
+  s: clamp(12px, map.get($font-sizes-base, s), 28px),
+  xs: clamp(11px, map.get($font-sizes-base, xs), 24px),
+  xxs: clamp(10px, map.get($font-sizes-base, xxs), 20px),
 ) !default;
 $line-height: (
   // h1:

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -3,16 +3,17 @@
 
 // There is a limit to how large text can be on narrow viewports with text resized
 // before segment-button texts start to collide horizontally, so we cap it at 135% for narrow viewports
+$base-font-size-in-px: 14px;
 $maximum-font-size-sm: utils.size('xs') * 1.35;
-$maximum-font-size-md: 14px * 1.35;
+$maximum-font-size-md: $base-font-size-in-px * 1.35;
 
 :host {
   display: block;
   user-select: none;
 
   --kirby-badge-position: absolute;
-  --kirby-badge-top: -#{utils.size('xxs')};
-  --kirby-badge-right: -#{utils.size('s')};
+  --kirby-badge-top: -#{utils.relative-size('xxs')};
+  --kirby-badge-right: -#{utils.relative-size('s')};
   --kirby-badge-z-index: #{utils.z('segment-badge')};
 
   &.sm {

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -3,18 +3,20 @@
 
 // There is a limit to how large text can be on narrow viewports with text resized
 // before segment-button texts start to collide horizontally, so we cap it at 135% for narrow viewports
-$base-font-size-in-px: 14px;
 $maximum-font-size-sm: utils.size('xs') * 1.35;
-$maximum-font-size-md: $base-font-size-in-px * 1.35;
+$maximum-font-size-md: utils.size('s') * 1.35;
+$badge-offset: 0.8em;
+$badge-font-size: 0.625em;
 
 :host {
   display: block;
   user-select: none;
 
   --kirby-badge-position: absolute;
-  --kirby-badge-top: -#{utils.relative-size('xxs')};
-  --kirby-badge-right: -#{utils.relative-size('s')};
+  --kirby-badge-top: #{-1 * $badge-offset};
+  --kirby-badge-right: #{-2 * $badge-offset};
   --kirby-badge-z-index: #{utils.z('segment-badge')};
+  --kirby-badge-font-size: #{$badge-font-size};
 
   &.sm {
     ion-segment-button {
@@ -132,7 +134,7 @@ ion-segment-button {
     min-height: utils.size('xl');
     min-width: fit-content;
     font-weight: utils.font-weight('normal');
-    font-size: min(utils.font-size('s'), $maximum-font-size-md);
+    font-size: min(utils.font-size('n'), $maximum-font-size-md);
     text-transform: none;
     margin: 0;
   }

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -6,9 +6,10 @@
 $maximum-font-size-sm: utils.size('xs') * 1.35;
 $maximum-font-size-md: utils.size('s') * 1.35;
 $badge-offset: 0.8em;
-$badge-font-size: calc(
-  10em / 14
-); // Base font size in segment-button is 14px, and our target is 10px. `em` ensures that badge scales with font-size of segment-button.
+
+// Make badge scale proportionally with segment font-size instead of browser setting, so it is also capped at 135%.
+// Achieved by calculating the font size ratio between badge and segment, and converting it to em.
+$badge-font-size: calc(utils.font-size-base('xxs') / utils.font-size-base('s') * 1em);
 
 :host {
   display: block;

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -134,7 +134,7 @@ ion-segment-button {
     min-height: utils.size('xl');
     min-width: fit-content;
     font-weight: utils.font-weight('normal');
-    font-size: min(utils.font-size('n'), $maximum-font-size-md);
+    font-size: min(utils.font-size('s'), $maximum-font-size-md);
     text-transform: none;
     margin: 0;
   }

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -1,6 +1,11 @@
 @use '@kirbydesign/core/src/scss/interaction-state';
 @use '@kirbydesign/core/src/scss/utils';
 
+// There is a limit to how large text can be on narrow viewports with text resized
+// before segment-button texts start to collide horizontally, so we cap it at 135% for narrow viewports
+$maximum-font-size-sm: utils.size('xs') * 1.35;
+$maximum-font-size-md: 14px * 1.35;
+
 :host {
   display: block;
   user-select: none;
@@ -13,7 +18,7 @@
   &.sm {
     ion-segment-button {
       min-height: utils.size('l');
-      font-size: utils.font-size('xs');
+      font-size: min(utils.font-size('xs'), $maximum-font-size-sm);
 
       --padding-start: #{utils.size('s')};
       --padding-end: #{utils.size('s')};
@@ -126,7 +131,7 @@ ion-segment-button {
     min-height: utils.size('xl');
     min-width: fit-content;
     font-weight: utils.font-weight('normal');
-    font-size: utils.font-size('s');
+    font-size: min(utils.font-size('s'), $maximum-font-size-md);
     text-transform: none;
     margin: 0;
   }

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -7,7 +7,7 @@ $maximum-font-size-sm: utils.size('xs') * 1.35;
 $maximum-font-size-md: utils.size('s') * 1.35;
 $badge-offset: 0.8em;
 
-// Make badge scale proportionally with segment font-size instead of browser setting, so it is also capped at 135%.
+// Make badge scale proportionally with segment font-size instead of browser setting, so it also caps at 135% and preserves ratio.
 // Achieved by calculating the font size ratio between badge and segment, and converting it to em.
 $badge-font-size: calc(utils.font-size-base('xxs') / utils.font-size-base('s') * 1em);
 

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -8,7 +8,7 @@ $maximum-font-size-md: utils.size('s') * 1.35;
 $badge-offset: 0.8em;
 $badge-font-size: calc(
   10em / 14
-); // Base font size in badge is 14px, and our target is 10px. Em ensures that badge scaels with font-size of segment-button.
+); // Base font size in segment-button is 14px, and our target is 10px. `em` ensures that badge scales with font-size of segment-button.
 
 :host {
   display: block;

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -6,7 +6,9 @@
 $maximum-font-size-sm: utils.size('xs') * 1.35;
 $maximum-font-size-md: utils.size('s') * 1.35;
 $badge-offset: 0.8em;
-$badge-font-size: 0.625em;
+$badge-font-size: calc(
+  10em / 14
+); // Base font size in badge is 14px, and our target is 10px. Em ensures that badge scaels with font-size of segment-button.
 
 :host {
   display: block;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4242

## What is the new behavior?
When text is resized in user agent settings or device settings, we cap the Segmented Control text size to try and limit usability impact of long segment texts, for very large (135% and above) text sizes.

See #4213 for reference.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

