### PR TITLE
[Enhancement] added environment initializer for modal controller to provideKirby

### DIFF
--- a/apps/cookbook/src/app/examples/examples-routing.module.ts
+++ b/apps/cookbook/src/app/examples/examples-routing.module.ts
@@ -1,9 +1,11 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { provideKirby } from '@kirbydesign/designsystem';
 import { EXAMPLE_ROUTES } from './examples.routes';
 
 @NgModule({
   imports: [RouterModule.forChild(EXAMPLE_ROUTES)],
   exports: [RouterModule],
+  providers: [provideKirby()],
 })
 export class ExamplesRoutingModule {}

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-size-selector.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-configuration/modal-example-size-selector.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Output } from '@angular/core';
 import { ModalSize } from '@kirbydesign/designsystem';
 import { RadioComponent, RadioGroupComponent } from '@kirbydesign/designsystem/radio';
 
-import { ItemComponent } from '@kirbydesign/designsystem/item';
+import { ItemComponent, LabelComponent } from '@kirbydesign/designsystem/item';
 
 export type ModalSizeOption = { text: string; value: ModalSize };
 
@@ -16,7 +16,7 @@ export type ModalSizeOption = { text: string; value: ModalSize };
       }
     `,
   ],
-  imports: [RadioComponent, ItemComponent, RadioGroupComponent],
+  imports: [RadioComponent, ItemComponent, RadioGroupComponent, LabelComponent],
 })
 export class ModalExampleSizeSelectorComponent {
   modalSizeOptions: ModalSizeOption[] = [

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-outlet.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-outlet.component.ts
@@ -1,12 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { Params } from '@angular/router';
 
-import {
-  ModalComponent,
-  ModalController,
-  ModalRouterLinkDirective,
-} from '@kirbydesign/designsystem';
-import { ButtonComponent } from '@kirbydesign/designsystem/button';
+import { KirbyModule, ModalController } from '@kirbydesign/designsystem';
+import { ButtonComponent } from '@kirbydesign/designsystem';
 
 const config = {
   selector: 'cookbook-modal-example-outlet',
@@ -161,7 +157,7 @@ navigate() {
   selector: config.selector,
   template: config.template,
   styleUrls: ['./modal-example-outlet.component.scss'],
-  imports: [ButtonComponent, ModalRouterLinkDirective],
+  imports: [ButtonComponent, KirbyModule],
 })
 export class ModalExampleOutletComponent {
   static readonly template = config.template;
@@ -178,9 +174,9 @@ export class ModalExampleOutletComponent {
   static readonly modalControllerWithinModalOutletCodeSnippet =
     config.modalControllerWithinModalOutletCodeSnippet;
 
-  constructor(private modalController: ModalController) {}
+  private readonly modalController = inject(ModalController);
 
-  navigateToModalRoute(path: string | string[], queryParams?: Params) {
-    this.modalController.navigateToModal(path, queryParams);
+  async navigateToModalRoute(path: string | string[], queryParams?: Params): Promise<void> {
+    await this.modalController.navigateToModal(path, queryParams);
   }
 }

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-outlet.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-outlet.component.ts
@@ -1,8 +1,11 @@
 import { Component, inject } from '@angular/core';
 import { Params } from '@angular/router';
 
-import { ModalController, ModalRouterLinkDirective } from '@kirbydesign/designsystem';
-import { ButtonComponent } from '@kirbydesign/designsystem';
+import {
+  ButtonComponent,
+  ModalController,
+  ModalRouterLinkDirective,
+} from '@kirbydesign/designsystem';
 
 const config = {
   selector: 'cookbook-modal-example-outlet',

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-outlet.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-outlet.component.ts
@@ -1,7 +1,11 @@
 import { Component } from '@angular/core';
 import { Params } from '@angular/router';
 
-import { ModalController } from '@kirbydesign/designsystem';
+import {
+  ModalComponent,
+  ModalController,
+  ModalRouterLinkDirective,
+} from '@kirbydesign/designsystem';
 import { ButtonComponent } from '@kirbydesign/designsystem/button';
 
 const config = {
@@ -157,7 +161,7 @@ navigate() {
   selector: config.selector,
   template: config.template,
   styleUrls: ['./modal-example-outlet.component.scss'],
-  imports: [ButtonComponent],
+  imports: [ButtonComponent, ModalRouterLinkDirective],
 })
 export class ModalExampleOutletComponent {
   static readonly template = config.template;

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-outlet.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-outlet.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { Params } from '@angular/router';
 
-import { KirbyModule, ModalController } from '@kirbydesign/designsystem';
+import { ModalController } from '@kirbydesign/designsystem';
 import { ButtonComponent } from '@kirbydesign/designsystem/button';
 
 const config = {
@@ -24,14 +24,14 @@ export const routes: ModalEnabledRoutes = [
         path: 'child-route-presented-in-modal',
         outlet: 'modal',
         component: FirstChildComponent,
-        
+
         // optional ModalConfig passed via Angular Router's built in data object
         data: {
           modalConfig: {
             size: 'large',
             flavor: 'drawer',
           },
-        },  
+        },
       },
       {
         path: 'second-child-route-presented-in-modal',
@@ -52,7 +52,7 @@ export const routes = [
     canDeactivate: [CanDismissModalGuard],
   }
 ];
-  
+
 // When using route based modals, set the guard on the child route(s):
 export const routes = [
   {
@@ -118,7 +118,7 @@ modalController.navigateToModal('../main-route-presented-behind-the-modal/child-
 // Absolute path when opened from another component:
 modalController.navigateToModal(['/home', 'main-route-presented-behind-the-modal', 'child-route-presented-in-modal']);
 
-// Passing query parameters (OPTIONAL): 
+// Passing query parameters (OPTIONAL):
 modalController.navigateToModal('child-route-presented-in-modal', {awesomeQueryParam: 'awesome value'});
 `,
 
@@ -136,10 +136,10 @@ constructor(private modalController: ModalController) {}
 
 navigate() {
   // Relative path to sibling modal route:
-  modalController.navigateWithinModal('../second-child-route-presented-in-modal');    
+  modalController.navigateWithinModal('../second-child-route-presented-in-modal');
 
   // Relative path to sibling modal route with query parameters (OPTIONAL):
-  modalController.navigateWithinModal('../second-child-route-presented-in-modal', {awesomeQueryParam: 'awesome value'});    
+  modalController.navigateWithinModal('../second-child-route-presented-in-modal', {awesomeQueryParam: 'awesome value'});
 }
 
 // OR using Angular Router:
@@ -157,7 +157,7 @@ navigate() {
   selector: config.selector,
   template: config.template,
   styleUrls: ['./modal-example-outlet.component.scss'],
-  imports: [ButtonComponent, KirbyModule],
+  imports: [ButtonComponent],
 })
 export class ModalExampleOutletComponent {
   static readonly template = config.template;

--- a/apps/cookbook/src/app/examples/modal-example/modal-example-outlet.component.ts
+++ b/apps/cookbook/src/app/examples/modal-example/modal-example-outlet.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject } from '@angular/core';
 import { Params } from '@angular/router';
 
-import { KirbyModule, ModalController } from '@kirbydesign/designsystem';
+import { ModalController, ModalRouterLinkDirective } from '@kirbydesign/designsystem';
 import { ButtonComponent } from '@kirbydesign/designsystem';
 
 const config = {
@@ -157,7 +157,7 @@ navigate() {
   selector: config.selector,
   template: config.template,
   styleUrls: ['./modal-example-outlet.component.scss'],
-  imports: [ButtonComponent, KirbyModule],
+  imports: [ButtonComponent, ModalRouterLinkDirective],
 })
 export class ModalExampleOutletComponent {
   static readonly template = config.template;

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { ModalComponent, ModalRouterLinkDirective } from '@kirbydesign/designsystem';
 import { ExampleViewerComponent } from '../../shared/example-viewer/example-viewer.component';
 import { IphoneComponent } from '../../iphone/iphone.component';
 import { CodeViewerComponent } from '../../shared/code-viewer/code-viewer.component';
@@ -33,6 +34,7 @@ import { ImportViewerComponent } from '~/app/shared/import-code-viewer/import-co
     ApiDescriptionPropertiesComponent,
     ApiDescriptionEventsComponent,
     ImportViewerComponent,
+    ModalRouterLinkDirective,
   ],
 })
 export class ModalShowcaseComponent {

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { KirbyModule } from '@kirbydesign/designsystem';
 import { RouterLink } from '@angular/router';
 import { ExampleViewerComponent } from '../../shared/example-viewer/example-viewer.component';
 import { IphoneComponent } from '../../iphone/iphone.component';
@@ -28,7 +27,6 @@ import { ImportViewerComponent } from '~/app/shared/import-code-viewer/import-co
   imports: [
     ExampleViewerComponent,
     IphoneComponent,
-    KirbyModule,
     CodeViewerComponent,
     RouterLink,
     ModalExampleAlertWithGuardStepperComponent,

--- a/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/modal-showcase/modal-showcase.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { ModalComponent, ModalRouterLinkDirective } from '@kirbydesign/designsystem';
+import { ModalRouterLinkDirective } from '@kirbydesign/designsystem';
 import { ExampleViewerComponent } from '../../shared/example-viewer/example-viewer.component';
 import { IphoneComponent } from '../../iphone/iphone.component';
 import { CodeViewerComponent } from '../../shared/code-viewer/code-viewer.component';

--- a/libs/designsystem/config/src/provide-kirby.ts
+++ b/libs/designsystem/config/src/provide-kirby.ts
@@ -71,7 +71,7 @@ export function provideKirby(
     ResizeObserverService,
     CanDismissHelper,
     ...patchIonicProviders(),
-    features,
+    ...features,
     provideEnvironmentInitializer(
       async () => await inject(ModalController).initialize(getGlobalConfig()?.moduleRootRoutePath)
     ),

--- a/libs/designsystem/config/src/provide-kirby.ts
+++ b/libs/designsystem/config/src/provide-kirby.ts
@@ -57,7 +57,7 @@ export const KIRBY_CONFIG = new InjectionToken<KirbyConfig>('KIRBY_CONFIG');
  * @see {@link withGlobalSetup} for setting up global configuration.
  */
 export function provideKirby(
-  ...features: Provider[] | EnvironmentProviders[]
+  ...features: (Provider | EnvironmentProviders)[]
 ): EnvironmentProviders {
   return makeEnvironmentProviders([
     ModalController,

--- a/libs/designsystem/config/src/provide-kirby.ts
+++ b/libs/designsystem/config/src/provide-kirby.ts
@@ -1,7 +1,9 @@
 import {
   EnvironmentProviders,
+  inject,
   InjectionToken,
   makeEnvironmentProviders,
+  provideEnvironmentInitializer,
   Provider,
 } from '@angular/core';
 import { AnimationController, isPlatform, provideIonicAngular } from '@ionic/angular/standalone';
@@ -70,6 +72,9 @@ export function provideKirby(
     CanDismissHelper,
     ...patchIonicProviders(),
     features,
+    provideEnvironmentInitializer(
+      async () => await inject(ModalController).initialize(getGlobalConfig()?.moduleRootRoutePath)
+    ),
   ]);
 }
 
@@ -108,7 +113,7 @@ export function getGlobalConfig(): KirbyConfig | undefined {
 function setGlobalConfig(config: KirbyConfig | undefined): void {
   if (getGlobalConfig()) {
     console.warn(
-      `Global Kirby configuration is already provided through withGlobalSetup() elsewhere. 
+      `Global Kirby configuration is already provided through withGlobalSetup() elsewhere.
 Overwriting the existing configuration is not recommended. Consider removing duplicate calls.`
     );
   }

--- a/libs/designsystem/src/lib/kirby.module.spec.ts
+++ b/libs/designsystem/src/lib/kirby.module.spec.ts
@@ -1,20 +1,13 @@
-import { ModalController } from '@kirbydesign/designsystem/modal';
 import { KirbyModule } from './kirby.module';
 
 describe('KirbyModule', () => {
   let kirbyModule: KirbyModule;
-  let modalControllerSpy: ModalController;
 
   beforeEach(() => {
-    modalControllerSpy = jasmine.createSpyObj<ModalController>('ModalController', ['initialize']);
     kirbyModule = new KirbyModule();
   });
 
   it('should create an instance', () => {
     expect(kirbyModule).toBeTruthy();
-  });
-
-  it('should initialize modalController', () => {
-    expect(modalControllerSpy.initialize).toHaveBeenCalledTimes(1);
   });
 });

--- a/libs/designsystem/src/lib/kirby.module.spec.ts
+++ b/libs/designsystem/src/lib/kirby.module.spec.ts
@@ -7,7 +7,7 @@ describe('KirbyModule', () => {
 
   beforeEach(() => {
     modalControllerSpy = jasmine.createSpyObj<ModalController>('ModalController', ['initialize']);
-    kirbyModule = new KirbyModule(modalControllerSpy);
+    kirbyModule = new KirbyModule();
   });
 
   it('should create an instance', () => {

--- a/libs/designsystem/src/lib/kirby.module.ts
+++ b/libs/designsystem/src/lib/kirby.module.ts
@@ -1,10 +1,9 @@
 import { CommonModule } from '@angular/common';
-import { Inject, NgModule, Optional } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
 import { CardModule } from '@kirbydesign/designsystem/card';
 import { IconModule } from '@kirbydesign/designsystem/icon';
-import { KIRBY_CONFIG, KirbyConfig } from '@kirbydesign/designsystem/config';
 import { ComponentLoaderDirective, ThemeColorDirective } from '@kirbydesign/designsystem/shared';
 import { FlagComponent } from '@kirbydesign/designsystem/flag';
 import { SpinnerModule } from '@kirbydesign/designsystem/spinner';
@@ -44,7 +43,6 @@ import {
   ActionSheetComponent,
   AlertComponent,
   ModalCompactWrapperComponent,
-  ModalController,
   ModalFooterComponent,
   ModalWrapperComponent,
 } from '@kirbydesign/designsystem/modal';
@@ -143,11 +141,4 @@ const importedModules = [...exportedModules];
   providers: [provideKirby()],
   exports: [allExports],
 })
-export class KirbyModule {
-  constructor(
-    modalController: ModalController,
-    @Optional() @Inject(KIRBY_CONFIG) config?: KirbyConfig
-  ) {
-    modalController.initialize(config && config.moduleRootRoutePath);
-  }
-}
+export class KirbyModule {}


### PR DESCRIPTION
## Which issue does this PR close?
This PR closes #4188 

## What is the new behavior?

`provideKirby()` now initializes modal controller such that modal navigation will work correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

