### PR TITLE
Modal: remove outline for focussed ion-title

### DIFF
--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.scss
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.scss
@@ -13,8 +13,9 @@ $toolbar-bottom-border-width: 1px;
   ion-content {
     contain: content;
     max-height: calc(
-      var(--vh100) - var(--kirby-modal-padding-top, 0px) - var(--header-height) -
-        var(--footer-height)
+      var(--vh100) - var(--kirby-modal-padding-top, 0px) - var(--header-height) - var(
+          --footer-height
+        )
     );
 
     &::part(scroll) {
@@ -134,6 +135,7 @@ ion-title {
   padding-inline: calc(48px + var(--padding-start)) calc(48px + var(--padding-end));
   font-size: utils.font-size('n');
   font-weight: utils.font-weight('bold');
+  outline: none;
 }
 
 ion-content {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4290

## What is the new behavior?
We make sure no outline is added when the modal is opened via keyboard and ion-title is focussed after the modal opens. [See context](https://github.com/kirbydesign/designsystem/issues/4290#issuecomment-3943636071) on the issue. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

