### PR TITLE
Accordion: change text color variable

### DIFF
--- a/libs/designsystem/accordion/src/accordion-item.component.scss
+++ b/libs/designsystem/accordion/src/accordion-item.component.scss
@@ -80,7 +80,7 @@ button[disabled] {
 
 button {
   // Enforce button text color to avoid inheriting native button color from browser
-  color: utils.get-color('black');
+  color: utils.get-text-color('black');
 }
 
 button[aria-expanded='true'] {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4259 

## What is the new behavior?

Accordion text color now uses kirby-text-color-black.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [X] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [X] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [X] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [X] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [X] Request that the changes are code-reviewed 
- [X] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

