### PR TITLE
Section Header: Fixed section header layout to align items properly

### DIFF
--- a/apps/cookbook/src/app/examples/section-header-example/examples/heading-with-label.ts
+++ b/apps/cookbook/src/app/examples/section-header-example/examples/heading-with-label.ts
@@ -8,7 +8,7 @@ const config = {
   template: `<kirby-section-header>
     <kirby-label>
       <h3 heading>Section Header</h3>
-      <p label>With a label</p>
+      <p label>Label</p>
     </kirby-label>
     <p detail slot="end">Detail in end-slot</p>
 </kirby-section-header>

--- a/apps/cookbook/src/app/examples/section-header-example/examples/heading-with-label.ts
+++ b/apps/cookbook/src/app/examples/section-header-example/examples/heading-with-label.ts
@@ -6,10 +6,11 @@ import { CardComponent } from '@kirbydesign/designsystem/card';
 const config = {
   selector: 'cookbook-section-header-heading-with-label',
   template: `<kirby-section-header>
-  <kirby-label>
-    <h3 heading>Section Header</h3>
-    <p label>With a label</p>
-  </kirby-label>
+    <kirby-label>
+      <h3 heading>Section Header</h3>
+      <p label>With a label</p>
+    </kirby-label>
+    <p detail slot="end">Detail in end-slot</p>
 </kirby-section-header>
 <kirby-card [hasPadding]="true">
   <kirby-item>

--- a/apps/cookbook/src/app/examples/section-header-example/examples/heading-with-label.ts
+++ b/apps/cookbook/src/app/examples/section-header-example/examples/heading-with-label.ts
@@ -6,10 +6,11 @@ import { CardComponent } from '@kirbydesign/designsystem/card';
 const config = {
   selector: 'cookbook-section-header-heading-with-label',
   template: `<kirby-section-header>
-  <kirby-label>
-    <h3 heading>Section Header</h3>
-    <p label>With a label</p>
-  </kirby-label>
+    <kirby-label>
+      <h3 heading>Section Header</h3>
+      <p label>With a label</p>
+    </kirby-label>
+    <p detail slot="end">Detail in end-slot</p>
 </kirby-section-header>
 <kirby-card>
   <kirby-item>

--- a/libs/designsystem/section-header/src/_section-header.utils.scss
+++ b/libs/designsystem/section-header/src/_section-header.utils.scss
@@ -15,7 +15,7 @@
     font-size: utils.font-size('m');
     line-height: utils.line-height('m');
     color: var(--kirby-section-header-color);
-    margin: 0;
+    margin: 0 0 utils.size('xxs');
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/libs/designsystem/section-header/src/section-header.component.scss
+++ b/libs/designsystem/section-header/src/section-header.component.scss
@@ -11,6 +11,7 @@
     font-weight: inherit;
     min-height: 0;
     z-index: initial;
+    align-items: flex-end;
 
     @include section-header.typography;
   }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4293 

## What is the new behavior?
`kirby-section-header` examples now showcase the combination of heading, label and detail as in Figma.
A small code-change in section-header is added to support this.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?
<img width="679" height="63" alt="image" src="https://github.com/user-attachments/assets/8bee6444-5966-4da4-a0fb-1b29f51221af" />

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

