### PR TITLE
Deps: Publish script for extensions added containing fix for legacy moduleResolution support

### DIFF
--- a/.github/workflows/publish-extensions-angular.yml
+++ b/.github/workflows/publish-extensions-angular.yml
@@ -1,0 +1,23 @@
+name: Publish extensions-angular to npm
+
+# Tags matching 'vX.X.X-extensions-angular' are protected tags and can only be pushed by admins.
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+-extensions-angular'
+
+permissions:
+  id-token: write  # Required for OIDC (https://docs.github.com/en/actions/concepts/security/openid-connect)
+  contents: read
+
+jobs:
+  publish_extensions_angular:
+    name: Publish extensions-angular
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Kirby setup
+        uses: ./.github/actions/kirby-setup
+      - name: Build extensions-angular package and publish to npm
+        run: npm run publish -- extensions-angular

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -35,11 +35,14 @@ const designsystemLibSrcDir = `${designsystemLibDir}/icon/src`;
 const coreLibDir = `${libsRootDir}/core`;
 const coreLibSrcDir = `${coreLibDir}/src`;
 
+const extensionsAngularLibDir = `${libsRootDir}/extensions/angular`;
+
 const dist = `dist`;
 const distDesignsystemTarget = `${designsystemLibDir}/${dist}`;
 const distDesignsystemPackageJsonPath = `${distDesignsystemTarget}/package.json`;
 const distCoreTarget = `${dist}/${coreLibDir}`;
 const distCorePackageJsonPath = `${distCoreTarget}/package.json`;
+const distExtensionsAngularTarget = `${extensionsAngularLibDir}/${dist}`;
 
 const { version: coreVersion } = require('../libs/core/package.json');
 
@@ -206,6 +209,7 @@ function publish(distTarget, tarballNamePrefix) {
 const args = process.argv.slice(2).map((value) => value.toLowerCase());
 const doPublishCore = args.length === 0 || args.includes('core');
 const doPublishDesignsystem = args.length === 0 || args.includes('designsystem');
+const doPublishExtensionsAngular = args.includes('extensions-angular');
 
 if (doPublishCore) {
   // Publish core
@@ -231,4 +235,14 @@ if (doPublishDesignsystem) {
     .then(() => copyIcons(designsystemLibSrcDir, distDesignsystemTarget))
     .then(() => publish(distDesignsystemTarget, 'kirbydesign-designsystem'))
     .catch((err) => console.warn('*** ERROR WHEN PUBLISHING DESIGNSYSTEM ***', err));
+}
+
+if (doPublishExtensionsAngular) {
+  // Publish extensions-angular
+  console.log('--- Publishing extensions-angular ---');
+  cleanDistribution(distExtensionsAngularTarget)
+    .then(() => buildPackage('extensions-angular'))
+    .then(() => removeNpmIgnoreNestedPackageJsonRule(distExtensionsAngularTarget))
+    .then(() => publish(distExtensionsAngularTarget, 'kirbydesign-extensions-angular'))
+    .catch((err) => console.warn('*** ERROR WHEN PUBLISHING EXTENSIONS-ANGULAR ***', err));
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4328 

## What is the new behavior?
The legacy-support fix in #4322 is an addition in the publish script. However this addition also needs to be applied when releasing our extensions-angular lib. Today we manually release our extensions lib by running `npm publish libs/extensions/angular/dist`. In this PR we have extended our publish script to also handle publishing or extensions-angular lib and introduced a new github-hook (publish-extensions-angular.yml) 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

