### PR TITLE
Docs: fix out-of-sync showcase title

### DIFF
--- a/apps/cookbook/src/app/showcase/showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/showcase.component.ts
@@ -39,7 +39,7 @@ export class ShowcaseComponent implements OnDestroy {
   private onNavigationEnd() {
     this.routerEventsSubscription = this.router.events
       .pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd))
-      .subscribe(() => setTimeout(() => this.setExampleComponentFromUrl(this.router.url)));
+      .subscribe((event) => this.setExampleComponentFromUrl(event.urlAfterRedirects));
   }
 
   private setExampleComponentFromUrl(url: string) {


### PR DESCRIPTION
## Which issue does this PR close?

This PR is a quick fix for the cookbook

## What is the new behavior?
Previously the `h1` of the showcase pages with each components name was not correctly updated when changing pages. For instance, after visiting the Accordion page and then navigating to Button, the title would read 'Accordion', and then when navigating to a new page from there, its title would read 'Button'.

Now it is synchronized again.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

