### PR TITLE
Dropdown: fix unselectable options in Safari

### DIFF
--- a/libs/designsystem/dropdown/src/dropdown.component.spec.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.spec.ts
@@ -691,15 +691,6 @@ describe('DropdownComponent', () => {
         });
       });
 
-      describe('and looses focus', () => {
-        it('should close dropdown', () => {
-          buttonElement.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
-          spectator.detectChanges();
-
-          expect(spectator.component.isOpen).toBeFalsy();
-        });
-      });
-
       describe('and popover is clicked', () => {
         it('should close dropdown', () => {
           spectator.click('kirby-popover');

--- a/libs/designsystem/dropdown/src/dropdown.component.stories.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.stories.ts
@@ -88,9 +88,6 @@ export const DropdownClosedOnOutsideClick: Story = {
     props: args,
     template: `
       <kirby-dropdown aria-label="Choose your favorite item" ${argsToTemplate(args)}></kirby-dropdown>
-         <button kirby-button style="position: absolute; top: 0; right: 0;" data-testid="outside-close-btn">
-        Outside Close
-      </button>
     `,
   }),
   play: async ({ canvasElement }) => {
@@ -103,8 +100,8 @@ export const DropdownClosedOnOutsideClick: Story = {
       expect(dropdown).toHaveAttribute('aria-expanded', 'true');
     });
 
-    const outsideButton = canvas.getByTestId('outside-close-btn');
-    await userEvent.click(outsideButton);
+    const popoverBackdrop = document.querySelector('kirby-popover') as HTMLElement;
+    await userEvent.click(popoverBackdrop);
 
     await waitFor(() => {
       expect(dropdown).toHaveAttribute('aria-expanded', 'false');

--- a/libs/designsystem/dropdown/src/dropdown.component.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.ts
@@ -444,6 +444,7 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
   }
 
   @HostListener('keydown.tab')
+  @HostListener('keydown.shift.tab')
   _onTab() {
     if (this.isOpen) {
       this.selectItem(this.focusedIndex);

--- a/libs/designsystem/dropdown/src/dropdown.component.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.ts
@@ -327,6 +327,7 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
     if (this.disabled) {
       return;
     }
+
     if (!this.isOpen) {
       this.state = OpenState.opening;
       // ensures that the dropdown is opened in case the IntersectionObserverCallback isn't invoked
@@ -603,17 +604,9 @@ export class DropdownComponent implements AfterViewInit, OnDestroy, ControlValue
     this._onTouched();
   }
 
-  @HostListener('focusout', ['$event'])
-  _onFocusOut(event: FocusEvent) {
-    const relatedTarget = event.relatedTarget as HTMLElement | null; // relatedTarget is the element receiving focus
-    const isOnTriggerButton =
-      relatedTarget && this.elementRef.nativeElement.contains(relatedTarget);
-    const isInsidePopover = relatedTarget && relatedTarget.closest('kirby-popover');
-
-    if (!isOnTriggerButton && !isInsidePopover) {
-      if (this.isOpen) {
-        this.close();
-      }
+  @HostListener('focusout')
+  _onFocusOut() {
+    if (!this.isOpen) {
       this._onTouched();
     }
   }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4347 

## What is the new behavior?
When changing the dropdown behavior to always use popover in 4c1fd75c6, I did not notice that the focus-out behavior in dropdown.component.ts also had logic for closing the dropdown.

In Safari, the logic had the unfortunate side-effect that when clicking an item, the `focusout`-event fires and immediately closes the dropdown, before the click-event handling on the item fires.  

The problem boils down to `relatedTarget` behaving differently for non-focusable elements (in this case a `kirby-item`) in Safari compared to other browsers.

The bug was masked in Chrome and Firefox because the relatedTarget has a value, which activates our `isInsidePopover` guard, which means that dropdown never calls the logic for closing itself but instead correctly leaves it to the popover component to handle (see images below).

In Safari on the other hand, the guards are not activated because relatedTarget is null and we end up closing the popover on focusout before any other logic can run.

The popover already has functionality for handling all types of focusout/click outside etc, so the logic is redundant and can be removed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?
Clicking item in Chrome:
<img width="450"  alt="image" src="https://github.com/user-attachments/assets/96ce9a98-9345-46be-8713-ce6ef63e8114" />

Clicking item in Safari:
<img  width="450" alt="image" src="https://github.com/user-attachments/assets/bdaca08e-f47d-4a30-a75b-1c37f24b3f4e" />

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

