### PR TITLE
Decimal Mask: format initial value with radix point correctly according to locale

### DIFF
--- a/libs/designsystem/form-field/src/directives/decimal-mask/decimal-mask.directive.spec.ts
+++ b/libs/designsystem/form-field/src/directives/decimal-mask/decimal-mask.directive.spec.ts
@@ -1,7 +1,7 @@
 import { registerLocaleData } from '@angular/common';
 import localeDa from '@angular/common/locales/da';
 import { Component, LOCALE_ID } from '@angular/core';
-import { ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
+import { FormControl, ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
 import { createDirectiveFactory, SpectatorDirective } from '@ngneat/spectator';
 
 import { InputComponent } from '../../input/input.component';
@@ -43,6 +43,22 @@ describe('NumberInputDirective', () => {
     spectator = createDirective(`<input kirby-input kirby-decimal-mask type="number" />`);
     const instance = spectator.directive;
     expect(instance).toBeDefined();
+  });
+
+  it('should format one-time string initialization correctly for DA locale', () => {
+    locale = 'da';
+    spectator = createDirective(
+      `<input kirby-input kirby-decimal-mask value="1000.00" type="number" />`
+    );
+    expect(spectator.element).toHaveValue('1.000,00');
+  });
+
+  it('should format one-time string initialization correctly for EN locale', () => {
+    locale = 'en-GB';
+    spectator = createDirective(
+      `<input kirby-input kirby-decimal-mask value="1000.00" type="number" />`
+    );
+    expect(spectator.element).toHaveValue('1,000.00');
   });
 
   describe('grouping seperator', () => {
@@ -293,6 +309,36 @@ describe('NumberInputDirective', () => {
   });
 
   describe('reactive form', () => {
+    it('should format initial value correctly for DA locale', () => {
+      locale = 'da';
+      spectator = createDirective(
+        `<input kirby-input kirby-decimal-mask [formControl]="numericInput" type="number" />`,
+        {
+          hostProps: {
+            numericInput: new FormControl(1000.12),
+          },
+        }
+      );
+      // @ts-ignore
+      const numericInput = spectator.hostComponent.numericInput;
+      expect(spectator.element).toHaveValue('1.000,12');
+    });
+
+    it('should format initial value correctly for EN locale', () => {
+      locale = 'en-GB';
+      spectator = createDirective(
+        `<input kirby-input kirby-decimal-mask [formControl]="numericInput" type="number" />`,
+        {
+          hostProps: {
+            numericInput: new FormControl(1000.12),
+          },
+        }
+      );
+      // @ts-ignore
+      const numericInput = spectator.hostComponent.numericInput;
+      expect(spectator.element).toHaveValue('1,000.12');
+    });
+
     it('should be able to receive value with locale radix point from form-control', () => {
       locale = 'da';
       spectator = createDirective(

--- a/libs/designsystem/form-field/src/directives/decimal-mask/decimal-mask.directive.ts
+++ b/libs/designsystem/form-field/src/directives/decimal-mask/decimal-mask.directive.ts
@@ -54,11 +54,16 @@ export class DecimalMaskDirective implements OnInit {
   }
 
   ngOnInit(): void {
+    const element = this.elementRef.nativeElement;
     // Set type="text", because functionality like 'setSelectionRange' are not supported on type="number"
-    this.elementRef.nativeElement.setAttribute('type', 'text');
+    element.setAttribute('type', 'text');
 
     // Remove maxlength as this is handled by the mask
-    this.elementRef.nativeElement.removeAttribute('maxlength');
+    element.removeAttribute('maxlength');
+
+    if (element.value) {
+      element.value = this.toLocaleRadixPoint(element.value);
+    }
 
     this.initMask();
   }
@@ -98,14 +103,21 @@ export class DecimalMaskDirective implements OnInit {
     return this.min === undefined ? maxlengthValue : -Math.abs(Math.max(this.min, maxlengthValue));
   }
 
+  private toLocaleRadixPoint(value: string): string {
+    return value.replace('.', this.radixPoint);
+  }
+
+  private toStandardRadixPoint(value: string): string {
+    return value.replace(this.radixPoint, '.');
+  }
+
   private extendBuiltinValueAccessor(): void {
     extendValueAccessors<string>(this.valueAccessors, {
       writeValue: {
         afterWriteValue: (value) => {
           // Update the inputmask display when value is set programmatically
           if (this.inputmask && value != null) {
-            const formattedValue = String(value).replace('.', this.radixPoint);
-            this.inputmask.setValue(formattedValue);
+            this.inputmask.setValue(this.toLocaleRadixPoint(String(value)));
           }
         },
       },
@@ -113,8 +125,7 @@ export class DecimalMaskDirective implements OnInit {
         transformValue: (value) => {
           // Provide unmasked and normalized values to the form control
           if (this.inputmask) {
-            const unmaskedValue = this.inputmask.unmaskedvalue();
-            return unmaskedValue.replace(this.radixPoint, '.');
+            return this.toStandardRadixPoint(this.inputmask.unmaskedvalue());
           }
           return value;
         },


### PR DESCRIPTION


## Which issue does this PR close?

This PR closes #4362 

## What is the new behavior?
We replace (aka. "normalize") the radix point for initial values similar to how dynamic values are handled.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

