### PR TITLE
Form field: native datepicker shows both kirby and native calendar icon inside card

### DIFF
--- a/apps/cookbook/src/app/examples/form-field-example/examples/input/date-native-in-card.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/examples/input/date-native-in-card.ts
@@ -1,0 +1,26 @@
+import { Component, Input } from '@angular/core';
+
+import { CardComponent, InputSize } from '@kirbydesign/designsystem';
+import {
+  DateInputDirective,
+  FormFieldComponent,
+  InputComponent,
+} from '@kirbydesign/designsystem/form-field';
+
+const config = {
+  selector: 'cookbook-form-field-input-date-native-in-card-example',
+  template: `<kirby-card hasPadding="true">
+<kirby-form-field label="Native (platform) date input with default Kirby calendar icon inside card">
+  <input kirby-input type="date" [size]="size" [useNativeDatePicker]="true" />
+</kirby-form-field></kirby-card>`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+  imports: [FormFieldComponent, DateInputDirective, InputComponent, CardComponent],
+})
+export class FormFieldInputDateNativeInCardExampleComponent {
+  template: string = config.template;
+  @Input() size: InputSize;
+}

--- a/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.html
+++ b/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.html
@@ -23,6 +23,9 @@
 <cookbook-form-field-input-date-native-example
   [size]="size"
 ></cookbook-form-field-input-date-native-example>
+<cookbook-form-field-input-date-native-in-card-example
+  [size]="size"
+></cookbook-form-field-input-date-native-in-card-example>
 <cookbook-form-field-input-disabled-example
   [size]="size"
 ></cookbook-form-field-input-disabled-example>

--- a/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.ts
+++ b/apps/cookbook/src/app/examples/form-field-example/form-field-example.component.ts
@@ -15,6 +15,7 @@ import { FormFieldInputCounterFormExampleComponent } from './examples/input/reac
 import { FormFieldInputNumericExampleComponent } from './examples/input/numeric';
 import { FormFieldInputDateExampleComponent } from './examples/input/date';
 import { FormFieldInputDateNativeExampleComponent } from './examples/input/date-native';
+import { FormFieldInputDateNativeInCardExampleComponent } from './examples/input/date-native-in-card';
 import { FormFieldInputDisabledExampleComponent } from './examples/input/disabled';
 import { FormFieldInputErrorExampleComponent } from './examples/input/error';
 import { FormFieldInputBorderlessExampleComponent } from './examples/input/borderless';
@@ -40,6 +41,7 @@ import { FormFieldTextareaCounterFormExampleComponent } from './examples/textare
     FormFieldInputNumericExampleComponent,
     FormFieldInputDateExampleComponent,
     FormFieldInputDateNativeExampleComponent,
+    FormFieldInputDateNativeInCardExampleComponent,
     FormFieldInputDisabledExampleComponent,
     FormFieldInputErrorExampleComponent,
     FormFieldInputBorderlessExampleComponent,

--- a/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.html
@@ -184,6 +184,12 @@
     #inputDateNativeExample
   ></cookbook-form-field-input-date-native-example>
 </cookbook-example-viewer>
+<cookbook-example-viewer [html]="inputDateNativeInCardExample.template">
+  <cookbook-form-field-input-date-native-in-card-example
+    [size]="size"
+    #inputDateNativeInCardExample
+  ></cookbook-form-field-input-date-native-in-card-example>
+</cookbook-example-viewer>
 <p>
   When opting into the native datepicker, the value should be in the
   <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#date_strings">

--- a/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/form-field-showcase/form-field-showcase.component.ts
@@ -13,6 +13,7 @@ import { FormFieldInputNumericExampleComponent } from '../../examples/form-field
 import { FormFieldInputDecimalMaskExampleComponent } from '../../examples/form-field-example/examples/input/decimal-mask';
 import { FormFieldInputDateExampleComponent } from '../../examples/form-field-example/examples/input/date';
 import { FormFieldInputDateNativeExampleComponent } from '../../examples/form-field-example/examples/input/date-native';
+import { FormFieldInputDateNativeInCardExampleComponent } from '../../examples/form-field-example/examples/input/date-native-in-card';
 import { FormFieldInputDisabledExampleComponent } from '../../examples/form-field-example/examples/input/disabled';
 import { FormFieldInputErrorExampleComponent } from '../../examples/form-field-example/examples/input/error';
 import { FormFieldInputBorderlessExampleComponent } from '../../examples/form-field-example/examples/input/borderless';
@@ -49,6 +50,7 @@ import { ImportViewerComponent } from '~/app/shared/import-code-viewer/import-co
     FormFieldInputPadPrecisionDigitsExampleComponent,
     FormFieldInputDateExampleComponent,
     FormFieldInputDateNativeExampleComponent,
+    FormFieldInputDateNativeInCardExampleComponent,
     FormFieldInputDisabledExampleComponent,
     FormFieldInputErrorExampleComponent,
     FormFieldInputBorderlessExampleComponent,

--- a/apps/cookbook/src/styles.scss
+++ b/apps/cookbook/src/styles.scss
@@ -62,3 +62,16 @@ code:not([class*='language-']) {
     font-size: smaller;
   }
 }
+
+/* Hide the native datepicker icon globally inside Kirby form-fields */
+kirby-form-field input[type='date']::-webkit-calendar-picker-indicator {
+  opacity: 0;
+}
+
+kirby-form-field input[type='date']::-webkit-inner-spin-button {
+  display: none;
+}
+
+kirby-form-field input[type='date']::-webkit-clear-button {
+  display: none;
+}

--- a/libs/designsystem/card/src/card.component.scss
+++ b/libs/designsystem/card/src/card.component.scss
@@ -110,3 +110,10 @@ $default-border-outline: 1px solid utils.get-color('medium');
     --kirby-card-main-color: #{utils.get-color($color-name + '-contrast')};
   }
 }
+
+/* stylelint-disable selector-pseudo-element-no-unknown */
+:host ::ng-deep kirby-form-field .affix-container,
+:host ::ng-deep kirby-form-field .wrap-content-in-label label {
+  --date-input-background-color: transparent;
+}
+/* stylelint-enable selector-pseudo-element-no-unknown */


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4092 

## What is the new behavior?

Native date picker in card only show kirby icon 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

