### PR TITLE
Input: Remove duplicate date picker icons for light/dark theme

### DIFF
--- a/libs/designsystem/form-field/src/form-field.component.scss
+++ b/libs/designsystem/form-field/src/form-field.component.scss
@@ -74,34 +74,3 @@ label {
     }
   }
 }
-
-// Background color needs to be synchronized with input.component
-// Background color must be fully opaque to cover native icon
-:host:not(.wrap-content-in-label) .affix-container:has(input[type='date']),
-:host(.wrap-content-in-label) label:has(input[type='date']) {
-  --date-input-background-color: var(--kirby-inputs-background-color);
-
-  @include interaction-state.apply-hover {
-    --date-input-background-color: #e0e0e0;
-  }
-
-  @include interaction-state.apply-active {
-    --date-input-background-color: #cbcbcb;
-  }
-
-  // Cover native calendar icon if custom icon is present
-  & .suffix:not(:empty) {
-    top: utils.size('xxs');
-    bottom: utils.size('xxs');
-
-    // Part of covering native icon (not bulletproof)
-    // and add space between icon and text
-    padding-inline-start: utils.size('xs');
-
-    // Clicks etc. hit native icon/button instead of suffixed element
-    pointer-events: none;
-    background-color: var(--date-input-background-color);
-    transition: interaction-state.transition();
-    transition-property: background-color;
-  }
-}

--- a/libs/designsystem/form-field/src/form-field.component.stories.ts
+++ b/libs/designsystem/form-field/src/form-field.component.stories.ts
@@ -1,5 +1,5 @@
 import { type Meta, moduleMetadata, type StoryObj } from '@storybook/angular';
-import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { userEvent, within } from 'storybook/test';
 
 import {
   FormFieldComponent,
@@ -8,7 +8,7 @@ import {
   TextareaComponent,
 } from '@kirbydesign/designsystem/form-field';
 
-import { IconComponent } from '@kirbydesign/designsystem';
+import { CardComponent, IconComponent } from '@kirbydesign/designsystem';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { FormFieldExampleComponent } from '~/app/examples/form-field-example/form-field-example.component';
 
@@ -125,4 +125,23 @@ export const DateInputWithPrefixIcon: Story = {
     await userEvent.click(input);
     await userEvent.type(input, '987654');
   },
+};
+
+export const InputWithNativeDatePicker: Story = {
+  decorators: [
+    moduleMetadata({
+      imports: [ReactiveFormsModule, InputComponent, FormFieldComponent, CardComponent],
+    }),
+  ],
+  render: () => ({
+    template: `<kirby-form-field>
+      <input kirby-input type="date" [useNativeDatePicker]="true" />
+    </kirby-form-field>
+    <kirby-card [hasPadding]="true">
+      <kirby-form-field style="margin-bottom: 0">
+        <input kirby-input type="date" [useNativeDatePicker]="true" />
+      </kirby-form-field>
+    </kirby-card>
+    `,
+  }),
 };

--- a/libs/designsystem/form-field/src/input/input.component.scss
+++ b/libs/designsystem/form-field/src/input/input.component.scss
@@ -25,9 +25,29 @@ $padding-block-size-md: shared.$form-field-input-padding * 0.5;
     /* stylelint-enable no-duplicate-selectors */
   }
 
-  // Background color needs to be synchronized with form-field.component
   &[type='date'] {
-    background-color: var(--date-input-background-color);
+    // Hide the builtin picker icon but position it so it overlays input, to ensure clicking the
+    // input opens the date picker as expected
+    &::-webkit-calendar-picker-indicator {
+      opacity: 0;
+      position: absolute;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
+  &[type='date']::ng-deep + .suffix {
+    pointer-events: none; // ensure clicking icon opens date picker
+
+    // In firefox, we can't target and hide the builtin picker icon, so we use a feature query to hide
+    // kirby-icon instead and accept that the native appearance is a bit different
+    @supports (-moz-appearance: none) {
+      kirby-icon {
+        display: none;
+      }
+    }
   }
 
   &[type='number'] {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4092

## What is the new behavior?
We simplify the existing solution for showing a custom icon as date picker icon. Before, we placed an element on top of the builtin picker icon to hide it, while placing our own kirby-icon on top.

Now, we instead accept a slightly different look in Firefox, because it allows us to use the `webkit-calendar-picker-indicator` pseudo element in Safari and Chromium to properly hide the icon instead of placing an element on top.

This solves the linked issue because we no longer have to account for theme styles when coloring the now removed element.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

