### PR TITLE
Card: outlined variant top missing

### DIFF
--- a/libs/designsystem/card/src/card.component.scss
+++ b/libs/designsystem/card/src/card.component.scss
@@ -64,12 +64,7 @@ $default-border-outline: 1px solid utils.get-color('medium');
     box-shadow: none;
 
     &:has(kirby-card-header.flagged) {
-      border: none;
-
       .content-wrapper {
-        border-block-end: var(--kirby-card-border, $default-border-outline);
-        border-inline-start: var(--kirby-card-border, $default-border-outline);
-        border-inline-end: var(--kirby-card-border, $default-border-outline);
         border-bottom-left-radius: utils.border-radius('n');
         border-bottom-right-radius: utils.border-radius('n');
       }

--- a/libs/designsystem/card/src/card.component.spec.ts
+++ b/libs/designsystem/card/src/card.component.spec.ts
@@ -91,18 +91,6 @@ describe('CardComponent', () => {
       const contentWrapperElement = spectator.queryHost('.content-wrapper');
 
       expect(contentWrapperElement).toHaveComputedStyle({
-        'border-block-end-color': getColor('medium'),
-        'border-block-end-style': 'solid',
-        'border-block-end-width': '1px',
-
-        'border-inline-start-color': getColor('medium'),
-        'border-inline-start-style': 'solid',
-        'border-inline-start-width': '1px',
-
-        'border-inline-end-color': getColor('medium'),
-        'border-inline-end-style': 'solid',
-        'border-inline-end-width': '1px',
-
         'border-bottom-left-radius': size('s'),
         'border-bottom-right-radius': size('s'),
       });


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4256 

## What is the new behavior?

Card outlined variant with flag and nested cards now has top border.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

