### PR TITLE
List: support kirby-section-header usage in list

### DIFF
--- a/apps/cookbook/src/app/examples/list-example/examples/sections.ts
+++ b/apps/cookbook/src/app/examples/list-example/examples/sections.ts
@@ -7,22 +7,28 @@ import {
   ListSectionHeaderDirective,
 } from '@kirbydesign/designsystem/list';
 import { ItemComponent, LabelComponent } from '@kirbydesign/designsystem/item';
+import { SectionHeaderComponent } from '@kirbydesign/designsystem/section-header';
 import { BaseListComponent } from '../../list-shared/base-list.component';
 
 export const template = `<kirby-list
   [items]="items"
   (itemSelect)="onItemSelect($event)"
   [getSectionName]="getSectionName">
-  <kirby-list-section-header
+  <kirby-section-header
     *kirbyListSectionHeader="let section"
-    [title]="section">
-  </kirby-list-section-header>
-  <kirby-item 
-    *kirbyListItemTemplate="let item" 
+    >
+    <kirby-label>
+      <h3 heading>Section Header</h3>
+      <p label>Label</p>
+    </kirby-label>
+    <p detail slot="end">Detail in end-slot</p>
+  </kirby-section-header>
+  <kirby-item
+    *kirbyListItemTemplate="let item"
     [selectable]="true">
     <kirby-label>
       <p class="kirby-item-title">{{ item.title }}</p>
-      <data [value]="item.detail" 
+      <data [value]="item.detail"
       class="kirby-item-detail">
       {{ item.detail }}</data>
     </kirby-label>
@@ -42,6 +48,8 @@ export const template = `<kirby-list
     LabelComponent,
     ListSectionHeaderComponent,
     ListSectionHeaderDirective,
+    SectionHeaderComponent,
+    LabelComponent,
     ListItemTemplateDirective,
   ],
 })

--- a/libs/designsystem/list/src/list.component.html
+++ b/libs/designsystem/list/src/list.component.html
@@ -43,11 +43,9 @@
   @for (section of _groupedItems; track sectionTrackBy($index, section)) {
     <ion-item-group [ngClass]="standAloneClass()">
       @if (_isSectionsEnabled) {
-        <ion-item-divider>
-          <ng-container
-            *ngTemplateOutlet="sectionHeaderTemplate; context: { $implicit: section.name }"
-          ></ng-container>
-        </ion-item-divider>
+        <ng-container
+          *ngTemplateOutlet="sectionHeaderTemplate; context: { $implicit: section.name }"
+        ></ng-container>
       }
       @if (_isSectionsEnabled && _isStandAloneEnabled) {
         @for (list of section.lists; track list) {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes # (insert issue number here)

## What is the new behavior?

Some quick PoC code for using section header directly in list instead of the quite similar kirby-list-section-header component.

We also need to handle:
- using `ion-item-divider` with `kirby-list-section-header` but not with `section-header` 
- Sorting/getSectionName stuff

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

