### PR TITLE
Segmented Control: fix delayed update of value in reactive forms

### DIFF
--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.spec.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.spec.ts
@@ -559,6 +559,22 @@ describe('SegmentedControlComponent', () => {
       spectator.detectChanges();
     });
 
+    it('should update form value when segment is selected', fakeAsync(() => {
+      ionSegmentElement.dispatchEvent(
+        new CustomEvent('ionChange', { detail: { value: items[1].id } })
+      );
+      tick();
+
+      expect(formGroup.controls.segmentedControl.value).toEqual(items[1]);
+
+      ionSegmentElement.dispatchEvent(
+        new CustomEvent('ionChange', { detail: { value: items[2].id } })
+      );
+      spectator.detectChanges();
+
+      expect(formGroup.controls.segmentedControl.value).toEqual(items[2]);
+    }));
+
     it('should update value on form control change', () => {
       expect(spectator.component.value.id).toBe(items[0].id);
 
@@ -609,6 +625,22 @@ describe('SegmentedControlComponent', () => {
       expect(spectator.component.value).toEqual(items[2]);
       expect(ionSegmentElement.value).toBe(items[2].id);
     });
+
+    it('should update form control value when segment is selected', fakeAsync(() => {
+      ionSegmentElement.dispatchEvent(
+        new CustomEvent('ionChange', { detail: { value: items[1].id } })
+      );
+      tick();
+
+      expect(formControl.value).toEqual(items[1]);
+
+      ionSegmentElement.dispatchEvent(
+        new CustomEvent('ionChange', { detail: { value: items[2].id } })
+      );
+      spectator.detectChanges();
+
+      expect(formControl.value).toEqual(items[2]);
+    }));
 
     it('should update disabled state when form control is disabled', () => {
       expect(ionSegmentElement.disabled).toBeFalsy();

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.spec.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.spec.ts
@@ -570,7 +570,7 @@ describe('SegmentedControlComponent', () => {
       ionSegmentElement.dispatchEvent(
         new CustomEvent('ionChange', { detail: { value: items[2].id } })
       );
-      spectator.detectChanges();
+      tick();
 
       expect(formGroup.controls.segmentedControl.value).toEqual(items[2]);
     }));
@@ -637,7 +637,7 @@ describe('SegmentedControlComponent', () => {
       ionSegmentElement.dispatchEvent(
         new CustomEvent('ionChange', { detail: { value: items[2].id } })
       );
-      spectator.detectChanges();
+      tick();
 
       expect(formControl.value).toEqual(items[2]);
     }));

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.ts
@@ -39,9 +39,9 @@ export enum SegmentedControlMode {
     },
   ],
 })
-export class SegmentedControlComponent<TItem extends SegmentItem = SegmentItem>
-  implements ControlValueAccessor
-{
+export class SegmentedControlComponent<
+  TItem extends SegmentItem = SegmentItem,
+> implements ControlValueAccessor {
   @ViewChild(IonSegment, { static: true, read: ElementRef })
   private ionSegmentElement: ElementRef<HTMLIonSegmentElement>;
 
@@ -154,11 +154,9 @@ export class SegmentedControlComponent<TItem extends SegmentItem = SegmentItem>
 
     if (selectedItemIndex !== this.selectedIndex) {
       this.selectedIndex = selectedItemIndex;
-      setTimeout(() => {
-        this.segmentSelect.emit(this.value);
-        this.onChange(this.value);
-        this.onTouched();
-      });
+      this.segmentSelect.emit(this.value);
+      this.onChange(this.value);
+      this.onTouched();
     }
   }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4403

## What is the new behavior?
We remove the seemingly unneeded timeout between setting the selectedIndex and emitting the events/updating + calling the onTouched hook.

The timeout is originally added [here](https://github.com/kirbydesign/designsystem/pull/2407/changes#diff-c7414021f10917d28ff7b107fcd8083fbc8512efb351dab11505ee052655900cR111), but as far as I can see has no impact as the value is updated at this point and ready to be emitted.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

