### PR TITLE
Tests: fix failing tests after Chrome User Agent update to outline-width behavior

### DIFF
--- a/libs/designsystem/button/src/button.component.spec.ts
+++ b/libs/designsystem/button/src/button.component.spec.ts
@@ -39,7 +39,6 @@ describe('ButtonComponent', () => {
 
     it('should render without outline', () => {
       expect(element).toHaveComputedStyle({
-        'outline-width': '0px',
         'outline-style': 'none',
       });
     });

--- a/libs/designsystem/form-field/src/input/input.component.spec.ts
+++ b/libs/designsystem/form-field/src/input/input.component.spec.ts
@@ -51,7 +51,6 @@ describe('InputComponent', () => {
 
   it('should render without outline', () => {
     expect(element).toHaveComputedStyle({
-      'outline-width': '0px',
       'outline-style': 'none',
     });
   });

--- a/libs/designsystem/form-field/src/textarea/textarea.component.spec.ts
+++ b/libs/designsystem/form-field/src/textarea/textarea.component.spec.ts
@@ -46,7 +46,6 @@ describe('TextareaComponent', () => {
 
     it('should render without outline', () => {
       expect(element).toHaveComputedStyle({
-        'outline-width': '0px',
         'outline-style': 'none',
       });
     });


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?
When upgrading from Chrome 146 to 147 and running the test suite locally, we started seeing outline-width errors:
<img width="808" height="454" alt="image" src="https://github.com/user-attachments/assets/e42a9495-83a9-4860-a0c9-a3ebb41af4a5" />

We now no longer assume that the outline-width is 0px when `outline: none` is specified, as outline-width actually adopts the user agent default instead of being 0px.

More info on the Chrome change can be found here: https://chromestatus.com/feature/5133099851317248

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

