### PR TITLE
Modal: Remove paint containment of drawer when interactWithBackground is enabled

### DIFF
--- a/libs/core/src/scss/components/_overlays.scss
+++ b/libs/core/src/scss/components/_overlays.scss
@@ -88,6 +88,11 @@ ion-modal.kirby-overlay {
           @include bottom-drawer;
 
           --kirby-modal-padding-top: 0;
+
+          // Override Ionic's `contain: strict` (which includes paint containment)
+          // to prevent the box-shadow from being clipped when the ion-modal host
+          // is resized to match the drawer wrapper bounds.
+          contain: size layout style;
         }
       }
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4413 

## What is the new behavior?

The paint contain constraint has been removed from the contain css property of the modal when its a drawer and has `interactWithBackground="true"`. This allows the drawer to paint outside its content, which results in the box shadow to not be cut-off.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

