### PR TITLE
Sidebar: footer does not respect underlying content size rules

### DIFF
--- a/libs/extensions/angular/sidebar-menu/src/public-components/sidebar-footer/sidebar-footer.component.ts
+++ b/libs/extensions/angular/sidebar-menu/src/public-components/sidebar-footer/sidebar-footer.component.ts
@@ -10,15 +10,14 @@ import { Component } from '@angular/core';
       flex-direction: column;
       align-items: center;
       justify-content: center;
+      flex-grow: 1;
     }
 
     :host {
       min-height: 80px;
     }
 
-    footer {
-      width: 100%;
-    }
+
   `,
 })
 export class SidebarFooterComponent {}


### PR DESCRIPTION
Removed width styling from footer in SidebarFooterComponent.

## Which issue does this PR close?

This PR closes #4430

## What is the new behavior?

The sidebar footer now grows to an appropriate size based on its content.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

The issue has screenshots and more information on the bug

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

