### PR TITLE
Housekeeping: Automatically add severity label when bug issue is opened

### DIFF
--- a/.github/workflows/label-bug-severity.yml
+++ b/.github/workflows/label-bug-severity.yml
@@ -1,0 +1,37 @@
+name: Label bug severity
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label-severity:
+    if: contains(github.event.issue.labels.*.name, 'bug')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Parse severity and apply label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            const match = body.match(/### Severity\s+\((\d)\)/);
+            if (!match) return;
+
+            const labels = {
+              '1': 'severity: critical',
+              '2': 'severity: high',
+              '3': 'severity: medium',
+              '4': 'severity: low',
+            };
+
+            const label = labels[match[1]];
+            if (!label) return;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [label],
+            });


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?
Automatically add severity label when bug issue has been opened.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

