### PR TITLE
Bug: prevent unrendered popover from always opening below target

### DIFF
--- a/libs/designsystem/dropdown/src/dropdown.component.stories.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.stories.ts
@@ -179,6 +179,48 @@ export const DropdownOpenedPopoutTopStart: Story = {
   },
 };
 
+const createDynamicItemsStory = (direction: 'up' | 'down'): Story => {
+  const isUp = direction === 'up';
+  return {
+    render: () => ({
+      props: { dynamicItems: [] as string[] },
+      template: `
+        <div style="${isUp ? 'height: calc(100vh - var(--kirby-spacing-s) * 2);' : ''}">
+          <button (click)="dynamicItems = ['Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5']" style="display: none;">Load items</button>
+          <kirby-dropdown aria-label="Choose your favorite item" ${isUp ? 'style="position: absolute; bottom: var(--kirby-spacing-s);"' : ''} [items]="dynamicItems"></kirby-dropdown>
+        </div>
+      `,
+    }),
+    play: async ({ canvasElement }) => {
+      // Simulate items being added after the dropdown has been initialized.
+      // Use native .click() so the Angular event binding fires regardless of display:none.
+      (canvasElement.querySelector('button') as HTMLButtonElement).click();
+
+      const canvas = within(canvasElement);
+      const dropdown = canvas.getByRole('combobox');
+      await userEvent.click(dropdown);
+
+      await waitFor(() => {
+        expect(dropdown).toHaveAttribute('aria-expanded', 'true');
+      });
+
+      const card = document.querySelector('kirby-card[role="listbox"]') as HTMLElement;
+      const buttonRect = dropdown.getBoundingClientRect();
+      const cardRect = card.getBoundingClientRect();
+      if (isUp) {
+        expect(cardRect.bottom).toBeLessThanOrEqual(buttonRect.top);
+      } else {
+        expect(cardRect.top).toBeGreaterThanOrEqual(buttonRect.bottom);
+      }
+    },
+  };
+};
+
+export const DropdownOpenedPopoutTopStartWithDynamicItems: Story = createDynamicItemsStory('up');
+
+export const DropdownOpenedPopoutBottomStartWithDynamicItems: Story =
+  createDynamicItemsStory('down');
+
 export const DropdownOpenedPopoutTopEnd: Story = {
   args: {
     items: items,

--- a/libs/designsystem/popover/src/popover.component.ts
+++ b/libs/designsystem/popover/src/popover.component.ts
@@ -201,15 +201,11 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
     const contentHeight = wrapperDimensions.height;
     const availableSpaceDown = viewPortHeight - targetDimensions.bottom;
     const availableSpaceUp = targetDimensions.top;
-    // contentHeight > 0 guards against treating an unrendered popover as fitting below
-    const contentCanFitBelowTarget =
+    // contentHeight > 0: popover may be unrendered; fall back to whichever side has more space
+    const fitsBelow =
       contentHeight > 0 && availableSpaceDown >= contentHeight + this.POPOVER_BODY_PADDING;
-
-    const isAvailableSpaceBelow =
-      contentCanFitBelowTarget || availableSpaceDown >= availableSpaceUp;
-    const [direction, oppositeDirection] = isAvailableSpaceBelow
-      ? ['bottom', 'top']
-      : ['top', 'bottom'];
+    const openBelow = fitsBelow || availableSpaceDown >= availableSpaceUp;
+    const [direction, oppositeDirection] = openBelow ? ['bottom', 'top'] : ['top', 'bottom'];
 
     const pxValue =
       direction === 'bottom' ? targetDimensions.bottom : viewPortHeight - targetDimensions.top;

--- a/libs/designsystem/popover/src/popover.component.ts
+++ b/libs/designsystem/popover/src/popover.component.ts
@@ -201,8 +201,9 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
     const contentHeight = wrapperDimensions.height;
     const availableSpaceDown = viewPortHeight - targetDimensions.bottom;
     const availableSpaceUp = targetDimensions.top;
+    // contentHeight > 0 guards against treating an unrendered popover as fitting below
     const contentCanFitBelowTarget =
-      availableSpaceDown >= contentHeight + this.POPOVER_BODY_PADDING;
+      contentHeight > 0 && availableSpaceDown >= contentHeight + this.POPOVER_BODY_PADDING;
 
     const isAvailableSpaceBelow =
       contentCanFitBelowTarget || availableSpaceDown >= availableSpaceUp;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4437 

## What is the new behavior?
Guard when popover may be unrendered; fall back to whichever side has more space

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?
The best would be to make a `resizeObserver` on the content of the popover to ensure right positioning ()

```TS
    if (wrapperDimensions.height === 0) {
      // Content may be reactive (e.g. signals) and not yet rendered — observe for
      // the first size change and reposition once real dimensions are available.
      const observer = new ResizeObserver(() => {
        if (this.isShowing) {
          this.positionWrapper();
        }
        observer.disconnect();
      });
      observer.observe(wrapperElement);
    }
```

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

