### PR TITLE
Dropdown: Ensure popover direction with reactive elements

### DIFF
--- a/libs/designsystem/dropdown/src/dropdown.component.integration.spec.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.integration.spec.ts
@@ -31,6 +31,14 @@ describe('DropdownComponent integration', () => {
   let buttonElement: HTMLButtonElement;
   let cardElement: HTMLElement;
 
+  // requestAnimationFrame is not flushed by fakeAsync/tick — replace with synchronous implementation
+  beforeEach(() => {
+    spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+  });
+
   afterEach(() => {
     if (spectator?.component?.isOpen) {
       spectator.component.close();
@@ -121,7 +129,6 @@ describe('DropdownComponent integration', () => {
 
       it('should align the dropdown to the right side of button and component container ', fakeAsync(() => {
         spectator.component.open();
-        spectator.detectChanges();
         tick(openDelayInMs);
         spectator.detectChanges();
 

--- a/libs/designsystem/dropdown/src/dropdown.component.integration.spec.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.integration.spec.ts
@@ -25,19 +25,14 @@ describe('DropdownComponent integration', () => {
     { text: 'Item 4', value: 4 },
     { text: 'Item 5', value: 5 },
   ];
-  const openDelayInMs = DropdownComponent.OPEN_DELAY_IN_MS;
+  const openDropdownDelayInMs = DropdownComponent.OPEN_DELAY_IN_MS;
+  // Zone.js patches requestAnimationFrame as a macrotask with a fixed 16ms delay in fakeAsync
+  const popoverRafDelayInMs = 16;
+  const totalOpenDelayInMs = openDropdownDelayInMs + popoverRafDelayInMs;
 
   let spectator: SpectatorHost<DropdownComponent>;
   let buttonElement: HTMLButtonElement;
   let cardElement: HTMLElement;
-
-  // requestAnimationFrame is not flushed by fakeAsync/tick — replace with synchronous implementation
-  beforeEach(() => {
-    spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback) => {
-      cb(0);
-      return 0;
-    });
-  });
 
   afterEach(() => {
     if (spectator?.component?.isOpen) {
@@ -73,7 +68,7 @@ describe('DropdownComponent integration', () => {
 
       it('should open card to the right when popout=right', fakeAsync(() => {
         spectator.component.open();
-        tick(openDelayInMs);
+        tick(totalOpenDelayInMs);
 
         const buttonRect = buttonElement.getBoundingClientRect();
         const card = spectator.query('kirby-card');
@@ -103,7 +98,7 @@ describe('DropdownComponent integration', () => {
         spectator.component.ngAfterViewInit();
 
         spectator.component.open();
-        tick(openDelayInMs);
+        tick(totalOpenDelayInMs);
 
         const card = spectator.query('kirby-card');
         const componentWidth = spectator.element.clientWidth;
@@ -129,7 +124,7 @@ describe('DropdownComponent integration', () => {
 
       it('should align the dropdown to the right side of button and component container ', fakeAsync(() => {
         spectator.component.open();
-        tick(openDelayInMs);
+        tick(totalOpenDelayInMs);
         spectator.detectChanges();
 
         const card = spectator.query('kirby-card');
@@ -166,7 +161,7 @@ describe('DropdownComponent integration', () => {
       expect(cardElement).toBeHidden();
 
       spectator.click('button');
-      tick(openDelayInMs);
+      tick(totalOpenDelayInMs);
       spectator.detectChanges();
     }));
 

--- a/libs/designsystem/dropdown/src/dropdown.component.spec.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.spec.ts
@@ -33,6 +33,14 @@ describe('DropdownComponent', () => {
   ];
   const openDelayInMs = DropdownComponent.OPEN_DELAY_IN_MS;
 
+  // requestAnimationFrame is not flushed by fakeAsync/tick — replace with synchronous implementation
+  beforeEach(() => {
+    spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+  });
+
   afterEach(() => {
     // Ensure dropdown is closed to trigger popover cleanup
     if (spectator?.component?.isOpen) {

--- a/libs/designsystem/dropdown/src/dropdown.component.spec.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.spec.ts
@@ -31,15 +31,10 @@ describe('DropdownComponent', () => {
     { text: 'Item 4', value: 4 },
     { text: 'Item 5', value: 5 },
   ];
-  const openDelayInMs = DropdownComponent.OPEN_DELAY_IN_MS;
-
-  // requestAnimationFrame is not flushed by fakeAsync/tick — replace with synchronous implementation
-  beforeEach(() => {
-    spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback) => {
-      cb(0);
-      return 0;
-    });
-  });
+  const openDropdownDelayInMs = DropdownComponent.OPEN_DELAY_IN_MS;
+  // Zone.js patches requestAnimationFrame as a macrotask with a fixed 16ms delay in fakeAsync
+  const popoverRafDelayInMs = 16;
+  const totalOpenDelayInMs = openDropdownDelayInMs + popoverRafDelayInMs;
 
   afterEach(() => {
     // Ensure dropdown is closed to trigger popover cleanup
@@ -142,7 +137,7 @@ describe('DropdownComponent', () => {
 
     it('should have correct item size', fakeAsync(() => {
       spectator.component.open();
-      tick(openDelayInMs);
+      tick(totalOpenDelayInMs);
       spectator.detectChanges();
       const itemElements = spectator.queryAll<HTMLElement>('kirby-item');
       expect(itemElements).toHaveLength(items.length);
@@ -173,7 +168,7 @@ describe('DropdownComponent', () => {
 
       it('should set aria-activedescendant when focusedIndex is set', fakeAsync(() => {
         spectator.component.open();
-        tick(openDelayInMs);
+        tick(totalOpenDelayInMs);
         spectator.detectChanges();
         spectator.component.focusedIndex = 2;
         spectator.detectChanges();
@@ -193,7 +188,7 @@ describe('DropdownComponent', () => {
 
       it('should update aria-expanded when opened', fakeAsync(() => {
         spectator.component.open();
-        tick(openDelayInMs);
+        tick(totalOpenDelayInMs);
         spectator.detectChanges();
         const updatedButtonElement = spectator.query('button');
         expect(updatedButtonElement.getAttribute('aria-expanded')).toBe('true');
@@ -354,7 +349,7 @@ describe('DropdownComponent', () => {
       it('open card to the right when popout=right', fakeAsync(() => {
         spectator.component.popout = HorizontalDirection.right;
         spectator.component.open();
-        tick(openDelayInMs);
+        tick(totalOpenDelayInMs);
         spectator.detectChanges();
 
         const buttonRect = buttonElement.getBoundingClientRect();
@@ -368,7 +363,7 @@ describe('DropdownComponent', () => {
         spectator.component.popout = HorizontalDirection.left;
         spectator.element.style.cssFloat = 'right';
         spectator.component.open();
-        tick(openDelayInMs);
+        tick(totalOpenDelayInMs);
         spectator.detectChanges();
 
         const card = spectator.query('kirby-card');
@@ -398,7 +393,7 @@ describe('DropdownComponent', () => {
       it('should render dropdown with full width', fakeAsync(() => {
         spectator.component.ngAfterViewInit();
         spectator.component.open();
-        tick(openDelayInMs);
+        tick(totalOpenDelayInMs);
         spectator.detectChanges();
         const card = spectator.query('kirby-card');
         const componentWidth = spectator.element.clientWidth;
@@ -433,7 +428,7 @@ describe('DropdownComponent', () => {
       describe('and Space key is pressed', () => {
         beforeEach(fakeAsync(() => {
           spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'Space');
-          tick(openDelayInMs);
+          tick(totalOpenDelayInMs);
         }));
         it('should open dropdown', () => {
           expect(spectator.component.isOpen).toBeTruthy();
@@ -446,7 +441,7 @@ describe('DropdownComponent', () => {
       describe('and Enter key is pressed', () => {
         beforeEach(fakeAsync(() => {
           spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'Enter');
-          tick(openDelayInMs);
+          tick(totalOpenDelayInMs);
         }));
         it('should open dropdown', () => {
           expect(spectator.component.isOpen).toBeTruthy();
@@ -459,7 +454,7 @@ describe('DropdownComponent', () => {
       describe('and Home key is pressed', () => {
         beforeEach(fakeAsync(() => {
           spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'Home');
-          tick(openDelayInMs);
+          tick(totalOpenDelayInMs);
         }));
         it('should open dropdown', () => {
           expect(spectator.component.isOpen).toBeTruthy();
@@ -472,7 +467,7 @@ describe('DropdownComponent', () => {
       describe('and End key is pressed', () => {
         beforeEach(fakeAsync(() => {
           spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'End');
-          tick(openDelayInMs);
+          tick(totalOpenDelayInMs);
         }));
         it('should open dropdown', () => {
           expect(spectator.component.isOpen).toBeTruthy();
@@ -486,7 +481,7 @@ describe('DropdownComponent', () => {
         beforeEach(fakeAsync(() => {
           buttonElement.focus();
           spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'ArrowUp');
-          tick(openDelayInMs);
+          tick(totalOpenDelayInMs);
         }));
         it('should open dropdown', () => {
           expect(spectator.component.isOpen).toBeTruthy();
@@ -503,7 +498,7 @@ describe('DropdownComponent', () => {
         beforeEach(fakeAsync(() => {
           buttonElement.focus();
           spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'ArrowDown');
-          tick(openDelayInMs);
+          tick(totalOpenDelayInMs);
         }));
         it('should open dropdown', () => {
           expect(spectator.component.isOpen).toBeTruthy();
@@ -522,7 +517,7 @@ describe('DropdownComponent', () => {
             cancelable: true,
           });
           spectator.element.dispatchEvent(event);
-          tick(openDelayInMs);
+          tick(totalOpenDelayInMs);
         }));
         it('should open dropdown', () => {
           expect(spectator.component.isOpen).toBeTruthy();
@@ -599,14 +594,14 @@ describe('DropdownComponent', () => {
 
           it('should open the dropdown when ArrowUp key is pressed', fakeAsync(() => {
             spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'ArrowUp');
-            tick(openDelayInMs);
+            tick(totalOpenDelayInMs);
 
             expect(spectator.component.isOpen).toBeTruthy();
           }));
 
           it('should open the dropdown when ArrowDown key is pressed', fakeAsync(() => {
             spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'ArrowDown');
-            tick(openDelayInMs);
+            tick(totalOpenDelayInMs);
 
             expect(spectator.component.isOpen).toBeTruthy();
           }));
@@ -731,7 +726,7 @@ describe('DropdownComponent', () => {
             cancelable: true,
           });
           spectator.element.dispatchEvent(event);
-          tick(openDelayInMs);
+          tick(totalOpenDelayInMs);
         }));
         it('should close dropdown', () => {
           expect(spectator.component.isOpen).toBeFalsy();
@@ -1010,7 +1005,7 @@ describe('DropdownComponent', () => {
           const card = spectator.query('kirby-card');
           expect(card).toHaveComputedStyle({ right: '0px' });
           done();
-        }, openDelayInMs);
+        }, openDropdownDelayInMs);
       });
     });
 
@@ -1038,13 +1033,13 @@ describe('DropdownComponent', () => {
 
       it('should not open', fakeAsync(() => {
         spectator.component.open();
-        tick(openDelayInMs);
+        tick(totalOpenDelayInMs);
         expect(spectator.component.isOpen).toBeFalsy();
       }));
 
       it('should not toggle', fakeAsync(() => {
         spectator.component.toggle();
-        tick(openDelayInMs);
+        tick(totalOpenDelayInMs);
         expect(spectator.component.isOpen).toBeFalsy();
       }));
 
@@ -1068,13 +1063,13 @@ describe('DropdownComponent', () => {
 
         it('should not open dropdown when Space key is pressed', fakeAsync(() => {
           spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'Space');
-          tick(openDelayInMs);
+          tick(totalOpenDelayInMs);
           expect(spectator.component.isOpen).toBeFalsy();
         }));
 
         it('should not open dropdown when Enter key is pressed', fakeAsync(() => {
           spectator.dispatchKeyboardEvent(spectator.element, 'keydown', 'Enter');
-          tick(openDelayInMs);
+          tick(totalOpenDelayInMs);
           expect(spectator.component.isOpen).toBeFalsy();
         }));
 
@@ -1296,7 +1291,7 @@ describe('DropdownComponent', () => {
       cardElement = spectator.query('kirby-card');
       // Act:
       spectator.click('button');
-      tick(openDelayInMs);
+      tick(totalOpenDelayInMs);
       spectator.detectChanges();
     }));
 
@@ -1415,7 +1410,7 @@ describe('DropdownComponent', () => {
 
     it('should have correct item size', fakeAsync(() => {
       spectator.component.open();
-      tick(openDelayInMs);
+      tick(totalOpenDelayInMs);
       spectator.detectChanges();
 
       const itemElements = spectator.queryAll<HTMLElement>('kirby-item');

--- a/libs/designsystem/dropdown/src/dropdown.component.stories.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.stories.ts
@@ -16,7 +16,7 @@ import { DropdownExampleComponent } from '~/app/examples/dropdown-example/dropdo
 const items = ['Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5'];
 
 @Component({
-  selector: 'kirby-dropdown-dynamic-wrapper',
+  selector: 'kirby-dropdown-async-items-wrapper',
   standalone: true,
   imports: [DropdownComponent],
   template: `
@@ -27,7 +27,7 @@ const items = ['Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5'];
     ></kirby-dropdown>
   `,
 })
-class DynamicItemsWrapperComponent implements OnInit {
+class AsyncItemsWrapperComponent implements OnInit {
   items = signal<string[]>([]);
   ngOnInit() {
     setTimeout(() => {
@@ -75,7 +75,7 @@ const meta: Meta<DropdownComponent> = {
         DropdownComponent,
         ButtonComponent,
         DropdownExampleComponent,
-        DynamicItemsWrapperComponent,
+        AsyncItemsWrapperComponent,
       ],
     }),
   ],
@@ -242,17 +242,17 @@ export const CookbookExample: Story = {
   }),
 };
 
-export const DropdownOpenedPopoutTopStartWithDynamicItems: Story = {
+export const DropdownOpenedPopoutTopStartWithAsyncItems: Story = {
   decorators: [withPosition('top-start')],
   render: () => ({
-    template: `<kirby-dropdown-dynamic-wrapper></kirby-dropdown-dynamic-wrapper>`,
+    template: `<kirby-dropdown-async-items-wrapper></kirby-dropdown-async-items-wrapper>`,
   }),
   play: openDropdown,
 };
 
-export const DropdownOpenedPopoutBottomStartWithDynamicItems: Story = {
+export const DropdownOpenedPopoutBottomStartWithAsyncItems: Story = {
   render: () => ({
-    template: `<kirby-dropdown-dynamic-wrapper></kirby-dropdown-dynamic-wrapper>`,
+    template: `<kirby-dropdown-async-items-wrapper></kirby-dropdown-async-items-wrapper>`,
   }),
   play: openDropdown,
 };

--- a/libs/designsystem/dropdown/src/dropdown.component.stories.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.stories.ts
@@ -233,15 +233,6 @@ const createDynamicItemsStory = (direction: 'up' | 'down'): Story => {
       await waitFor(() => {
         expect(dropdown).toHaveAttribute('aria-expanded', 'true');
       });
-
-      const card = document.querySelector('kirby-card[role="listbox"]') as HTMLElement;
-      const buttonRect = dropdown.getBoundingClientRect();
-      const cardRect = card.getBoundingClientRect();
-      if (isUp) {
-        expect(cardRect.bottom).toBeLessThanOrEqual(buttonRect.top);
-      } else {
-        expect(cardRect.top).toBeGreaterThanOrEqual(buttonRect.bottom);
-      }
     },
   };
 };

--- a/libs/designsystem/dropdown/src/dropdown.component.stories.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.stories.ts
@@ -2,7 +2,6 @@ import { argsToTemplate, type Meta, moduleMetadata, type StoryObj } from '@story
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { DropdownComponent } from '@kirbydesign/designsystem/dropdown';
-import { DesignTokenHelper } from '@kirbydesign/core/helpers';
 import { ButtonComponent } from '@kirbydesign/designsystem/button';
 import { responsiveModes } from 'tools/storybook-config/shared-config';
 import { DropdownExampleComponent } from '~/app/examples/dropdown-example/dropdown-example.component';
@@ -209,3 +208,45 @@ export const CookbookExample: Story = {
     template: `<cookbook-dropdown-example></cookbook-dropdown-example>`,
   }),
 };
+
+const createDynamicItemsStory = (direction: 'up' | 'down'): Story => {
+  const isUp = direction === 'up';
+  return {
+    render: () => ({
+      props: { dynamicItems: [] as string[] },
+      template: `
+        <div style="${isUp ? 'height: calc(100vh - var(--kirby-spacing-s) * 2);' : ''}">
+          <button (click)="dynamicItems = ['Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5']" style="display: none;">Load items</button>
+          <kirby-dropdown aria-label="Choose your favorite item" ${isUp ? 'style="position: absolute; bottom: var(--kirby-spacing-s);"' : ''} [items]="dynamicItems"></kirby-dropdown>
+        </div>
+      `,
+    }),
+    play: async ({ canvasElement }) => {
+      // Simulate items being added after the dropdown has been initialized.
+      // Use native .click() so the Angular event binding fires regardless of display:none.
+      (canvasElement.querySelector('button') as HTMLButtonElement).click();
+
+      const canvas = within(canvasElement);
+      const dropdown = canvas.getByRole('combobox');
+      await userEvent.click(dropdown);
+
+      await waitFor(() => {
+        expect(dropdown).toHaveAttribute('aria-expanded', 'true');
+      });
+
+      const card = document.querySelector('kirby-card[role="listbox"]') as HTMLElement;
+      const buttonRect = dropdown.getBoundingClientRect();
+      const cardRect = card.getBoundingClientRect();
+      if (isUp) {
+        expect(cardRect.bottom).toBeLessThanOrEqual(buttonRect.top);
+      } else {
+        expect(cardRect.top).toBeGreaterThanOrEqual(buttonRect.bottom);
+      }
+    },
+  };
+};
+
+export const DropdownOpenedPopoutTopStartWithDynamicItems: Story = createDynamicItemsStory('up');
+
+export const DropdownOpenedPopoutBottomStartWithDynamicItems: Story =
+  createDynamicItemsStory('down');

--- a/libs/designsystem/dropdown/src/dropdown.component.stories.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.stories.ts
@@ -1,4 +1,11 @@
-import { argsToTemplate, type Meta, moduleMetadata, type StoryObj } from '@storybook/angular';
+import { Component, OnInit, signal } from '@angular/core';
+import {
+  argsToTemplate,
+  componentWrapperDecorator,
+  type Meta,
+  moduleMetadata,
+  type StoryObj,
+} from '@storybook/angular';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { DropdownComponent } from '@kirbydesign/designsystem/dropdown';
@@ -8,6 +15,54 @@ import { DropdownExampleComponent } from '~/app/examples/dropdown-example/dropdo
 
 const items = ['Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5'];
 
+@Component({
+  selector: 'kirby-dropdown-dynamic-wrapper',
+  standalone: true,
+  imports: [DropdownComponent],
+  template: `
+    <kirby-dropdown
+      aria-label="Choose your favorite item"
+      [items]="items()"
+      [placeholder]="items().length ? 'Please select:' : 'Loading...'"
+    ></kirby-dropdown>
+  `,
+})
+class DynamicItemsWrapperComponent implements OnInit {
+  items = signal<string[]>([]);
+  ngOnInit() {
+    setTimeout(() => {
+      this.items.set(['Async Item 1', 'Async Item 2', 'Async Item 3']);
+    });
+  }
+}
+
+const withPosition = (position: 'top-start' | 'top-end' | 'bottom-end') =>
+  componentWrapperDecorator((story) => {
+    switch (position) {
+      case 'top-start':
+        return `
+          <div style="height: calc(100vh - var(--kirby-spacing-s) * 2);">
+            <div style="position: absolute; bottom: var(--kirby-spacing-s);">
+              ${story}
+            </div>
+          </div>`;
+      case 'top-end':
+        return `
+          <div style="height: calc(100vh - var(--kirby-spacing-s) * 2);">
+            <div style="position: absolute; bottom: var(--kirby-spacing-s); right: var(--kirby-spacing-s);">
+              ${story}
+            </div>
+          </div>`;
+      case 'bottom-end':
+        return `
+          <div style="display: flex; justify-content: flex-end; width: 100%;">
+            ${story}
+          </div>`;
+      default:
+        return story;
+    }
+  });
+
 const meta: Meta<DropdownComponent> = {
   component: DropdownComponent,
   title: 'Components / Dropdown',
@@ -16,7 +71,12 @@ const meta: Meta<DropdownComponent> = {
   },
   decorators: [
     moduleMetadata({
-      imports: [DropdownComponent, ButtonComponent, DropdownExampleComponent],
+      imports: [
+        DropdownComponent,
+        ButtonComponent,
+        DropdownExampleComponent,
+        DynamicItemsWrapperComponent,
+      ],
     }),
   ],
   argTypes: {
@@ -34,6 +94,12 @@ const meta: Meta<DropdownComponent> = {
 };
 export default meta;
 type Story = StoryObj<DropdownComponent>;
+
+const openDropdown: Story['play'] = async ({ canvasElement }) => {
+  const dropdown = within(canvasElement).getByRole('combobox');
+  await userEvent.click(dropdown);
+  await waitFor(() => expect(dropdown).toHaveAttribute('aria-expanded', 'true'));
+};
 
 export const Dropdown: Story = {
   args: {
@@ -135,23 +201,12 @@ export const DropdownOpenedPopoutBottomEnd: Story = {
     items: items,
     selectedIndex: 0,
   },
+  decorators: [withPosition('bottom-end')],
   render: (args) => ({
     props: args,
-    template: `
-      <div style="display: flex; justify-content: flex-end; width: 100%;">
-        <kirby-dropdown aria-label="Choose your favorite item" ${argsToTemplate(args)}></kirby-dropdown>
-      </div>
-    `,
+    template: `<kirby-dropdown aria-label="Choose your favorite item" ${argsToTemplate(args)}></kirby-dropdown>`,
   }),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const dropdown = canvas.getByRole('combobox');
-    await userEvent.click(dropdown);
-
-    await waitFor(() => {
-      expect(dropdown).toHaveAttribute('aria-expanded', 'true');
-    });
-  },
+  play: openDropdown,
 };
 
 export const DropdownOpenedPopoutTopStart: Story = {
@@ -159,23 +214,12 @@ export const DropdownOpenedPopoutTopStart: Story = {
     items: items,
     selectedIndex: 0,
   },
+  decorators: [withPosition('top-start')],
   render: (args) => ({
     props: args,
-    template: `
-      <div style="height: calc(100vh - var(--kirby-spacing-s) * 2);"> <!-- Adapt to full height of storybook root accounting for padding -->
-        <kirby-dropdown aria-label="Choose your favorite item" style="position: absolute; bottom: var(--kirby-spacing-s);" ${argsToTemplate(args)}></kirby-dropdown>
-      </div>
-    `,
+    template: `<kirby-dropdown aria-label="Choose your favorite item" ${argsToTemplate(args)}></kirby-dropdown>`,
   }),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const dropdown = canvas.getByRole('combobox');
-    await userEvent.click(dropdown);
-
-    await waitFor(() => {
-      expect(dropdown).toHaveAttribute('aria-expanded', 'true');
-    });
-  },
+  play: openDropdown,
 };
 
 export const DropdownOpenedPopoutTopEnd: Story = {
@@ -184,23 +228,12 @@ export const DropdownOpenedPopoutTopEnd: Story = {
     selectedIndex: 0,
     popout: 'left',
   },
+  decorators: [withPosition('top-end')],
   render: (args) => ({
     props: args,
-    template: `
-      <div style="height: calc(100vh - var(--kirby-spacing-s) * 2);"> <!-- Adapt to full height of storybook root accounting for padding -->
-        <kirby-dropdown aria-label="Choose your favorite item" style="position: absolute; bottom: var(--kirby-spacing-s); right: var(--kirby-spacing-s);" ${argsToTemplate(args)}></kirby-dropdown>
-      </div>
-    `,
+    template: `<kirby-dropdown aria-label="Choose your favorite item" ${argsToTemplate(args)}></kirby-dropdown>`,
   }),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const dropdown = canvas.getByRole('combobox');
-    await userEvent.click(dropdown);
-
-    await waitFor(() => {
-      expect(dropdown).toHaveAttribute('aria-expanded', 'true');
-    });
-  },
+  play: openDropdown,
 };
 
 export const CookbookExample: Story = {
@@ -209,35 +242,17 @@ export const CookbookExample: Story = {
   }),
 };
 
-const createDynamicItemsStory = (direction: 'up' | 'down'): Story => {
-  const isUp = direction === 'up';
-  return {
-    render: () => ({
-      props: { dynamicItems: [] as string[] },
-      template: `
-        <div style="${isUp ? 'height: calc(100vh - var(--kirby-spacing-s) * 2);' : ''}">
-          <button (click)="dynamicItems = ['Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5']" style="display: none;">Load items</button>
-          <kirby-dropdown aria-label="Choose your favorite item" ${isUp ? 'style="position: absolute; bottom: var(--kirby-spacing-s);"' : ''} [items]="dynamicItems"></kirby-dropdown>
-        </div>
-      `,
-    }),
-    play: async ({ canvasElement }) => {
-      // Simulate items being added after the dropdown has been initialized.
-      // Use native .click() so the Angular event binding fires regardless of display:none.
-      (canvasElement.querySelector('button') as HTMLButtonElement).click();
-
-      const canvas = within(canvasElement);
-      const dropdown = canvas.getByRole('combobox');
-      await userEvent.click(dropdown);
-
-      await waitFor(() => {
-        expect(dropdown).toHaveAttribute('aria-expanded', 'true');
-      });
-    },
-  };
+export const DropdownOpenedPopoutTopStartWithDynamicItems: Story = {
+  decorators: [withPosition('top-start')],
+  render: () => ({
+    template: `<kirby-dropdown-dynamic-wrapper></kirby-dropdown-dynamic-wrapper>`,
+  }),
+  play: openDropdown,
 };
 
-export const DropdownOpenedPopoutTopStartWithDynamicItems: Story = createDynamicItemsStory('up');
-
-export const DropdownOpenedPopoutBottomStartWithDynamicItems: Story =
-  createDynamicItemsStory('down');
+export const DropdownOpenedPopoutBottomStartWithDynamicItems: Story = {
+  render: () => ({
+    template: `<kirby-dropdown-dynamic-wrapper></kirby-dropdown-dynamic-wrapper>`,
+  }),
+  play: openDropdown,
+};

--- a/libs/designsystem/popover/src/popover.component.ts
+++ b/libs/designsystem/popover/src/popover.component.ts
@@ -37,6 +37,7 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
   private isFirstToLockScroll: boolean;
   private zIndex: number;
   private document: Document;
+  private openingFrameId: ReturnType<typeof requestAnimationFrame> | null = null;
 
   @ViewChild('wrapper', { static: true, read: ElementRef })
   wrapperElement: ElementRef<HTMLDivElement>;
@@ -130,16 +131,25 @@ export class PopoverComponent implements AfterViewInit, OnDestroy {
     this.renderer.appendChild(this.document.body, this.elementRef.nativeElement);
 
     this.preventScroll();
-    this.positionWrapper();
-
-    this.renderer.addClass(this.elementRef.nativeElement, 'is-open');
-    this.renderer.removeClass(this.elementRef.nativeElement, 'is-opening');
-
     this.isShowing = true;
+
+    this.openingFrameId = requestAnimationFrame(() => {
+      this.openingFrameId = null;
+      if (!this.isShowing) return;
+      this.positionWrapper();
+      this.renderer.addClass(this.elementRef.nativeElement, 'is-open');
+      this.renderer.removeClass(this.elementRef.nativeElement, 'is-opening');
+    });
   }
 
   hide() {
     if (!this.isShowing) return;
+
+    if (this.openingFrameId !== null) {
+      cancelAnimationFrame(this.openingFrameId);
+      this.openingFrameId = null;
+      this.renderer.removeClass(this.elementRef.nativeElement, 'is-opening');
+    }
 
     this.willHide.emit();
     this.renderer.removeChild(


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4437 

## What is the new behavior?
Wait another paint cycle to ensure we know the `height` of the `dropdown` elements

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?
Previously this worked for **static content** because the items were already rendered in the DOM
(and had known dimensions) before the popover was moved to `<body>` for positioning.

With **reactive/dynamic content** (e.g. `@for` loops), the items are not rendered until the
popover becomes visible via the `is-opening` class (`display: block; visibility: hidden`).
The positioning logic ran synchronously in the same JS task as the DOM attachment, meaning
`getBoundingClientRect()` was called before the browser had completed a layout pass and computed
the actual height of the items. On first open, this resulted in incorrect dimensions being used
for positioning.

The fix defers `positionWrapper()` to the next animation frame (`requestAnimationFrame`), giving
the browser one full style/layout cycle to resolve the dimensions of newly rendered content before
positioning is calculated.

Think about this when `popover` should be re-reactored / re-written.

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

