### PR TITLE
Badge: Cap text resize at threshold

### DIFF
--- a/libs/designsystem/badge/src/badge.component.scss
+++ b/libs/designsystem/badge/src/badge.component.scss
@@ -5,6 +5,7 @@ $badge-size-medium: 1.6em;
 $badge-padding-inline: 0.5em;
 $badge-padding-block: 0.3em;
 $badge-icon-size: 1.6em;
+$maximum-font-size: 10px * utils.$text-resize-threshold;
 
 :host {
   position: var(--kirby-badge-position, relative);
@@ -12,7 +13,7 @@ $badge-icon-size: 1.6em;
   right: var(--kirby-badge-right, auto);
   top: var(--kirby-badge-top, auto);
   z-index: var(--kirby-badge-z-index, auto);
-  font-size: var(--kirby-badge-font-size, var(--kirby-font-size-xxs));
+  font-size: var(--kirby-badge-font-size, min($maximum-font-size, var(--kirby-font-size-xxs)));
   display: inline-flex;
 
   ion-badge {

--- a/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
+++ b/libs/designsystem/src/lib/components/segmented-control/segmented-control.component.scss
@@ -7,10 +7,6 @@ $maximum-font-size-sm: utils.size('xs') * utils.$text-resize-threshold;
 $maximum-font-size-md: utils.size('s') * utils.$text-resize-threshold;
 $badge-offset: 0.8em;
 
-// Make badge scale proportionally with segment font-size instead of browser setting, so it also caps and preserves ratio.
-// Achieved by calculating the font size ratio between badge and segment, and converting it to em.
-$badge-font-size: calc(utils.font-size-base('xxs') / utils.font-size-base('s') * 1em);
-
 :host {
   display: block;
   user-select: none;
@@ -19,7 +15,6 @@ $badge-font-size: calc(utils.font-size-base('xxs') / utils.font-size-base('s') *
   --kirby-badge-top: #{-1 * $badge-offset};
   --kirby-badge-right: #{-2 * $badge-offset};
   --kirby-badge-z-index: #{utils.z('segment-badge')};
-  --kirby-badge-font-size: #{$badge-font-size};
 
   &.sm {
     ion-segment-button {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4410

## What is the new behavior?
Badges no longer grow linearly, but are capped to preserve visual hierarchy and not block out text.

The issue is most prominent when used with segmented controls, avatar etc, but to ensure consistency it is implemented for badges throughout.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

