### PR TITLE
Workflow: update dependencies in actions

### DIFF
--- a/.github/actions/kirby-setup/action.yml
+++ b/.github/actions/kirby-setup/action.yml
@@ -14,7 +14,7 @@ runs:
       run: jq 'del(.version)' package.json > hash-file1.json && jq 'del(.version)' package-lock.json > hash-file2.json
       shell: bash
     - name: Fetch Node Modules Cache
-      uses: actions/cache@v5
+      uses: actions/cache@v5.0.5
       id: cache
       with:
         path: | 

--- a/.github/actions/kirby-setup/action.yml
+++ b/.github/actions/kirby-setup/action.yml
@@ -7,19 +7,19 @@ runs:
       run: echo "NODE_VERSION=$(jq -r .engines.node ./package.json)" >> $GITHUB_ENV
       shell: bash
     - name: Install Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{env.NODE_VERSION}}
     - name: Prepare hash-files
       run: jq 'del(.version)' package.json > hash-file1.json && jq 'del(.version)' package-lock.json > hash-file2.json
       shell: bash
     - name: Fetch Node Modules Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: cache
       with:
         path: | 
           **/node_modules
-        key: node-modules-${{ runner.os }}-${{ inputs.node-version }}-${{hashFiles('**/hash-file1.json', '**/hash-file2.json')}}
+        key: node-modules-${{ runner.os }}-${{ env.NODE_VERSION }}-${{hashFiles('**/hash-file1.json', '**/hash-file2.json')}}
     - name: Remove hash-files
       run: rm hash-file1.json && rm hash-file2.json
       shell: bash

--- a/.github/actions/kirby-setup/action.yml
+++ b/.github/actions/kirby-setup/action.yml
@@ -7,14 +7,14 @@ runs:
       run: echo "NODE_VERSION=$(jq -r .engines.node ./package.json)" >> $GITHUB_ENV
       shell: bash
     - name: Install Node.js
-      uses: actions/setup-node@v6.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{env.NODE_VERSION}}
     - name: Prepare hash-files
       run: jq 'del(.version)' package.json > hash-file1.json && jq 'del(.version)' package-lock.json > hash-file2.json
       shell: bash
     - name: Fetch Node Modules Cache
-      uses: actions/cache@v5.0.5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: cache
       with:
         path: | 

--- a/.github/actions/kirby-setup/action.yml
+++ b/.github/actions/kirby-setup/action.yml
@@ -7,7 +7,7 @@ runs:
       run: echo "NODE_VERSION=$(jq -r .engines.node ./package.json)" >> $GITHUB_ENV
       shell: bash
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6.4.0
       with:
         node-version: ${{env.NODE_VERSION}}
     - name: Prepare hash-files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -95,6 +98,9 @@ jobs:
     name: Deploy cookbook
     needs: [build_kirby, build_kirby_cookbook]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # git push to gh-pages branch
+      deployments: write   # create/update GitHub deployments
     env:
       DOMAIN: 'kirby.design'
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,10 @@ jobs:
       node_version: ${{ steps.get_node_version.outputs.node_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Check modified files
         id: filter
-        uses: dorny/paths-filter@v4.0.1
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             libs:
@@ -47,7 +47,7 @@ jobs:
       NODE_VERSION: ${{ needs.pre_build.outputs.node_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Kirby setup
         uses: ./.github/actions/kirby-setup
       - name: Run linting
@@ -64,7 +64,7 @@ jobs:
       NODE_VERSION: ${{ needs.pre_build.outputs.node_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Kirby setup
         uses: ./.github/actions/kirby-setup
       - name: Build Kirby lib
@@ -79,13 +79,13 @@ jobs:
       NODE_VERSION: ${{ needs.pre_build.outputs.node_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Kirby setup
         uses: ./.github/actions/kirby-setup
       - name: Build Kirby Cookbook
         run: npx nx build cookbook --configuration=production
       - name: Upload Kirby Cookbook dist files
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             dist/
@@ -99,7 +99,7 @@ jobs:
       DOMAIN: 'kirby.design'
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get deployment name for default or feature branch
         if: "github.event_name == 'pull_request' || github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/v')"
         env:
@@ -167,7 +167,7 @@ jobs:
             -f state="$DEPLOYMENT_STATE" \
             -f log_url="$REPO_URL/$REPO/actions/runs/$RUN_ID"
       - name: Download Kirby Cookbook dist files
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Build Kirby Cookbook
         run: npx nx build cookbook --configuration=production
       - name: Upload Kirby Cookbook dist files
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: |
             dist/
@@ -159,7 +159,7 @@ jobs:
             -f state="$DEPLOYMENT_STATE" \
             -f log_url="$REPO_URL/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - name: Download Kirby Cookbook dist files
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: |
             dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ defaults:
   run:
     shell: bash
 
+env:
+  REPO_URL: https://github.com
+  REPO_HOST: github.com
+
 jobs:
   pre_build:
     name: Check if build is needed
@@ -22,7 +26,7 @@ jobs:
       node_version: ${{ steps.get_node_version.outputs.node_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check modified files
         id: filter
         uses: dorny/paths-filter@v2.9.2
@@ -32,7 +36,7 @@ jobs:
               - 'libs/**'
       - name: Get Node.JS version from package.json
         id: get_node_version
-        run: echo ::set-output name=node_version::$(jq -r .engines.node ./package.json)
+        run: echo "node_version=$(jq -r .engines.node ./package.json)" >> $GITHUB_OUTPUT
 
   lint_and_unittest:
     name: Lint & unit test
@@ -43,7 +47,7 @@ jobs:
       NODE_VERSION: ${{ needs.pre_build.outputs.node_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Kirby setup
         uses: ./.github/actions/kirby-setup
       - name: Run linting
@@ -60,7 +64,7 @@ jobs:
       NODE_VERSION: ${{ needs.pre_build.outputs.node_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Kirby setup
         uses: ./.github/actions/kirby-setup
       - name: Build Kirby lib
@@ -75,13 +79,13 @@ jobs:
       NODE_VERSION: ${{ needs.pre_build.outputs.node_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Kirby setup
         uses: ./.github/actions/kirby-setup
       - name: Build Kirby Cookbook
         run: npx nx build cookbook --configuration=production
       - name: Upload Kirby Cookbook dist files
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             dist/
@@ -95,7 +99,7 @@ jobs:
       DOMAIN: 'kirby.design'
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Get deployment name for default or feature branch
         if: "github.event_name == 'pull_request' || github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/v')"
         run: |
@@ -132,31 +136,31 @@ jobs:
         run: echo "HOSTNAME=cookbook" >> $GITHUB_ENV
       - name: Create Github Deployment
         id: create_deployment
-        uses: octokit/request-action@v2.x
-        with:
-          route: POST /repos/:repository/deployments
-          repository: ${{ github.repository }}
-          ref: ${{ github.event_name == 'pull_request' && format('refs/heads/{0}', github.head_ref) || github.ref }}
-          environment: ${{ env.GH_DEPLOY_ENVIRONMENT }}
-          production_environment: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
-          auto_merge: false
-          required_contexts: '[]' # Skip commit checks
-          mediaType: '{"previews": ["flash", "ant-man"]}' # some parameters need preview: https://docs.github.com/en/rest/reference/repos#list-deployment-statuses-preview-notices
+        run: |
+          # Skip commit checks
+          required_contexts='[]'
+          deployment_id=$(gh api /repos/${{ github.repository }}/deployments \
+            --method POST \
+            -f ref="${{ github.event_name == 'pull_request' && format('refs/heads/{0}', github.head_ref) || github.ref }}" \
+            -f environment="${{ env.GH_DEPLOY_ENVIRONMENT }}" \
+            -F production_environment=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }} \
+            -F auto_merge=false \
+            --field required_contexts:json="$required_contexts" \
+            --jq '.id')
+          echo "deployment_id=${deployment_id}" >> $GITHUB_OUTPUT
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set deployment status to in progress
-        uses: octokit/request-action@v2.x
-        with:
-          route: POST /repos/:repository/deployments/:deployment/statuses
-          repository: ${{ github.repository }}
-          deployment: ${{ fromJson(steps.create_deployment.outputs.data).id }}
-          log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          state: in_progress
-          mediaType: '{"previews": ["flash", "ant-man"]}'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOYMENT_STATE: in_progress
+        run: |
+          gh api /repos/${{ github.repository }}/deployments/${{ steps.create_deployment.outputs.deployment_id }}/statuses \
+            --method POST \
+            -f state="$DEPLOYMENT_STATE" \
+            -f log_url="$REPO_URL/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - name: Download Kirby Cookbook dist files
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             dist/
@@ -166,7 +170,7 @@ jobs:
           set -e
           echo "Hostname: ${HOSTNAME}"
 
-          git clone https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/kirbydesign/designsystem.git -b gh-pages designsystem_web
+          git clone https://$GITHUB_ACTOR:$GITHUB_TOKEN@$REPO_HOST/kirbydesign/designsystem.git -b gh-pages designsystem_web
 
           git config --global user.name 'DRB-bot'
           git config --global user.email 'dbrr00@bankdata.dk'
@@ -223,27 +227,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set deployment status to success
         id: successful_deployment
-        uses: octokit/request-action@v2.x
-        with:
-          route: POST /repos/:repository/deployments/:deployment/statuses
-          repository: ${{ github.repository }}
-          deployment: ${{ fromJson(steps.create_deployment.outputs.data).id }}
-          environment_url: ${{ env.HOSTNAME == 'cookbook' && format('https://cookbook.{0}', env.DOMAIN) || format('https://cookbook.{0}/branch/{1}/index.html', env.DOMAIN, env.HOSTNAME) }}
-          log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          state: success
-          mediaType: '{"previews": ["ant-man"]}'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOYMENT_STATE: success
+        run: |
+          gh api /repos/${{ github.repository }}/deployments/${{ steps.create_deployment.outputs.deployment_id }}/statuses \
+            --method POST \
+            -f state="$DEPLOYMENT_STATE" \
+            -f log_url="$REPO_URL/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f environment_url="${{ env.HOSTNAME == 'cookbook' && format('https://cookbook.{0}', env.DOMAIN) || format('https://cookbook.{0}/branch/{1}/index.html', env.DOMAIN, env.HOSTNAME) }}"
       - name: Set deployment status to failure
         id: failed_deployment
-        uses: octokit/request-action@v2.x
         if: failure()
-        with:
-          route: POST /repos/:repository/deployments/:deployment/statuses
-          repository: ${{ github.repository }}
-          deployment: ${{ fromJson(steps.create_deployment.outputs.data).id }}
-          log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          state: failure
-          mediaType: '{"previews": ["ant-man"]}'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOYMENT_STATE: failure
+        run: |
+          gh api /repos/${{ github.repository }}/deployments/${{ steps.create_deployment.outputs.deployment_id }}/statuses \
+            --method POST \
+            -f state="$DEPLOYMENT_STATE" \
+            -f log_url="$REPO_URL/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,8 +102,10 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: Get deployment name for default or feature branch
         if: "github.event_name == 'pull_request' || github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/v')"
+        env:
+          GIT_REF: ${{ github.head_ref || github.ref }}
         run: |
-          branchname="${{ github.head_ref || github.ref }}"
+          branchname="$GIT_REF"
           echo "Github branchname: ${branchname}"
           branchname="${branchname##*/}"
           echo "Removed leading paths - branchname: ${branchname}"
@@ -136,28 +138,34 @@ jobs:
         run: echo "HOSTNAME=cookbook" >> $GITHUB_ENV
       - name: Create Github Deployment
         id: create_deployment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOY_REF: ${{ github.event_name == 'pull_request' && format('refs/heads/{0}', github.head_ref) || github.ref }}
+          PRODUCTION_ENV: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+          REPO: ${{ github.repository }}
         run: |
           payload=$(jq -n \
-            --arg ref "${{ github.event_name == 'pull_request' && format('refs/heads/{0}', github.head_ref) || github.ref }}" \
-            --arg environment "${{ env.GH_DEPLOY_ENVIRONMENT }}" \
-            --argjson production_environment ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }} \
+            --arg ref "$DEPLOY_REF" \
+            --arg environment "$GH_DEPLOY_ENVIRONMENT" \
+            --argjson production_environment $PRODUCTION_ENV \
             '{ref: $ref, environment: $environment, production_environment: $production_environment, auto_merge: false, required_contexts: []}')
-          deployment_id=$(echo "$payload" | gh api /repos/${{ github.repository }}/deployments \
+          deployment_id=$(echo "$payload" | gh api /repos/$REPO/deployments \
             --method POST \
             --input - \
             --jq '.id')
           echo "deployment_id=${deployment_id}" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set deployment status to in progress
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPLOYMENT_STATE: in_progress
+          REPO: ${{ github.repository }}
+          DEPLOYMENT_ID: ${{ steps.create_deployment.outputs.deployment_id }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          gh api /repos/${{ github.repository }}/deployments/${{ steps.create_deployment.outputs.deployment_id }}/statuses \
+          gh api /repos/$REPO/deployments/$DEPLOYMENT_ID/statuses \
             --method POST \
             -f state="$DEPLOYMENT_STATE" \
-            -f log_url="$REPO_URL/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            -f log_url="$REPO_URL/$REPO/actions/runs/$RUN_ID"
       - name: Download Kirby Cookbook dist files
         uses: actions/cache@v5.0.5
         with:
@@ -229,20 +237,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPLOYMENT_STATE: success
+          REPO: ${{ github.repository }}
+          DEPLOYMENT_ID: ${{ steps.create_deployment.outputs.deployment_id }}
+          RUN_ID: ${{ github.run_id }}
+          ENVIRONMENT_URL: ${{ env.HOSTNAME == 'cookbook' && format('https://cookbook.{0}', env.DOMAIN) || format('https://cookbook.{0}/branch/{1}/index.html', env.DOMAIN, env.HOSTNAME) }}
         run: |
-          gh api /repos/${{ github.repository }}/deployments/${{ steps.create_deployment.outputs.deployment_id }}/statuses \
+          gh api /repos/$REPO/deployments/$DEPLOYMENT_ID/statuses \
             --method POST \
             -f state="$DEPLOYMENT_STATE" \
-            -f log_url="$REPO_URL/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            -f environment_url="${{ env.HOSTNAME == 'cookbook' && format('https://cookbook.{0}', env.DOMAIN) || format('https://cookbook.{0}/branch/{1}/index.html', env.DOMAIN, env.HOSTNAME) }}"
+            -f log_url="$REPO_URL/$REPO/actions/runs/$RUN_ID" \
+            -f environment_url="$ENVIRONMENT_URL"
       - name: Set deployment status to failure
         id: failed_deployment
         if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPLOYMENT_STATE: failure
+          REPO: ${{ github.repository }}
+          DEPLOYMENT_ID: ${{ steps.create_deployment.outputs.deployment_id }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          gh api /repos/${{ github.repository }}/deployments/${{ steps.create_deployment.outputs.deployment_id }}/statuses \
+          gh api /repos/$REPO/deployments/$DEPLOYMENT_ID/statuses \
             --method POST \
             -f state="$DEPLOYMENT_STATE" \
-            -f log_url="$REPO_URL/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            -f log_url="$REPO_URL/$REPO/actions/runs/$RUN_ID"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,10 @@ jobs:
       node_version: ${{ steps.get_node_version.outputs.node_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Check modified files
         id: filter
-        uses: dorny/paths-filter@v2.9.2
+        uses: dorny/paths-filter@v4.0.1
         with:
           filters: |
             libs:
@@ -47,7 +47,7 @@ jobs:
       NODE_VERSION: ${{ needs.pre_build.outputs.node_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Kirby setup
         uses: ./.github/actions/kirby-setup
       - name: Run linting
@@ -64,7 +64,7 @@ jobs:
       NODE_VERSION: ${{ needs.pre_build.outputs.node_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Kirby setup
         uses: ./.github/actions/kirby-setup
       - name: Build Kirby lib
@@ -79,7 +79,7 @@ jobs:
       NODE_VERSION: ${{ needs.pre_build.outputs.node_version }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Kirby setup
         uses: ./.github/actions/kirby-setup
       - name: Build Kirby Cookbook
@@ -99,7 +99,7 @@ jobs:
       DOMAIN: 'kirby.design'
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Get deployment name for default or feature branch
         if: "github.event_name == 'pull_request' || github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/v')"
         run: |
@@ -137,15 +137,14 @@ jobs:
       - name: Create Github Deployment
         id: create_deployment
         run: |
-          # Skip commit checks
-          required_contexts='[]'
-          deployment_id=$(gh api /repos/${{ github.repository }}/deployments \
+          payload=$(jq -n \
+            --arg ref "${{ github.event_name == 'pull_request' && format('refs/heads/{0}', github.head_ref) || github.ref }}" \
+            --arg environment "${{ env.GH_DEPLOY_ENVIRONMENT }}" \
+            --argjson production_environment ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }} \
+            '{ref: $ref, environment: $environment, production_environment: $production_environment, auto_merge: false, required_contexts: []}')
+          deployment_id=$(echo "$payload" | gh api /repos/${{ github.repository }}/deployments \
             --method POST \
-            -f ref="${{ github.event_name == 'pull_request' && format('refs/heads/{0}', github.head_ref) || github.ref }}" \
-            -f environment="${{ env.GH_DEPLOY_ENVIRONMENT }}" \
-            -F production_environment=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }} \
-            -F auto_merge=false \
-            --field required_contexts:json="$required_contexts" \
+            --input - \
             --jq '.id')
           echo "deployment_id=${deployment_id}" >> $GITHUB_OUTPUT
         env:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Check if storybook dist folders exist
         id: check_storybook_folders
         run: |
-          if [ -d ${{ github.workspace }}/dist/storybook/designsystem ]; then
+          if [ -d "$GITHUB_WORKSPACE/dist/storybook/designsystem" ]; then
             echo "designsystem=true" >> $GITHUB_OUTPUT
           fi
-          if [ -d ${{ github.workspace }}/dist/storybook/extensions/angular ]; then
+          if [ -d "$GITHUB_WORKSPACE/dist/storybook/extensions/angular" ]; then
             echo "extensions_angular=true" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -18,7 +18,7 @@ jobs:
         uses: ./.github/actions/kirby-setup
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v5.0.1
+        uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
         with: 
           main-branch-name: develop
 
@@ -36,7 +36,7 @@ jobs:
           fi
 
       - name: Publish Designsystem  to Chromatic
-        uses: chromaui/action@latest  
+        uses: chromaui/action@7aca53e7aa87489020a97f633c1e7e82c12e5973 # 1.0.0
         # If designsystem storybook dist has been built, it means project might have been affected and should be tested
         if: steps.check_storybook_folders.outputs.designsystem == 'true'
         with:
@@ -49,7 +49,7 @@ jobs:
       - name: Publish Extensions to Chromatic
       # If extensions storybook dist has been built, it means project might have been affected and should be tested
         if: steps.check_storybook_folders.outputs.extensions_angular == 'true'
-        uses: chromaui/action@latest
+        uses: chromaui/action@7aca53e7aa87489020a97f633c1e7e82c12e5973 # 1.0.0
         with:
           projectToken: ${{ secrets.EXTENSIONS_CHROMATIC_PROJECT_TOKEN }}
           workingDir: libs/extensions/angular

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,6 +5,9 @@ on:
     branches-ignore:
       - "gh-pages"
 
+permissions:
+  contents: read
+
 jobs:
   chromatic:
     runs-on: ubuntu-latest

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -18,7 +18,7 @@ jobs:
         uses: ./.github/actions/kirby-setup
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v4
+        uses: nrwl/nx-set-shas@v5.0.1
         with: 
           main-branch-name: develop
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -39,7 +39,7 @@ jobs:
           fi
 
       - name: Publish Designsystem  to Chromatic
-        uses: chromaui/action@7aca53e7aa87489020a97f633c1e7e82c12e5973 # 1.0.0
+        uses: chromaui/action@7aca53e7aa87489020a97f633c1e7e82c12e5973 # 17.0.0
         # If designsystem storybook dist has been built, it means project might have been affected and should be tested
         if: steps.check_storybook_folders.outputs.designsystem == 'true'
         with:
@@ -52,7 +52,7 @@ jobs:
       - name: Publish Extensions to Chromatic
       # If extensions storybook dist has been built, it means project might have been affected and should be tested
         if: steps.check_storybook_folders.outputs.extensions_angular == 'true'
-        uses: chromaui/action@7aca53e7aa87489020a97f633c1e7e82c12e5973 # 1.0.0
+        uses: chromaui/action@7aca53e7aa87489020a97f633c1e7e82c12e5973 # 17.0.0
         with:
           projectToken: ${{ secrets.EXTENSIONS_CHROMATIC_PROJECT_TOKEN }}
           workingDir: libs/extensions/angular

--- a/.github/workflows/cleanup-branch-deployment.yml
+++ b/.github/workflows/cleanup-branch-deployment.yml
@@ -8,37 +8,28 @@ jobs:
     if: github.event.ref_type == 'branch'
     runs-on: ubuntu-latest
     steps:
-      - name: Get deployments for branch
-        id: get_branch_deployments
-        uses: octokit/request-action@v2.x
-        with:
-          route: GET /repos/:repository/deployments
-          repository: ${{ github.repository }}
-          ref: ${{ startsWith(github.event.ref, 'refs/heads/') && '' || 'refs/heads/' }}${{ github.event.ref }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Get latest deployment"
+      - name: Get latest deployment for branch
         id: get_latest_deployment
-        if: fromJson(steps.get_branch_deployments.outputs.data)[0] != null
-        run: echo "::set-output name=id::${{ fromJson(steps.get_branch_deployments.outputs.data)[0].id }}"
+        run: |
+          ref="${{ startsWith(github.event.ref, 'refs/heads/') && '' || 'refs/heads/' }}${{ github.event.ref }}"
+          deployment_id=$(gh api "/repos/${{ github.repository }}/deployments?ref=${ref}" --jq '.[0].id // empty')
+          echo "id=${deployment_id}" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set deployment status to inactive
-        if: steps.get_latest_deployment.outputs.id != null
-        uses: octokit/request-action@v2.x
-        with:
-          route: POST /repos/:repository/deployments/:deployment/statuses
-          repository: ${{ github.repository }}
-          deployment: ${{ steps.get_latest_deployment.outputs.id }}
-          log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          state: inactive
-          mediaType: '{"previews": ["ant-man"]}'
+        if: steps.get_latest_deployment.outputs.id != ''
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOYMENT_STATE: inactive
+        run: |
+          gh api /repos/${{ github.repository }}/deployments/${{ steps.get_latest_deployment.outputs.id }}/statuses \
+            --method POST \
+            -f state="$DEPLOYMENT_STATE" \
+            -f log_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - name: Delete deployment
-        if: steps.get_latest_deployment.outputs.id != null
-        uses: octokit/request-action@v2.x
-        with:
-          route: DELETE /repos/:repository/deployments/:deployment
-          repository: ${{ github.repository }}
-          deployment: ${{ steps.get_latest_deployment.outputs.id }}
+        if: steps.get_latest_deployment.outputs.id != ''
+        run: |
+          gh api /repos/${{ github.repository }}/deployments/${{ steps.get_latest_deployment.outputs.id }} \
+            --method DELETE
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cleanup-branch-deployment.yml
+++ b/.github/workflows/cleanup-branch-deployment.yml
@@ -10,26 +10,34 @@ jobs:
     steps:
       - name: Get latest deployment for branch
         id: get_latest_deployment
-        run: |
-          ref="${{ startsWith(github.event.ref, 'refs/heads/') && '' || 'refs/heads/' }}${{ github.event.ref }}"
-          deployment_id=$(gh api "/repos/${{ github.repository }}/deployments?ref=${ref}" --jq '.[0].id // empty')
-          echo "id=${deployment_id}" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_REF: ${{ github.event.ref }}
+          REF_PREFIX: ${{ startsWith(github.event.ref, 'refs/heads/') && '' || 'refs/heads/' }}
+          REPO: ${{ github.repository }}
+        run: |
+          ref="${REF_PREFIX}${EVENT_REF}"
+          deployment_id=$(gh api "/repos/$REPO/deployments?ref=${ref}" --jq '.[0].id // empty')
+          echo "id=${deployment_id}" >> $GITHUB_OUTPUT
       - name: Set deployment status to inactive
         if: steps.get_latest_deployment.outputs.id != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPLOYMENT_STATE: inactive
+          REPO: ${{ github.repository }}
+          DEPLOYMENT_ID: ${{ steps.get_latest_deployment.outputs.id }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          gh api /repos/${{ github.repository }}/deployments/${{ steps.get_latest_deployment.outputs.id }}/statuses \
+          gh api /repos/$REPO/deployments/$DEPLOYMENT_ID/statuses \
             --method POST \
             -f state="$DEPLOYMENT_STATE" \
-            -f log_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            -f log_url="https://github.com/$REPO/actions/runs/$RUN_ID"
       - name: Delete deployment
         if: steps.get_latest_deployment.outputs.id != ''
-        run: |
-          gh api /repos/${{ github.repository }}/deployments/${{ steps.get_latest_deployment.outputs.id }} \
-            --method DELETE
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          DEPLOYMENT_ID: ${{ steps.get_latest_deployment.outputs.id }}
+        run: |
+          gh api /repos/$REPO/deployments/$DEPLOYMENT_ID \
+            --method DELETE

--- a/.github/workflows/cleanup-branch-deployment.yml
+++ b/.github/workflows/cleanup-branch-deployment.yml
@@ -2,6 +2,9 @@ name: Clean up branch deployment
 on:
   delete
 
+permissions:
+  deployments: write
+
 jobs:
   delete_latest_deployment_for_branch:
     name: Delete latest deployment for branch

--- a/.github/workflows/publish-extensions-angular.yml
+++ b/.github/workflows/publish-extensions-angular.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Kirby setup
         uses: ./.github/actions/kirby-setup
       - name: Build extensions-angular package and publish to npm

--- a/.github/workflows/publish-extensions-angular.yml
+++ b/.github/workflows/publish-extensions-angular.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Kirby setup
         uses: ./.github/actions/kirby-setup
       - name: Build extensions-angular package and publish to npm

--- a/.github/workflows/publish-extensions-angular.yml
+++ b/.github/workflows/publish-extensions-angular.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Kirby setup
         uses: ./.github/actions/kirby-setup
       - name: Build extensions-angular package and publish to npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Kirby setup
         uses: ./.github/actions/kirby-setup
       - name: Build core package and publish to npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Kirby setup
         uses: ./.github/actions/kirby-setup
       - name: Build core package and publish to npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Kirby setup
         uses: ./.github/actions/kirby-setup
       - name: Build core package and publish to npm

--- a/.github/workflows/spot-illustration-validation.yml
+++ b/.github/workflows/spot-illustration-validation.yml
@@ -10,10 +10,10 @@ jobs:
     name: Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'
 

--- a/.github/workflows/spot-illustration-validation.yml
+++ b/.github/workflows/spot-illustration-validation.yml
@@ -10,7 +10,7 @@ jobs:
     name: Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/spot-illustration-validation.yml
+++ b/.github/workflows/spot-illustration-validation.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'libs/extensions/angular/spot-illustration/src/svgs/**'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validation


### PR DESCRIPTION
Nodejs v.20 is deprecated in the Github Pipelines. This updates dependencies to versions that uses nodejs v.24

All versions is pinned to sha to prevent supply chain attach 

## Changes
- Updated GitHub Actions dependencies to latest versions:
  - `actions/checkout` v2 → v6.0.2
  - `actions/setup-node` v4 → v6.4.0
  - `actions/cache` v4 → v5.0.5
  - `dorny/paths-filter` v2.9.2 → v4.0.1
  - `nrwl/nx-set-shas` v4 → v5.0.1
- Replaced deprecated `octokit/request-action` with native `gh api` CLI calls for deployment management
- Fixed deprecated `::set-output` syntax → `$GITHUB_OUTPUT`
- Fixed cache key using wrong input variable (`inputs.node-version` → `env.NODE_VERSION`)

## Be aware of
- Added the `permissions` scope to limit the `gh_token` permissions in the workflow