### PR TITLE
Dropdown: wrong item selected when items are prepended async

### DIFF
--- a/libs/designsystem/dropdown/src/dropdown.component.spec.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.spec.ts
@@ -1443,5 +1443,29 @@ describe('DropdownComponent', () => {
         expect(unlistenCounter).toEqual(unlistenMockArrayLength);
       });
     });
+
+    describe('when items are prepended asynchronously', () => {
+      const prependedItems = [
+        { text: 'Prepended 1', value: 10 },
+        { text: 'Prepended 2', value: 20 },
+      ];
+
+      it('should select the correct item when clicking after items are prepended', fakeAsync(() => {
+        const newItems = [...prependedItems, ...items];
+        spectator.setHostInput('items', newItems);
+        spectator.detectChanges();
+
+        spectator.component.open();
+        tick(totalOpenDelayInMs);
+        spectator.detectChanges();
+
+        const itemElements = spectator.queryAll<HTMLElement>('kirby-item');
+        const thirdItemElement = itemElements[2];
+        thirdItemElement.click();
+        spectator.detectChanges();
+
+        expect(spectator.component.value).toEqual(newItems[2]);
+      }));
+    });
   });
 });

--- a/libs/designsystem/dropdown/src/dropdown.component.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.ts
@@ -264,17 +264,7 @@ export class DropdownComponent
         kirbyItem.nativeElement,
         'click',
         () => {
-          const sorted = this._kirbyItemsSlotted
-            .toArray()
-            .sort((a, b) =>
-              a.nativeElement.compareDocumentPosition(b.nativeElement) &
-              Node.DOCUMENT_POSITION_FOLLOWING
-                ? -1
-                : 1
-            );
-          this.onItemSelect(
-            sorted.findIndex((item) => item.nativeElement === kirbyItem.nativeElement)
-          );
+          this.onItemSelect(this.domIndexOf(kirbyItem));
         }
       );
 
@@ -716,6 +706,17 @@ export class DropdownComponent
       this.focusedIndex = newFocusedIndex;
     }
     return false;
+  }
+
+  private domIndexOf(kirbyItem: ElementRef<HTMLElement>): number {
+    return this._kirbyItemsSlotted
+      .toArray()
+      .sort((a, b) =>
+        a.nativeElement.compareDocumentPosition(b.nativeElement) & Node.DOCUMENT_POSITION_FOLLOWING
+          ? -1
+          : 1
+      )
+      .findIndex((item) => item.nativeElement === kirbyItem.nativeElement);
   }
 
   private unlistenAllSlottedItems() {

--- a/libs/designsystem/dropdown/src/dropdown.component.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.ts
@@ -709,14 +709,13 @@ export class DropdownComponent
   }
 
   private domIndexOf(kirbyItem: ElementRef<HTMLElement>): number {
-    return this._kirbyItemsSlotted
+    return this.kirbyItemsSlotted
       .toArray()
-      .sort((a, b) =>
-        a.nativeElement.compareDocumentPosition(b.nativeElement) & Node.DOCUMENT_POSITION_FOLLOWING
-          ? -1
-          : 1
-      )
-      .findIndex((item) => item.nativeElement === kirbyItem.nativeElement);
+      .filter(
+        (item) =>
+          item.nativeElement.compareDocumentPosition(kirbyItem.nativeElement) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+      ).length;
   }
 
   private unlistenAllSlottedItems() {

--- a/libs/designsystem/dropdown/src/dropdown.component.ts
+++ b/libs/designsystem/dropdown/src/dropdown.component.ts
@@ -258,13 +258,23 @@ export class DropdownComponent
     }
 
     // Setup a click listener for each new slotted items
-    kirbyItems.forEach((kirbyItem, index) => {
+    kirbyItems.forEach((kirbyItem) => {
       this.renderer.setAttribute(kirbyItem.nativeElement, 'role', 'option');
       const disposeClickListener: EventListenerDisposeFn = this.renderer.listen(
         kirbyItem.nativeElement,
         'click',
         () => {
-          this.onItemSelect(index);
+          const sorted = this._kirbyItemsSlotted
+            .toArray()
+            .sort((a, b) =>
+              a.nativeElement.compareDocumentPosition(b.nativeElement) &
+              Node.DOCUMENT_POSITION_FOLLOWING
+                ? -1
+                : 1
+            );
+          this.onItemSelect(
+            sorted.findIndex((item) => item.nativeElement === kirbyItem.nativeElement)
+          );
         }
       );
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4424

## What is the new behavior?

Fix dropdown selecting wrong item when items are asynchronously prepended, by resolving item index from live DOM order at click-time instead of capturing it during setup

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.