### PR TITLE
Deps: updated peer dependency to ^11.8.0 of @kirbydesign/designsystem from in extensions

### DIFF
--- a/libs/extensions/angular/package.json
+++ b/libs/extensions/angular/package.json
@@ -16,7 +16,7 @@
     "@angular/platform-browser": "^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
     "@angular/router": "^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
-    "@kirbydesign/designsystem": "^11.4.0",
+    "@kirbydesign/designsystem": "^11.8.0",
     "rxjs": "~7.8.0"
   },
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -268,7 +268,7 @@
         "@angular/platform-browser": "^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
         "@angular/router": "^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
-        "@kirbydesign/designsystem": "^11.4.0",
+        "@kirbydesign/designsystem": "^11.8.0",
         "rxjs": "~7.8.0"
       }
     },


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes no issue

## What is the new behavior?
In extensions we are introducing a combobox component. This combobox component needs to work with the kirby-form-field. However integrating a custom component within a kirby-form-field was first introduced in v11.8.0 of the kirby design system, and thus for the combobox to work, the extensions lib need to have at least this version of the designsystem.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?


## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

