### PR TITLE
Checkbox; add checked error

### DIFF
--- a/apps/cookbook/src/app/examples/checkbox-example/examples/states.ts
+++ b/apps/cookbook/src/app/examples/checkbox-example/examples/states.ts
@@ -9,6 +9,7 @@ const config = {
 <kirby-checkbox disabled="true" [checked]="true" text="Disabled checked"></kirby-checkbox>
 <kirby-checkbox [indeterminate]="true" text="Indeterminate"></kirby-checkbox>
 <kirby-checkbox [indeterminate]="true" text="Disabled Indeterminate" [disabled]="true"></kirby-checkbox>
+<kirby-checkbox [checked]="true" hasError="true" text="Checked with error"></kirby-checkbox>
 <kirby-checkbox hasError="true" text="Has error"></kirby-checkbox>`,
 };
 

--- a/libs/designsystem/checkbox/src/checkbox.component.scss
+++ b/libs/designsystem/checkbox/src/checkbox.component.scss
@@ -60,6 +60,7 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
 
   &.error ion-checkbox {
     --border-color: #{utils.get-color('danger')};
+    --border-color-checked: #{utils.get-color('danger')};
   }
 
   &[disabled] {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4316

## What is the new behavior?

It is possible to display an error on a checked checkbox.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

