### PR TITLE
CI: Fix branch cleanup step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,22 +188,6 @@ jobs:
             cp designsystem_web/branch/$RELEASENAME/index.html designsystem_web/branch/$RELEASENAME/404.html
           fi
 
-          # Build list of valid release names from active remote branches
-          branchList=""
-          for branch in $(git -C designsystem_web branch -r); do
-            branchList="$branchList $(bash .github/scripts/normalize-branch-name.sh "$branch")"
-          done
-
-          # Delete branch folders for closed branches
-          for folder in designsystem_web/branch/*/; do
-            foldername="${folder%/}"
-            foldername="${foldername##*/}"
-            if ! grep -q "$foldername" <<< "$branchList"; then
-              echo "Deleting branch folder $foldername (branch closed)"
-              rm -rf "designsystem_web/branch/$foldername"
-            fi
-          done
-
           cd designsystem_web
           git add .
 

--- a/.github/workflows/cleanup-branch-deployment.yml
+++ b/.github/workflows/cleanup-branch-deployment.yml
@@ -12,6 +12,8 @@ jobs:
     if: github.event.ref_type == 'branch'
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Get latest deployment for branch
         id: get_latest_deployment
         env:


### PR DESCRIPTION
## What is the new behavior?

Fix branch [cleanup action](https://github.com/kirbydesign/designsystem/actions/workflows/cleanup-branch-deployment.yml). We need to checkout the branch to get the ref. 
Furthermore we can remove the branch cleanup in the build pipeline. This fixes conflicts when pr's build on the same time because of the branch cleanup steps in the build

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

