### PR TITLE
Input: fix focus on click for nativeDatePicker input

### DIFF
--- a/libs/designsystem/form-field/src/form-field.component.html
+++ b/libs/designsystem/form-field/src/form-field.component.html
@@ -47,7 +47,7 @@
       <ng-content select="[kirby-affix='prefix']"></ng-content>
     </div>
     <ng-content></ng-content>
-    <div class="suffix vertical-align semi-dark-text" (click)="onSuffixClick()">
+    <div class="suffix vertical-align semi-dark-text" (click)="openDatePicker()">
       <ng-content select="[kirby-affix='suffix']"></ng-content>
       @if (showDefaultCalendarIcon) {
         <kirby-icon name="calendar"></kirby-icon>

--- a/libs/designsystem/form-field/src/form-field.component.html
+++ b/libs/designsystem/form-field/src/form-field.component.html
@@ -47,7 +47,7 @@
       <ng-content select="[kirby-affix='prefix']"></ng-content>
     </div>
     <ng-content></ng-content>
-    <div class="suffix vertical-align semi-dark-text">
+    <div class="suffix vertical-align semi-dark-text" (click)="onSuffixClick()">
       <ng-content select="[kirby-affix='suffix']"></ng-content>
       @if (showDefaultCalendarIcon) {
         <kirby-icon name="calendar"></kirby-icon>

--- a/libs/designsystem/form-field/src/form-field.component.ts
+++ b/libs/designsystem/form-field/src/form-field.component.ts
@@ -132,13 +132,8 @@ export class FormFieldComponent
     }
   }
 
-  onSuffixClick() {
-    if (this.dateInput?.useNativeDatePicker) {
-      this.openDatePicker();
-    }
-  }
-
   openDatePicker() {
+    if (!this.dateInput?.useNativeDatePicker) return;
     (this.nestedInteractiveElement as HTMLInputElement).showPicker();
   }
 

--- a/libs/designsystem/form-field/src/form-field.component.ts
+++ b/libs/designsystem/form-field/src/form-field.component.ts
@@ -132,6 +132,16 @@ export class FormFieldComponent
     }
   }
 
+  onSuffixClick() {
+    if (this.dateInput?.useNativeDatePicker) {
+      this.openDatePicker();
+    }
+  }
+
+  openDatePicker() {
+    (this.nestedInteractiveElement as HTMLInputElement).showPicker();
+  }
+
   public focus() {
     if (!this.nestedInteractiveElement) return;
 

--- a/libs/designsystem/form-field/src/input/input.component.scss
+++ b/libs/designsystem/form-field/src/input/input.component.scss
@@ -26,20 +26,15 @@ $padding-block-size-md: shared.$form-field-input-padding * 0.5;
   }
 
   &[type='date'] {
-    // Hide the builtin picker icon but position it so it overlays input, to ensure clicking the
-    // input opens the date picker as expected
+    // Hide the builtin picker icon - we use our own calendar icon with showPicker()
     &::-webkit-calendar-picker-indicator {
-      opacity: 0;
-      position: absolute;
-      left: 0;
-      width: 100%;
-      height: 100%;
+      display: none;
     }
   }
 
   /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
   &[type='date']::ng-deep + .suffix {
-    pointer-events: none; // ensure clicking icon opens date picker
+    cursor: pointer;
 
     // In firefox, we can't target and hide the builtin picker icon, so we use a feature query to hide
     // kirby-icon instead and accept that the native appearance is a bit different


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4497

## What is the new behavior?
Instead of overlaying the builtin icon on the whole input, we now listen for click on the date picker icon (suffix area) and use the input fields showPicker() method. This solves the issue because:

- We no longer intercept clicks on the whole input, so the picker should act as defined by the browser
  - In Chrome, it only appears on click on the date picker icon
  - In Safari, it is always present no matter where the input is clicked
  - In Firefox we hide our own implementation and use the browsers builtin, to avoid unnecessary complexity for hiding the builtin icon.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

