### PR TITLE
Combobox: reset scroll when leaving focus if no item has been selected

### DIFF
--- a/libs/extensions/angular/combobox/src/combobox.component.ts
+++ b/libs/extensions/angular/combobox/src/combobox.component.ts
@@ -963,9 +963,8 @@ export class ComboboxComponent
 
   private scrollToIndexIntoViewWhenOpeningPopup(): void {
     const focusedIndex = this.searchItems.indexOf(this.focusedItem);
-    if (focusedIndex < 0) return;
 
-    if (focusedIndex === 0) {
+    if (focusedIndex <= 0) {
       this.virtualScrollViewport?.setRenderedRange({ start: 0, end: 20 });
       this.virtualScrollViewport?.checkViewportSize();
       return;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4503

## What is the new behavior?
Reset the rendered window, if the user scrolls down and outside of the initial rendered items, and does not select an item.
<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

