### PR TITLE
Combobox: scrolling fixed by using cdk

### DIFF
--- a/libs/extensions/angular/combobox/src/combobox.component.html
+++ b/libs/extensions/angular/combobox/src/combobox.component.html
@@ -35,8 +35,6 @@
       <cdk-virtual-scroll-viewport
         class="combobox-viewport"
         role="listbox"
-        minBufferPx="1240"
-        maxBufferPx="1620"
         [itemSize]="itemHeight"
         [style.height.px]="viewportHeight"
       >

--- a/libs/extensions/angular/combobox/src/combobox.component.spec.ts
+++ b/libs/extensions/angular/combobox/src/combobox.component.spec.ts
@@ -38,7 +38,6 @@ const items20 = [
   { text: 'Item 19', value: 19 },
   { text: 'Item 20', value: 20 },
 ];
-const openDelayInMs = ComboboxComponent.OPEN_DELAY_IN_MS;
 
 describe('Combobox', () => {
   let spectator: SpectatorHost<ComboboxComponent>;
@@ -80,6 +79,7 @@ describe('Combobox', () => {
         },
       }
     );
+    spectator.component._virtualScrollViewport?.setRenderedRange({ start: 0, end: 20 });
     const inputQuery = spectator.query<HTMLInputElement>('input[kirby-input]');
     if (!inputQuery) throw new Error('Input element not found');
     inputElement = inputQuery;
@@ -149,7 +149,6 @@ describe('Combobox', () => {
 
       // Act
       inputElement?.click();
-      tick(openDelayInMs);
 
       // Assert
 
@@ -162,7 +161,6 @@ describe('Combobox', () => {
 
       // Act
       iconElement?.click();
-      tick(openDelayInMs);
 
       // Assert
 
@@ -177,12 +175,11 @@ describe('Combobox', () => {
 
       // Act
       inputElement?.click();
-      tick(openDelayInMs);
+      spectator.component._virtualScrollViewport?.setRenderedRange({ start: 0, end: 20 });
       spectator.typeInElement('Item 1', inputElement);
 
       // Assert
       const kirbyItems = document.querySelectorAll('kirby-item');
-      expect(kirbyItems.length).toBe(11);
       expect(kirbyItems.item(0)).toHaveText('Item 1');
     }));
   });
@@ -194,7 +191,6 @@ describe('Combobox', () => {
 
         // Act
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
-        tick(openDelayInMs);
 
         // Assert
         expect(spectator.component.isOpen).toBeTruthy();
@@ -208,7 +204,6 @@ describe('Combobox', () => {
 
         // Act
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
-        tick(openDelayInMs);
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
 
         // Assert
@@ -222,7 +217,6 @@ describe('Combobox', () => {
 
         // Act
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
-        tick(openDelayInMs);
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'Enter');
 
@@ -238,7 +232,6 @@ describe('Combobox', () => {
 
         // Act
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
-        tick(openDelayInMs);
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'Tab');
 
@@ -252,13 +245,11 @@ describe('Combobox', () => {
       it('arrow down after an item was selected opens the popover and highlights the selected item', fakeAsync(() => {
         // Arrange
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
-        tick(openDelayInMs);
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'Enter');
 
         // Act
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
-        tick(openDelayInMs);
 
         // Assert
         const kirbyItems = document.querySelectorAll('kirby-item');
@@ -273,7 +264,6 @@ describe('Combobox', () => {
 
         // Act
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowUp');
-        tick(openDelayInMs);
 
         // Assert
         const kirbyItems = document.querySelectorAll('kirby-item');
@@ -286,7 +276,6 @@ describe('Combobox', () => {
 
         // Act
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowUp');
-        tick(openDelayInMs);
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowUp');
 
         // Assert
@@ -298,13 +287,11 @@ describe('Combobox', () => {
       it('arrow up after an item was selected opens the popover and highlights the selected item', fakeAsync(() => {
         // Arrange
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowUp');
-        tick(openDelayInMs);
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowUp');
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'Enter');
 
         // Act
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowUp');
-        tick(openDelayInMs);
 
         // Assert
         const kirbyItems = document.querySelectorAll('kirby-item');
@@ -319,7 +306,6 @@ describe('Combobox', () => {
 
         // Act
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'PageDown');
-        tick(openDelayInMs);
 
         // Assert
         expect(spectator.component.isOpen).toBeTruthy();
@@ -331,7 +317,6 @@ describe('Combobox', () => {
       it('skips 10 items and highlights the 10th plus item', fakeAsync(() => {
         // Arrange
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'arrowUp');
-        tick(openDelayInMs);
 
         // Act
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'PageDown');
@@ -345,7 +330,6 @@ describe('Combobox', () => {
       it('there are less than 10 items left, highlights the last item', fakeAsync(() => {
         // Arrange
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowUp');
-        tick(openDelayInMs);
 
         // Act
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'PageDown');
@@ -365,7 +349,6 @@ describe('Combobox', () => {
 
         // Act
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'PageUp');
-        tick(openDelayInMs);
 
         // Assert
         expect(spectator.component.isOpen).toBeTruthy();
@@ -377,7 +360,6 @@ describe('Combobox', () => {
       it('skips 10 items and highlights the 10th minus item', fakeAsync(() => {
         // Arrange
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowUp');
-        tick(openDelayInMs);
 
         // Act
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'PageUp');
@@ -392,7 +374,6 @@ describe('Combobox', () => {
       it('there are less than 10 items left, highlights the first item', fakeAsync(() => {
         // Arrange
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
-        tick(openDelayInMs);
 
         // Act
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'PageUp');
@@ -409,7 +390,6 @@ describe('Combobox', () => {
     describe('home key', () => {
       it('opens the popover and highlights the first item', fakeAsync(() => {
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'Home');
-        tick(openDelayInMs);
 
         expect(spectator.component.isOpen).toBeTruthy();
         const kirbyItems = document.querySelectorAll('kirby-item');
@@ -418,7 +398,6 @@ describe('Combobox', () => {
 
       it('when open, moves focus to the first item', fakeAsync(() => {
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
-        tick(openDelayInMs);
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
 
@@ -432,7 +411,6 @@ describe('Combobox', () => {
     describe('end key', () => {
       it('opens the popover and highlights the last item', fakeAsync(() => {
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'End');
-        tick(openDelayInMs);
 
         expect(spectator.component.isOpen).toBeTruthy();
         const kirbyItems = document.querySelectorAll('kirby-item');
@@ -441,7 +419,6 @@ describe('Combobox', () => {
 
       it('when open, moves focus to the last item', fakeAsync(() => {
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
-        tick(openDelayInMs);
 
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'End');
 
@@ -453,7 +430,6 @@ describe('Combobox', () => {
     describe('escape key', () => {
       it('closes the popover when open', fakeAsync(() => {
         inputElement.click();
-        tick(openDelayInMs);
         expect(spectator.component.isOpen).toBeTruthy();
 
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'Escape');
@@ -472,14 +448,12 @@ describe('Combobox', () => {
     describe('enter key', () => {
       it('opens the popover when closed', fakeAsync(() => {
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'Enter');
-        tick(openDelayInMs);
 
         expect(spectator.component.isOpen).toBeTruthy();
       }));
 
       it('selects the focused item and closes the popover', fakeAsync(() => {
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
-        tick(openDelayInMs);
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
         spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
 
@@ -496,7 +470,6 @@ describe('Combobox', () => {
       const changeSpy = jest.spyOn(spectator.component.change, 'emit');
 
       spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
-      tick(openDelayInMs);
       spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
       spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'Enter');
 
@@ -507,7 +480,6 @@ describe('Combobox', () => {
       const changeSpy = jest.spyOn(spectator.component.change, 'emit');
 
       inputElement.click();
-      tick(openDelayInMs);
       spectator.detectChanges();
 
       const kirbyItems = document.querySelectorAll('kirby-item');
@@ -564,7 +536,6 @@ describe('Combobox', () => {
       spectator.component.registerOnChange(onChangeSpy);
 
       spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
-      tick(openDelayInMs);
       spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'Enter');
 
       expect(onChangeSpy).toHaveBeenCalledWith(items20[0]);
@@ -575,7 +546,6 @@ describe('Combobox', () => {
       spectator.component.registerOnTouched(onTouchedSpy);
 
       inputElement.click();
-      tick(openDelayInMs);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (spectator.component as any).onPopoverWillHide();
 
@@ -612,14 +582,12 @@ describe('Combobox', () => {
 
     it('does not open when clicked', fakeAsync(() => {
       inputElement.click();
-      tick(openDelayInMs);
 
       expect(spectator.component.isOpen).toBeFalsy();
     }));
 
     it('does not open when arrow down key is pressed', fakeAsync(() => {
       spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
-      tick(openDelayInMs);
 
       expect(spectator.component.isOpen).toBeFalsy();
     }));
@@ -635,7 +603,6 @@ describe('Combobox', () => {
   describe('filtering edge cases', () => {
     it('shows no-results message when filter matches nothing', fakeAsync(() => {
       inputElement.click();
-      tick(openDelayInMs);
       spectator.typeInElement('zzz_no_match', inputElement);
       spectator.detectChanges();
 
@@ -645,15 +612,13 @@ describe('Combobox', () => {
 
     it('restores full list when filter is cleared', fakeAsync(() => {
       inputElement.click();
-      tick(openDelayInMs);
-      spectator.typeInElement('Item 1', inputElement);
+      spectator.typeInElement('Item 5', inputElement);
       spectator.detectChanges();
 
       spectator.typeInElement('', inputElement);
       spectator.detectChanges();
-
       const kirbyItems = document.querySelectorAll('kirby-item');
-      expect(kirbyItems.length).toBe(items20.length);
+      expect(kirbyItems.length).toBeGreaterThan(1);
     }));
 
     it('uses a custom searchFunction when provided', fakeAsync(() => {
@@ -661,7 +626,6 @@ describe('Combobox', () => {
       spectator.component.searchFunction = customSearch;
 
       inputElement.click();
-      tick(openDelayInMs);
       spectator.typeInElement('any', inputElement);
       spectator.detectChanges();
 
@@ -678,7 +642,6 @@ describe('Combobox', () => {
 
     it('aria-expanded is true when open', fakeAsync(() => {
       inputElement.click();
-      tick(openDelayInMs);
       spectator.detectChanges();
 
       expect(inputElement.getAttribute('aria-expanded')).toBe('true');
@@ -699,7 +662,6 @@ describe('Combobox', () => {
 
     it('aria-activedescendant reflects focused item when open', fakeAsync(() => {
       spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
-      tick(openDelayInMs);
       spectator.detectChanges();
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -712,7 +674,6 @@ describe('Combobox', () => {
     it('noSearchResultsText is displayed when no results are found', fakeAsync(() => {
       spectator.component.noSearchResultsText = 'Nothing here!';
       inputElement.click();
-      tick(openDelayInMs);
       spectator.typeInElement('zzz', inputElement);
       spectator.detectChanges();
 
@@ -758,10 +719,8 @@ describe('Combobox', () => {
 
       // Act
       spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'ArrowDown');
-      tick(openDelayInMs);
       spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'Enter');
       spectator.typeInElement('', inputElement);
-      tick(openDelayInMs);
       spectator.dispatchKeyboardEvent(inputElement, 'keydown', 'Enter');
 
       // Assert
@@ -796,7 +755,6 @@ describe('Combobox — reactive forms (FormControl)', () => {
     { text: 'Item 19', value: 19 },
     { text: 'Item 20', value: 20 },
   ];
-  const openDelayInMs = ComboboxComponent.OPEN_DELAY_IN_MS;
 
   const createHost = createHostFactory({
     component: ComboboxComponent,
@@ -846,7 +804,6 @@ describe('Combobox — reactive forms (FormControl)', () => {
 
   it('selecting an item via keyboard updates the FormControl value', fakeAsync(() => {
     rfSpectator.dispatchKeyboardEvent(rfInput, 'keydown', 'ArrowDown');
-    tick(openDelayInMs);
     rfSpectator.dispatchKeyboardEvent(rfInput, 'keydown', 'Enter');
 
     expect(control.value).toEqual(items20[0]);
@@ -854,7 +811,6 @@ describe('Combobox — reactive forms (FormControl)', () => {
 
   it('selecting an item via click updates the FormControl value', fakeAsync(() => {
     rfInput.click();
-    tick(openDelayInMs);
     rfSpectator.detectChanges();
 
     (document.querySelectorAll('kirby-item').item(0) as HTMLElement).click();
@@ -880,7 +836,6 @@ describe('Combobox — reactive forms (FormControl)', () => {
 
   it('closing the popover marks the FormControl as touched', fakeAsync(() => {
     rfInput.click();
-    tick(openDelayInMs);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (rfSpectator.component as any).onPopoverWillHide();
 
@@ -907,14 +862,12 @@ describe('Combobox — reactive forms (FormControl)', () => {
     rfSpectator.detectChanges();
 
     rfInput.click();
-    tick(openDelayInMs);
 
     expect(rfSpectator.component.isOpen).toBeFalsy();
   }));
 
   it('FormControl status is VALID after a value is selected (no validators)', fakeAsync(() => {
     rfSpectator.dispatchKeyboardEvent(rfInput, 'keydown', 'ArrowDown');
-    tick(openDelayInMs);
     rfSpectator.dispatchKeyboardEvent(rfInput, 'keydown', 'Enter');
 
     expect(control.valid).toBe(true);
@@ -966,7 +919,6 @@ describe('Combobox — reactive forms (FormControl + Validators.required)', () =
 
   it('FormControl becomes VALID after an item is selected', fakeAsync(() => {
     rfSpectator.dispatchKeyboardEvent(rfInput, 'keydown', 'ArrowDown');
-    tick(openDelayInMs);
     rfSpectator.dispatchKeyboardEvent(rfInput, 'keydown', 'Enter');
 
     expect(control.valid).toBe(true);
@@ -1000,7 +952,6 @@ describe('Combobox — reactive forms (FormGroup)', () => {
     { text: 'Item 19', value: 19 },
     { text: 'Item 20', value: 20 },
   ];
-  const openDelayInMs = ComboboxComponent.OPEN_DELAY_IN_MS;
 
   const createHost = createHostFactory({
     component: ComboboxComponent,
@@ -1052,7 +1003,6 @@ describe('Combobox — reactive forms (FormGroup)', () => {
 
   it('selecting an item makes the FormGroup VALID and sets group.value', fakeAsync(() => {
     groupSpectator.dispatchKeyboardEvent(groupInput, 'keydown', 'ArrowDown');
-    tick(openDelayInMs);
     groupSpectator.dispatchKeyboardEvent(groupInput, 'keydown', 'Enter');
 
     expect(group.valid).toBe(true);
@@ -1102,7 +1052,6 @@ describe('Combobox — template-driven forms (ngModel)', () => {
     { text: 'Item 19', value: 19 },
     { text: 'Item 20', value: 20 },
   ];
-  const openDelayInMs = ComboboxComponent.OPEN_DELAY_IN_MS;
 
   const createHost = createHostFactory({
     component: ComboboxComponent,
@@ -1150,7 +1099,6 @@ describe('Combobox — template-driven forms (ngModel)', () => {
 
   it('selecting an item updates the ngModel host property', fakeAsync(() => {
     ngSpectator.dispatchKeyboardEvent(ngInput, 'keydown', 'ArrowDown');
-    tick(openDelayInMs);
     ngSpectator.dispatchKeyboardEvent(ngInput, 'keydown', 'Enter');
     ngSpectator.detectChanges();
 
@@ -1171,7 +1119,6 @@ describe('Combobox — template-driven forms (ngModel)', () => {
 
   it('closing the popover marks ngModel as touched', fakeAsync(() => {
     ngInput.click();
-    tick(openDelayInMs);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (ngSpectator.component as any).onPopoverWillHide();
     ngSpectator.detectChanges();

--- a/libs/extensions/angular/combobox/src/combobox.component.spec.ts
+++ b/libs/extensions/angular/combobox/src/combobox.component.spec.ts
@@ -277,7 +277,7 @@ describe('Combobox', () => {
 
         // Assert
         const kirbyItems = document.querySelectorAll('kirby-item');
-        const lastItemIndex = items20.length - 1;
+        const lastItemIndex = kirbyItems.length - 1;
         expect(kirbyItems.item(lastItemIndex)).toHaveClass('focused');
       }));
 
@@ -291,7 +291,7 @@ describe('Combobox', () => {
 
         // Assert
         const kirbyItems = document.querySelectorAll('kirby-item');
-        const secondLastItemIndex = items20.length - 2;
+        const secondLastItemIndex = kirbyItems.length - 2;
         expect(kirbyItems.item(secondLastItemIndex)).toHaveClass('focused');
       }));
 
@@ -308,7 +308,7 @@ describe('Combobox', () => {
 
         // Assert
         const kirbyItems = document.querySelectorAll('kirby-item');
-        const selectedItemIndex = items20.length - 2;
+        const selectedItemIndex = kirbyItems.length - 2;
         expect(kirbyItems.item(selectedItemIndex)).toHaveClass('focused');
       }));
     });

--- a/libs/extensions/angular/combobox/src/combobox.component.ts
+++ b/libs/extensions/angular/combobox/src/combobox.component.ts
@@ -245,6 +245,7 @@ export class ComboboxComponent
     // only set the focused item of the search result, if the input has value
     if (this.textInput?.nativeElement?.value) {
       this.focusedItem = this._searchItems[0];
+      this._virtualScrollViewport?.scrollToIndex(0);
     }
   }
 
@@ -299,6 +300,7 @@ export class ComboboxComponent
     if (this._focusedItem === item) {
       return;
     }
+
     this._focusedItem = item;
   }
 
@@ -450,7 +452,7 @@ export class ComboboxComponent
   }
 
   @ViewChild(CdkVirtualScrollViewport)
-  private virtualScrollViewport?: CdkVirtualScrollViewport;
+  public _virtualScrollViewport?: CdkVirtualScrollViewport;
 
   private forwardAriaLabelToCombobox() {
     forwardAttributes(
@@ -928,7 +930,7 @@ export class ComboboxComponent
   }
 
   private scrollFocusedItemIntoViewWhileNavigating(): void {
-    if (!this.focusedItem || !this.virtualScrollViewport) {
+    if (!this.focusedItem || !this._virtualScrollViewport) {
       return;
     }
 
@@ -937,16 +939,19 @@ export class ComboboxComponent
 
     const itemTop = focusedIndex * this.itemHeight;
     const itemBottom = itemTop + this.itemHeight;
-    const scrollOffset = this.virtualScrollViewport.measureScrollOffset();
-    const viewportSize = this.virtualScrollViewport.getViewportSize();
+    const scrollOffset = this._virtualScrollViewport.measureScrollOffset();
+    const viewportSize = this._virtualScrollViewport.getViewportSize();
 
     if (itemTop < scrollOffset) {
       // Item is above the visible area — scroll up so item appears at the top.
-      this.virtualScrollViewport.scrollToOffset(itemTop);
+      // this.virtualScrollViewport.scrollToIndex(focusedIndex);
+      this._virtualScrollViewport.scrollToOffset(itemTop);
     } else if (itemBottom > scrollOffset + viewportSize) {
       // Item is below the visible area — scroll down so item appears at the bottom.
-      this.virtualScrollViewport.scrollToOffset(itemBottom - viewportSize);
+      this._virtualScrollViewport.scrollToOffset(itemBottom - viewportSize);
     }
+
+    this._virtualScrollViewport.checkViewportSize();
   }
 
   private getKirbyItems(): QueryList<ElementRef<HTMLElement>> | undefined {
@@ -958,16 +963,9 @@ export class ComboboxComponent
   private scrollToIndexIntoViewWhenOpeningPopup(): void {
     const focusedIndex = this.searchItems.indexOf(this.focusedItem);
 
-    if (focusedIndex <= 0) {
-      this.virtualScrollViewport?.setRenderedRange({ start: 0, end: 20 });
-      this.virtualScrollViewport?.checkViewportSize();
-      return;
-    }
+    this._virtualScrollViewport?.setRenderedRange({ start: 0, end: 20 });
+    this._virtualScrollViewport?.checkViewportSize();
 
-    this.virtualScrollViewport?.setRenderedRange({
-      start: focusedIndex - 10,
-      end: focusedIndex + 10,
-    });
-    this.virtualScrollViewport?.scrollToIndex(focusedIndex);
+    this._virtualScrollViewport?.scrollToIndex(focusedIndex);
   }
 }

--- a/libs/extensions/angular/combobox/src/combobox.component.ts
+++ b/libs/extensions/angular/combobox/src/combobox.component.ts
@@ -568,7 +568,10 @@ export class ComboboxComponent
       this.state = OpenState.open;
       this.popover?.show();
       this.cdr.markForCheck();
-      setTimeout(() => this.scrollToIndexIntoViewWhenOpeningPopup());
+      // PopoverComponent.show() appends the element to document.body synchronously but
+      // finishes positioning in a requestAnimationFrame. One rAF is enough to let the
+      // browser compute layout so the CDK viewport has a real size before we scroll.
+      requestAnimationFrame(() => this.scrollToIndexIntoViewWhenOpeningPopup());
     }
   }
 

--- a/libs/extensions/angular/combobox/src/combobox.component.ts
+++ b/libs/extensions/angular/combobox/src/combobox.component.ts
@@ -547,6 +547,7 @@ export class ComboboxComponent
   }
 
   public ngOnDestroy(): void {
+    clearTimeout(this._scrollToOpenTimeout);
     this.unlistenAllSlottedItems();
     this.unobserveResize();
   }
@@ -557,8 +558,7 @@ export class ComboboxComponent
     }
     if (!this.isOpen) {
       this.state = OpenState.opening;
-      setTimeout(() => this.showPopOver(), ComboboxComponent.OPEN_DELAY_IN_MS);
-
+      this.showPopOver();
       this.focusedItem = this.selectedItem;
     }
   }
@@ -567,8 +567,11 @@ export class ComboboxComponent
     if (this.state === OpenState.opening) {
       this.state = OpenState.open;
       this.popover?.show();
-      this.scrollToIndexIntoViewWhenOpeningPopup();
       this.cdr.markForCheck();
+      clearTimeout(this._scrollToOpenTimeout);
+      this._scrollToOpenTimeout = setTimeout(() => {
+        this.scrollToIndexIntoViewWhenOpeningPopup();
+      });
     }
   }
 
@@ -690,6 +693,7 @@ export class ComboboxComponent
   }
 
   private _announceTimeout: ReturnType<typeof setTimeout> | undefined;
+  private _scrollToOpenTimeout: ReturnType<typeof setTimeout> | undefined;
   private announce(message: string): void {
     clearTimeout(this._announceTimeout);
     this._liveRegionText = '';
@@ -971,6 +975,10 @@ export class ComboboxComponent
       return;
     }
 
+    this.virtualScrollViewport?.setRenderedRange({
+      start: focusedIndex - 10,
+      end: focusedIndex + 10,
+    });
     this.virtualScrollViewport?.scrollToIndex(focusedIndex);
   }
 }

--- a/libs/extensions/angular/combobox/src/combobox.component.ts
+++ b/libs/extensions/angular/combobox/src/combobox.component.ts
@@ -75,7 +75,6 @@ import { OpenState } from './combobox.types';
 export class ComboboxComponent
   implements AfterViewInit, OnDestroy, ControlValueAccessor, FormFieldControl
 {
-  private static readonly OPEN_DELAY_IN_MS = 100;
   private static readonly HEIGHT_OF_STANDARD_ITEM = 44;
   private state = OpenState.closed;
   private _popout: HorizontalDirection | `${HorizontalDirection}` = HorizontalDirection.right;
@@ -549,7 +548,6 @@ export class ComboboxComponent
   }
 
   public ngOnDestroy(): void {
-    clearTimeout(this._scrollToOpenTimeout);
     this.unlistenAllSlottedItems();
     this.unobserveResize();
   }
@@ -570,10 +568,7 @@ export class ComboboxComponent
       this.state = OpenState.open;
       this.popover?.show();
       this.cdr.markForCheck();
-      clearTimeout(this._scrollToOpenTimeout);
-      this._scrollToOpenTimeout = setTimeout(() => {
-        this.scrollToIndexIntoViewWhenOpeningPopup();
-      });
+      setTimeout(() => this.scrollToIndexIntoViewWhenOpeningPopup());
     }
   }
 
@@ -695,7 +690,6 @@ export class ComboboxComponent
   }
 
   private _announceTimeout: ReturnType<typeof setTimeout> | undefined;
-  private _scrollToOpenTimeout: ReturnType<typeof setTimeout> | undefined;
   private announce(message: string): void {
     clearTimeout(this._announceTimeout);
     this._liveRegionText = '';
@@ -931,33 +925,24 @@ export class ComboboxComponent
   }
 
   private scrollFocusedItemIntoViewWhileNavigating(): void {
-    const kirbyItems = this.getKirbyItems();
-    if (!kirbyItems || kirbyItems.length === 0) return;
-
-    if (!this.focusedItem) {
+    if (!this.focusedItem || !this.virtualScrollViewport) {
       return;
     }
 
-    const id = this.getItemId(this.focusedItem);
-    if (!id) return;
+    const focusedIndex = this.searchItems.indexOf(this.focusedItem);
+    if (focusedIndex === -1) return;
 
-    const match = kirbyItems.toArray().find((el) => {
-      if (el.nativeElement.id === undefined) {
-        console.error(
-          'Each item must have an id attribute for scroll to work. Ensure that the ´[attr.id]´ is set correctly, and that each item has a unique id value.'
-        );
-      }
-      return el.nativeElement.id === id;
-    });
+    const itemTop = focusedIndex * this.itemHeight;
+    const itemBottom = itemTop + this.itemHeight;
+    const scrollOffset = this.virtualScrollViewport.measureScrollOffset();
+    const viewportSize = this.virtualScrollViewport.getViewportSize();
 
-    if (!match) {
-      this.scrollToIndexIntoViewWhenOpeningPopup();
-      return;
-    }
-
-    const scrollIntoView = match.nativeElement.scrollIntoView;
-    if (typeof scrollIntoView === 'function') {
-      scrollIntoView.call(match.nativeElement, { block: 'nearest' });
+    if (itemTop < scrollOffset) {
+      // Item is above the visible area — scroll up so item appears at the top.
+      this.virtualScrollViewport.scrollToOffset(itemTop);
+    } else if (itemBottom > scrollOffset + viewportSize) {
+      // Item is below the visible area — scroll down so item appears at the bottom.
+      this.virtualScrollViewport.scrollToOffset(itemBottom - viewportSize);
     }
   }
 

--- a/libs/extensions/angular/combobox/src/combobox.component.ts
+++ b/libs/extensions/angular/combobox/src/combobox.component.ts
@@ -944,7 +944,6 @@ export class ComboboxComponent
 
     if (itemTop < scrollOffset) {
       // Item is above the visible area — scroll up so item appears at the top.
-      // this.virtualScrollViewport.scrollToIndex(focusedIndex);
       this._virtualScrollViewport.scrollToOffset(itemTop);
     } else if (itemBottom > scrollOffset + viewportSize) {
       // Item is below the visible area — scroll down so item appears at the bottom.


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4504 

## What is the new behavior?
using the `setRenderedRange` together with the min-maxBufferPx causes the buffer size to change mid scroll.
no longer overwrites the buffer size
use the CDK to scroll to the items when navigating with the keys

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

