### PR TITLE
make sure to render items again when setting search items

### DIFF
--- a/libs/extensions/angular/combobox/src/combobox.component.spec.ts
+++ b/libs/extensions/angular/combobox/src/combobox.component.spec.ts
@@ -13,6 +13,7 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
+import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
 import { ComboboxComponent } from './combobox.component';
 
 // Shared constants used by the form integration top-level describes
@@ -62,6 +63,12 @@ describe('Combobox', () => {
   beforeAll(() => {
     Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
       value: jest.fn(),
+      writable: true,
+      configurable: true,
+    });
+
+    Object.defineProperty(CdkVirtualScrollViewport.prototype, 'measureViewportSize', {
+      value: () => 8 * 44,
       writable: true,
       configurable: true,
     });
@@ -181,6 +188,51 @@ describe('Combobox', () => {
       // Assert
       const kirbyItems = document.querySelectorAll('kirby-item');
       expect(kirbyItems.item(0)).toHaveText('Item 1');
+    }));
+
+    it('shows no-results message when filter matches nothing', fakeAsync(() => {
+      // Arrange
+
+      // Act
+      inputElement.click();
+      spectator.typeInElement('zzz_no_match', inputElement);
+      spectator.detectChanges();
+
+      // Assert
+      const noResultsItem = document.querySelector('.no-results');
+      expect(noResultsItem).not.toBeNull();
+    }));
+
+    it('restores full list when filter is cleared', fakeAsync(() => {
+      // Arrange
+
+      // Act
+      inputElement.click();
+      spectator.typeInElement('Item 5', inputElement);
+      spectator.detectChanges();
+
+      spectator.typeInElement('', inputElement);
+      spectator.detectChanges();
+
+      // Assert
+      const kirbyItems = document.querySelectorAll('kirby-item');
+      expect(kirbyItems.length).toBeGreaterThanOrEqual(8);
+    }));
+
+    it('uses a custom searchFunction when provided', fakeAsync(() => {
+      // Arrange
+      const customSearch = jest.fn().mockReturnValue([items20[0]]);
+      spectator.component.searchFunction = customSearch;
+
+      // Act
+      inputElement.click();
+      spectator.typeInElement('any', inputElement);
+      spectator.detectChanges();
+
+      // Assert
+      expect(customSearch).toHaveBeenCalledWith('any', items20);
+      const kirbyItems = document.querySelectorAll('kirby-item');
+      expect(kirbyItems.length).toBe(1);
     }));
   });
 
@@ -598,41 +650,6 @@ describe('Combobox', () => {
 
       expect(event.defaultPrevented).toBe(true);
     });
-  });
-
-  describe('filtering edge cases', () => {
-    it('shows no-results message when filter matches nothing', fakeAsync(() => {
-      inputElement.click();
-      spectator.typeInElement('zzz_no_match', inputElement);
-      spectator.detectChanges();
-
-      const noResultsItem = document.querySelector('.no-results');
-      expect(noResultsItem).not.toBeNull();
-    }));
-
-    it('restores full list when filter is cleared', fakeAsync(() => {
-      inputElement.click();
-      spectator.typeInElement('Item 5', inputElement);
-      spectator.detectChanges();
-
-      spectator.typeInElement('', inputElement);
-      spectator.detectChanges();
-      const kirbyItems = document.querySelectorAll('kirby-item');
-      expect(kirbyItems.length).toBeGreaterThan(1);
-    }));
-
-    it('uses a custom searchFunction when provided', fakeAsync(() => {
-      const customSearch = jest.fn().mockReturnValue([items20[0]]);
-      spectator.component.searchFunction = customSearch;
-
-      inputElement.click();
-      spectator.typeInElement('any', inputElement);
-      spectator.detectChanges();
-
-      expect(customSearch).toHaveBeenCalledWith('any', items20);
-      const kirbyItems = document.querySelectorAll('kirby-item');
-      expect(kirbyItems.length).toBe(1);
-    }));
   });
 
   describe('aria attributes', () => {

--- a/libs/extensions/angular/combobox/src/combobox.component.ts
+++ b/libs/extensions/angular/combobox/src/combobox.component.ts
@@ -247,6 +247,8 @@ export class ComboboxComponent
       this.focusedItem = this._searchItems[0];
       this._virtualScrollViewport?.scrollToIndex(0);
     }
+
+    this.renderFirstItems();
   }
 
   private _items: unknown[] = [];
@@ -573,7 +575,7 @@ export class ComboboxComponent
       // PopoverComponent.show() appends the element to document.body synchronously but
       // finishes positioning in a requestAnimationFrame. One rAF is enough to let the
       // browser compute layout so the CDK viewport has a real size before we scroll.
-      requestAnimationFrame(() => this.scrollToIndexIntoViewWhenOpeningPopup());
+      this.scrollToIndexIntoViewWhenOpeningPopup();
     }
   }
 
@@ -962,9 +964,15 @@ export class ComboboxComponent
   private scrollToIndexIntoViewWhenOpeningPopup(): void {
     const focusedIndex = this.searchItems.indexOf(this.focusedItem);
 
-    this._virtualScrollViewport?.setRenderedRange({ start: 0, end: 20 });
-    this._virtualScrollViewport?.checkViewportSize();
+    this.renderFirstItems();
 
     this._virtualScrollViewport?.scrollToIndex(focusedIndex);
+  }
+
+  private renderFirstItems(): void {
+    requestAnimationFrame(() => {
+      this._virtualScrollViewport?.setRenderedRange({ start: 0, end: 20 });
+      this._virtualScrollViewport?.checkViewportSize();
+    });
   }
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4512 

## What is the new behavior?
Updating the search items, makes sure to render the first items in the viewport
<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

