### PR TITLE
Page & Section Header: fix alignment in landscape with safe area left

### DIFF
--- a/libs/designsystem/page/src/page.component.scss
+++ b/libs/designsystem/page/src/page.component.scss
@@ -23,9 +23,9 @@ $toolbar-max-font-size: 18px * 1.2;
 
 ion-header,
 ion-toolbar {
-  --background: #{utils.get-color('background-color')};
+  box-sizing: border-box;
 
-  margin: 0 auto;
+  --background: #{utils.get-color('background-color')};
 }
 
 ion-title h1 {
@@ -270,7 +270,10 @@ ion-back-button {
  */
 ion-content {
   --padding-top: #{$ion-content-padding-top};
-  --padding-start: var(--page-content-padding-start, #{utils.size('s')});
+  --padding-start: var(
+    --page-content-padding-start,
+    calc(#{utils.size('s')} + var(--ion-safe-area-left))
+  );
   --padding-end: var(--page-content-padding-end, #{utils.size('s')});
   --background: #{utils.get-color('background-color')};
   --color: #{utils.get-color('black')};

--- a/libs/designsystem/section-header/src/section-header.component.scss
+++ b/libs/designsystem/section-header/src/section-header.component.scss
@@ -14,6 +14,9 @@
     min-height: 0;
     z-index: initial;
     align-items: flex-end;
+    padding-left: utils.size(
+      's'
+    ); // Padding left is fixed here, so safe-area is not added. Handled in page instead.
 
     @include section-header.typography;
   }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4540

## What is the new behavior?
Page Header / toolbar area and section header should now be correctly aligned during landscape browsing on a device with safe area set (primarily iOS devices).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

