### PR TITLE
Item: support text resize layout for Android WebView

### DIFF
--- a/libs/designsystem/shared/src/text-resize-observer/text-resize-observer.service.spec.ts
+++ b/libs/designsystem/shared/src/text-resize-observer/text-resize-observer.service.spec.ts
@@ -13,7 +13,7 @@ describe('TextResizeObserverService', () => {
   let disconnectSpy: jasmine.Spy;
 
   const hasTextResizeClass = () => document.documentElement.classList.contains('kirby-trt');
-  const getTextResizeObserverElement = (): HTMLElement | null =>
+  const getObserverElement = (): HTMLElement | null =>
     document.querySelector('body > [style*="top: -9999px"]');
 
   beforeEach(() => {
@@ -49,20 +49,19 @@ describe('TextResizeObserverService', () => {
     it('should create a hidden observed element and append it to the body', () => {
       spectator.service.initialize();
 
-      const textResizeObserverElement = getTextResizeObserverElement();
+      const el = getObserverElement();
 
-      expect(textResizeObserverElement).toBeTruthy();
-      expect(textResizeObserverElement.style.position).toBe('absolute');
-      expect(textResizeObserverElement.style.width).toBe('1rem');
-      expect(textResizeObserverElement.style.height).toBe('1rem');
-      expect(textResizeObserverElement.style.visibility).toBe('hidden');
-      expect(textResizeObserverElement.style.pointerEvents).toBe('none');
+      expect(el).toBeTruthy();
+      expect(el.style.position).toBe('absolute');
+      expect(el.style.height).toBe('1rem');
+      expect(el.style.visibility).toBe('hidden');
+      expect(el.style.pointerEvents).toBe('none');
     });
 
     it('should create a ResizeObserver and observe the element', () => {
       spectator.service.initialize();
 
-      expect(observeSpy).toHaveBeenCalledWith(getTextResizeObserverElement());
+      expect(observeSpy).toHaveBeenCalledWith(getObserverElement());
     });
 
     it('should not add kirby-trt class at default text scale', () => {
@@ -83,13 +82,11 @@ describe('TextResizeObserverService', () => {
     it('should remove the observed element from the DOM', () => {
       spectator.service.initialize();
 
-      const textResizeObserverElement = getTextResizeObserverElement();
-      expect(textResizeObserverElement).toBeTruthy();
-      expect(textResizeObserverElement.parentNode).toBe(document.body);
+      expect(getObserverElement()).toBeTruthy();
 
       spectator.service.ngOnDestroy();
 
-      expect(getTextResizeObserverElement()).toBeNull();
+      expect(getObserverElement()).toBeNull();
     });
 
     it('should handle being called before initialize gracefully', () => {
@@ -98,21 +95,10 @@ describe('TextResizeObserverService', () => {
   });
 
   describe('text scale class toggling', () => {
-    it('should not add kirby-trt class at default text scale', () => {
-      spectator.service.initialize();
-
-      expect(hasTextResizeClass()).toBeFalse();
-    });
-
     it('should add kirby-trt class when text scale exceeds threshold', () => {
       spectator.service.initialize();
 
-      const textResizeObserverElement = getTextResizeObserverElement();
-      const valueExceedingThreshold = 24;
-      spyOnProperty(textResizeObserverElement, 'offsetWidth', 'get').and.returnValue(
-        valueExceedingThreshold
-      );
-
+      spyOnProperty(getObserverElement(), 'offsetWidth', 'get').and.returnValue(24);
       resizeObserverCallback([], {} as ResizeObserver);
 
       expect(hasTextResizeClass()).toBeTrue();
@@ -121,12 +107,7 @@ describe('TextResizeObserverService', () => {
     it('should not add kirby-trt class when text scale is at threshold', () => {
       spectator.service.initialize();
 
-      const textResizeObserverElement = getTextResizeObserverElement();
-      const valueExactlyAtThreshold = 23.2;
-      spyOnProperty(textResizeObserverElement, 'offsetWidth', 'get').and.returnValue(
-        valueExactlyAtThreshold
-      );
-
+      spyOnProperty(getObserverElement(), 'offsetWidth', 'get').and.returnValue(23.2);
       resizeObserverCallback([], {} as ResizeObserver);
 
       expect(hasTextResizeClass()).toBeFalse();
@@ -135,12 +116,7 @@ describe('TextResizeObserverService', () => {
     it('should not add kirby-trt class when text scale is below threshold', () => {
       spectator.service.initialize();
 
-      const textResizeObserverElement = getTextResizeObserverElement();
-      const valueBelowThreshold = 19.2;
-      spyOnProperty(textResizeObserverElement, 'offsetWidth', 'get').and.returnValue(
-        valueBelowThreshold
-      );
-
+      spyOnProperty(getObserverElement(), 'offsetWidth', 'get').and.returnValue(19.2);
       resizeObserverCallback([], {} as ResizeObserver);
 
       expect(hasTextResizeClass()).toBeFalse();
@@ -149,14 +125,11 @@ describe('TextResizeObserverService', () => {
     it('should remove kirby-trt class when text scale drops below threshold', () => {
       spectator.service.initialize();
 
-      const textResizeObserverElement = getTextResizeObserverElement();
-
-      spyOnProperty(textResizeObserverElement, 'offsetWidth', 'get').and.returnValues(24, 16);
+      spyOnProperty(getObserverElement(), 'offsetWidth', 'get').and.returnValues(24, 16);
       resizeObserverCallback([], {} as ResizeObserver);
       expect(hasTextResizeClass()).toBeTrue();
 
       resizeObserverCallback([], {} as ResizeObserver);
-
       expect(hasTextResizeClass()).toBeFalse();
     });
   });

--- a/libs/designsystem/shared/src/text-resize-observer/text-resize-observer.service.ts
+++ b/libs/designsystem/shared/src/text-resize-observer/text-resize-observer.service.ts
@@ -4,15 +4,30 @@ import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
 const TEXT_RESIZE_THRESHOLD = parseFloat(DesignTokenHelper.textResizeThreshold());
 const TEXT_RESIZE_CLASS = 'kirby-trt';
 const BASE_FONT_SIZE_PX = parseInt(DesignTokenHelper.baseFontSizePx());
+
+/**
+ * Element width combines both signals: rem scaling (desktop/iOS) and env(preferred-text-scale)
+ * (Android). On platforms where env() is unsupported, the fallback `1` makes it a no-op multiplier.
+ */
 const OBSERVER_ELEMENT_STYLES =
-  'position:absolute;width:1rem;height:1rem;top:-9999px;visibility:hidden;pointer-events:none';
+  'position:absolute;width:calc(1rem * env(preferred-text-scale, 1));height:1rem;top:-9999px;visibility:hidden;pointer-events:none';
 
 /**
  * Detects when text is resized above a certain threshold in browser/OS settings and toggles a
  * `kirby-trt` class on the root html element.
  *
- * Uses a `ResizeObserver` on a hidden rem-sized element. When the user changes text size, the element's pixel size changes,
- * triggering the observer.
+ * Uses a `ResizeObserver` on a hidden element sized with `calc(1rem * env(preferred-text-scale, 1))`.
+ * This combines two detections into one element:
+ *
+ * - **rem scaling** — on desktop browsers and iOS, changing text size modifies the root font-size,
+ *   which changes `1rem` and triggers the observer.
+ *
+ * - **`env(preferred-text-scale)`** — on platforms that support this CSS environment variable
+ *   (e.g. Android Chrome/WebView), the multiplier reflects the OS/browser text scale factor.
+ *   When the user changes font size in system settings, the env value updates and the element resizes.
+ *
+ * On platforms where `env(preferred-text-scale)` is not supported, the value falls back to `1`,
+ * making the width equivalent to `1rem`.
  *
  * @example
  * ```scss
@@ -23,8 +38,6 @@ const OBSERVER_ELEMENT_STYLES =
  * }
  * ```
  *
- * If `env(preferred-text-scale)` from the CSS Environment Variables spec matures,
- * it might replace some of this functionality.
  * @see https://drafts.csswg.org/css-env-1/#preferred-text-scale
  */
 @Injectable({ providedIn: 'root' })
@@ -41,10 +54,10 @@ export class TextResizeObserverService implements OnDestroy {
     this.textResizeObserverElement.style.cssText = OBSERVER_ELEMENT_STYLES;
     document.body.appendChild(this.textResizeObserverElement);
 
-    this.resizeObserver = new ResizeObserver(this.updateTextScaleClass);
+    this.resizeObserver = new ResizeObserver(this.onObservedResize);
     this.resizeObserver.observe(this.textResizeObserverElement);
 
-    this.updateTextScaleClass();
+    this.onObservedResize();
   }
 
   ngOnDestroy(): void {
@@ -52,9 +65,9 @@ export class TextResizeObserverService implements OnDestroy {
     this.textResizeObserverElement?.remove();
   }
 
-  private updateTextScaleClass = (): void => {
-    const remInPx = this.textResizeObserverElement?.offsetWidth ?? BASE_FONT_SIZE_PX;
-    const scale = remInPx / BASE_FONT_SIZE_PX;
+  private onObservedResize = (): void => {
+    const widthInPx = this.textResizeObserverElement?.offsetWidth ?? BASE_FONT_SIZE_PX;
+    const scale = widthInPx / BASE_FONT_SIZE_PX;
     document.documentElement.classList.toggle(TEXT_RESIZE_CLASS, scale > TEXT_RESIZE_THRESHOLD);
   };
 }


### PR DESCRIPTION
## Which issue does this PR close?

Closes no issue

## What is the new behavior?

We add support for `env(preferred-text-size)`, so that Webview on Android (that does not support rem units like[ you might expect](https://issues.chromium.org/issues/375209519)) correctly communicates actual font size to our TextResizeObserver, and applies the kirby-trt class correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

