### PR TITLE
Header: fixed infinite shrinking of headers with titleMaxLines

### DIFF
--- a/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
@@ -131,15 +131,12 @@
   <div class="header-example-container">
     <h2>Scaling of title</h2>
     <p>
-      Titles are default rendered as
-      <code>h1</code>
-      .
+      It's possible to enable auto-scaling of the header title. This will progressively reduce the
+      font size and line height to fit the text within the configured number of lines.
     </p>
     <p>
-      It's possible to enable auto-scaling of the header title. This will scale both font-size &
-      line-height between h1 -> h3 depending on amount of text and maximum number of lines
-      configured. If the text cannot fit within the configured number of lines it will be truncated
-      using an ellipsis (
+      If the text still cannot fit after scaling to the smallest size, it will be truncated using an
+      ellipsis (
       <code>&mldr;</code>
       ).
     </p>

--- a/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.html
@@ -131,7 +131,7 @@
   <div class="header-example-container">
     <h2>Scaling of title</h2>
     <p>
-      It's possible to enable auto-scaling of the header title. This will progressively reduce the
+      It is possible to enable auto-scaling of the header title. This will progressively reduce the
       font size and line height to fit the text within the configured number of lines.
     </p>
     <p>

--- a/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/header-showcase/header-showcase.component.ts
@@ -95,7 +95,7 @@ export class HeaderShowcaseComponent {
     {
       name: 'titleMaxLines',
       description:
-        'The allowed number of lines in the title. The text will be scaled from h1 -> h3 to fit and otherwise truncated.',
+        'The maximum number of lines allowed for the title. The font size will be progressively reduced to fit. If the text still overflows, it will be truncated with an ellipsis. Only the visual size changes — no heading levels are affected.',
       type: ['number'],
       defaultValue: '',
     },

--- a/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.html
@@ -227,7 +227,7 @@
   <div>
     <h2 #autoscale>Scaling of Page Title</h2>
     <p>
-      It's possible to enable auto-scaling of the page title. This will progressively reduce the
+      It is possible to enable auto-scaling of the page title. This will progressively reduce the
       font size and line height to fit the text within the configured number of lines. If the text
       still cannot fit, it will be truncated with an ellipsis. This can be configured by setting the
       <code>titleMaxLines="NUMBER OF MAXIMUM LINES"</code>

--- a/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/page-showcase/page-showcase.component.html
@@ -227,14 +227,9 @@
   <div>
     <h2 #autoscale>Scaling of Page Title</h2>
     <p>
-      Titles are default rendered as
-      <code>h1</code>
-      .
-    </p>
-    <p>
-      It's possible to enable auto-scaling of the page title. This will scale both font-size &
-      line-height between h1 -> h3 depending on amount of text and maximum number of lines
-      configured. This can be configured by setting the
+      It's possible to enable auto-scaling of the page title. This will progressively reduce the
+      font size and line height to fit the text within the configured number of lines. If the text
+      still cannot fit, it will be truncated with an ellipsis. This can be configured by setting the
       <code>titleMaxLines="NUMBER OF MAXIMUM LINES"</code>
       attribute of
       <code>kirby-page</code>

--- a/libs/designsystem/header/src/header.component.scss
+++ b/libs/designsystem/header/src/header.component.scss
@@ -73,6 +73,7 @@ $column-gap: utils.size('xxl') - $margin-inline - $actions-margin-inline;
 
   .title-container {
     align-items: center;
+    align-self: stretch;
     text-align: center;
   }
 

--- a/libs/designsystem/header/src/header.component.scss
+++ b/libs/designsystem/header/src/header.component.scss
@@ -132,6 +132,7 @@ $column-gap: utils.size('xxl') - $margin-inline - $actions-margin-inline;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  width: 100%;
   max-width: calc(100% - 2 * $margin-inline);
 }
 

--- a/libs/designsystem/header/src/header.component.scss
+++ b/libs/designsystem/header/src/header.component.scss
@@ -60,6 +60,7 @@ $column-gap: utils.size('xxl') - $margin-inline - $actions-margin-inline;
   align-items: center;
 
   .container {
+    align-self: stretch;
     align-items: center;
 
     & > span.title {
@@ -73,7 +74,6 @@ $column-gap: utils.size('xxl') - $margin-inline - $actions-margin-inline;
 
   .title-container {
     align-items: center;
-    align-self: stretch;
     text-align: center;
   }
 

--- a/libs/designsystem/header/src/header.component.stories.ts
+++ b/libs/designsystem/header/src/header.component.stories.ts
@@ -3,6 +3,7 @@ import { type Meta, moduleMetadata, type StoryObj } from '@storybook/angular';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { HeaderComponent } from '@kirbydesign/designsystem/header';
+import { FlagComponent } from '@kirbydesign/designsystem/flag';
 import { ModalNavigationService } from '@kirbydesign/designsystem/modal';
 import { PageComponent, PageContentComponent } from '@kirbydesign/designsystem/page';
 import { AppComponent } from '@kirbydesign/designsystem/kirby-app';
@@ -23,6 +24,7 @@ const meta: Meta<HeaderComponent> = {
         AppComponent,
         PageComponent,
         PageContentComponent,
+        FlagComponent,
       ],
     }),
   ],
@@ -77,18 +79,36 @@ export const TitleMaxLinesScaling: Story = {
       <kirby-app>
         <kirby-page title="titleMaxLines scaling">
           <kirby-page-content>
+
+            <!-- Title only -->
             <kirby-header title="min titel" [titleMaxLines]="1" subtitle1="titleMaxLines=1"></kirby-header>
             <kirby-header title="min titel" [titleMaxLines]="2" subtitle1="titleMaxLines=2"></kirby-header>
             <kirby-header title="min titel" [titleMaxLines]="3" subtitle1="titleMaxLines=3"></kirby-header>
             <kirby-header title="min titel" subtitle1="no max lines"></kirby-header>
 
+            <!-- Wide character regression -->
             <kirby-header title="Mobile banking" [titleMaxLines]="1" subtitle1="titleMaxLines=1, starts with M"></kirby-header>
             <kirby-header title="mobile banking" [titleMaxLines]="1" subtitle1="titleMaxLines=1, starts with m"></kirby-header>
 
+            <!-- Medium and long titles -->
             <kirby-header title="A medium length title that might need scaling on smaller screens" [titleMaxLines]="1" subtitle1="titleMaxLines=1, medium title"></kirby-header>
             <kirby-header title="A medium length title that might need scaling on smaller screens" [titleMaxLines]="2" subtitle1="titleMaxLines=2, medium title"></kirby-header>
-
             <kirby-header title="Fall prices consulting quarterly municipal appeal inverse expenses market value credit quality market exposure potential appeal funds debt downturn NASDAQ Fitch 401k appeal corporate bonds municipal Nikkei market index treasury lucrative holder fiat corporation funds default interest rollover 401k exchange traded funds dividends inverse credit investment capitalization" [titleMaxLines]="2" subtitle1="titleMaxLines=2, very long title"></kirby-header>
+
+            <!-- Key value: titleMaxLines scales the value -->
+            <kirby-header title="Opsparing" value="12.345,67" valueUnit="kr." [titleMaxLines]="1" subtitle1="key value, titleMaxLines=1"></kirby-header>
+            <kirby-header title="Opsparing" value="12.345,67" valueUnit="kr." subtitle1="key value, no max lines"></kirby-header>
+            <kirby-header title="Opsparing" value="1.234.567.890,12" valueUnit="kr." [titleMaxLines]="1" subtitle1="key value, long value, titleMaxLines=1"></kirby-header>
+
+            <!-- Centered -->
+            <kirby-header title="min titel" [titleMaxLines]="1" [centered]="true" subtitle1="centered, titleMaxLines=1"></kirby-header>
+            <kirby-header title="min titel" [centered]="true" subtitle1="centered, no max lines"></kirby-header>
+
+            <!-- With flag -->
+            <kirby-header title="min titel" [titleMaxLines]="1" subtitle1="with flag, titleMaxLines=1">
+              <kirby-flag themeColor="success">Aktiv</kirby-flag>
+            </kirby-header>
+
           </kirby-page-content>
         </kirby-page>
       </kirby-app>

--- a/libs/designsystem/header/src/header.component.stories.ts
+++ b/libs/designsystem/header/src/header.component.stories.ts
@@ -1,6 +1,11 @@
 import { type Meta, moduleMetadata, type StoryObj } from '@storybook/angular';
 
+import { RouterTestingModule } from '@angular/router/testing';
+
 import { HeaderComponent } from '@kirbydesign/designsystem/header';
+import { ModalNavigationService } from '@kirbydesign/designsystem/modal';
+import { PageComponent, PageContentComponent } from '@kirbydesign/designsystem/page';
+import { AppComponent } from '@kirbydesign/designsystem/kirby-app';
 
 import { responsiveModes } from 'tools/storybook-config/shared-config';
 import { HeaderExampleComponent } from '~/app/examples/header-example/header-example.component';
@@ -10,7 +15,15 @@ const meta: Meta<HeaderComponent> = {
   title: 'Components / Header',
   decorators: [
     moduleMetadata({
-      imports: [HeaderComponent, HeaderExampleComponent],
+      providers: [ModalNavigationService],
+      imports: [
+        RouterTestingModule,
+        HeaderComponent,
+        HeaderExampleComponent,
+        AppComponent,
+        PageComponent,
+        PageContentComponent,
+      ],
     }),
   ],
   parameters: {
@@ -41,5 +54,44 @@ export const Default: Story = {
 export const CookbookExamples: Story = {
   render: () => ({
     template: `<cookbook-header-example></cookbook-header-example>`,
+  }),
+};
+
+/**
+ * Acceptance tests for titleMaxLines scaling behavior.
+ * Each scenario verifies that the title font size is only scaled down
+ * when the text genuinely cannot fit within the configured max lines.
+ */
+export const TitleMaxLinesScaling: Story = {
+  parameters: {
+    chromatic: {
+      modes: {
+        mobile: {
+          viewport: 'small',
+        },
+      },
+    },
+  },
+  render: () => ({
+    template: `
+      <kirby-app>
+        <kirby-page title="titleMaxLines scaling">
+          <kirby-page-content>
+            <kirby-header title="min titel" [titleMaxLines]="1" subtitle1="titleMaxLines=1"></kirby-header>
+            <kirby-header title="min titel" [titleMaxLines]="2" subtitle1="titleMaxLines=2"></kirby-header>
+            <kirby-header title="min titel" [titleMaxLines]="3" subtitle1="titleMaxLines=3"></kirby-header>
+            <kirby-header title="min titel" subtitle1="no max lines"></kirby-header>
+
+            <kirby-header title="Mobile banking" [titleMaxLines]="1" subtitle1="titleMaxLines=1, starts with M"></kirby-header>
+            <kirby-header title="mobile banking" [titleMaxLines]="1" subtitle1="titleMaxLines=1, starts with m"></kirby-header>
+
+            <kirby-header title="A medium length title that might need scaling on smaller screens" [titleMaxLines]="1" subtitle1="titleMaxLines=1, medium title"></kirby-header>
+            <kirby-header title="A medium length title that might need scaling on smaller screens" [titleMaxLines]="2" subtitle1="titleMaxLines=2, medium title"></kirby-header>
+
+            <kirby-header title="Fall prices consulting quarterly municipal appeal inverse expenses market value credit quality market exposure potential appeal funds debt downturn NASDAQ Fitch 401k appeal corporate bonds municipal Nikkei market index treasury lucrative holder fiat corporation funds default interest rollover 401k exchange traded funds dividends inverse credit investment capitalization" [titleMaxLines]="2" subtitle1="titleMaxLines=2, very long title"></kirby-header>
+          </kirby-page-content>
+        </kirby-page>
+      </kirby-app>
+    `,
   }),
 };

--- a/libs/designsystem/header/src/header.component.stories.ts
+++ b/libs/designsystem/header/src/header.component.stories.ts
@@ -81,32 +81,26 @@ export const TitleMaxLinesScaling: Story = {
           <kirby-page-content>
 
             <!-- Title only -->
-            <kirby-header title="min titel" [titleMaxLines]="1" subtitle1="titleMaxLines=1"></kirby-header>
-            <kirby-header title="min titel" [titleMaxLines]="2" subtitle1="titleMaxLines=2"></kirby-header>
-            <kirby-header title="min titel" [titleMaxLines]="3" subtitle1="titleMaxLines=3"></kirby-header>
-            <kirby-header title="min titel" subtitle1="no max lines"></kirby-header>
-
-            <!-- Wide character regression -->
-            <kirby-header title="Mobile banking" [titleMaxLines]="1" subtitle1="titleMaxLines=1, starts with M"></kirby-header>
-            <kirby-header title="mobile banking" [titleMaxLines]="1" subtitle1="titleMaxLines=1, starts with m"></kirby-header>
+            <kirby-header title="Just a header" subtitle1="no max lines"></kirby-header>
+            <kirby-header title="Just a header" [titleMaxLines]="1" subtitle1="titleMaxLines=1"></kirby-header>
 
             <!-- Medium and long titles -->
             <kirby-header title="A medium length title that might need scaling on smaller screens" [titleMaxLines]="1" subtitle1="titleMaxLines=1, medium title"></kirby-header>
             <kirby-header title="A medium length title that might need scaling on smaller screens" [titleMaxLines]="2" subtitle1="titleMaxLines=2, medium title"></kirby-header>
-            <kirby-header title="Fall prices consulting quarterly municipal appeal inverse expenses market value credit quality market exposure potential appeal funds debt downturn NASDAQ Fitch 401k appeal corporate bonds municipal Nikkei market index treasury lucrative holder fiat corporation funds default interest rollover 401k exchange traded funds dividends inverse credit investment capitalization" [titleMaxLines]="2" subtitle1="titleMaxLines=2, very long title"></kirby-header>
+            <kirby-header title="Fall prices consulting quarterly municipal appeal inverse expenses market value credit quality market exposure potential appeal funds debt downturn NASDAQ Fitch 401k appeal corporate bonds municipal Nikkei market index treasury lucrative holder fiat corporation funds default interest rollover 401k exchange traded funds dividends inverse credit investment capitalization" [titleMaxLines]="3" subtitle1="titleMaxLines=3, very long title"></kirby-header>
 
             <!-- Key value: titleMaxLines scales the value -->
-            <kirby-header title="Opsparing" value="12.345,67" valueUnit="kr." [titleMaxLines]="1" subtitle1="key value, titleMaxLines=1"></kirby-header>
-            <kirby-header title="Opsparing" value="12.345,67" valueUnit="kr." subtitle1="key value, no max lines"></kirby-header>
-            <kirby-header title="Opsparing" value="1.234.567.890,12" valueUnit="kr." [titleMaxLines]="1" subtitle1="key value, long value, titleMaxLines=1"></kirby-header>
+            <kirby-header title="Savings" value="12.345,67" valueUnit="kr." subtitle1="key value, no max lines"></kirby-header>
+            <kirby-header title="Savings" value="12.345,67" valueUnit="kr." [titleMaxLines]="1" subtitle1="key value, titleMaxLines=1"></kirby-header>
+            <kirby-header title="Savings" value="1.234.567.890,12" valueUnit="kr." [titleMaxLines]="1" subtitle1="key value, long value, titleMaxLines=1"></kirby-header>
 
             <!-- Centered -->
-            <kirby-header title="min titel" [titleMaxLines]="1" [centered]="true" subtitle1="centered, titleMaxLines=1"></kirby-header>
-            <kirby-header title="min titel" [centered]="true" subtitle1="centered, no max lines"></kirby-header>
+            <kirby-header title="Just a header" [titleMaxLines]="1" [centered]="true" subtitle1="centered, titleMaxLines=1"></kirby-header>
+            <kirby-header title="Just a header" [centered]="true" subtitle1="centered, no max lines"></kirby-header>
 
             <!-- With flag -->
-            <kirby-header title="min titel" [titleMaxLines]="1" subtitle1="with flag, titleMaxLines=1">
-              <kirby-flag themeColor="success">Aktiv</kirby-flag>
+            <kirby-header title="Just a header" [titleMaxLines]="1" subtitle1="with flag, titleMaxLines=1">
+              <kirby-flag themeColor="success">Active</kirby-flag>
             </kirby-header>
 
           </kirby-page-content>

--- a/libs/designsystem/header/src/header.component.stories.ts
+++ b/libs/designsystem/header/src/header.component.stories.ts
@@ -76,36 +76,28 @@ export const TitleMaxLinesScaling: Story = {
   },
   render: () => ({
     template: `
-      <kirby-app>
-        <kirby-page title="titleMaxLines scaling">
-          <kirby-page-content>
+      <!-- Title only -->
+      <kirby-header title="Just a header" subtitle1="no max lines"></kirby-header>
+      <kirby-header title="Just a header" [titleMaxLines]="1" subtitle1="titleMaxLines=1"></kirby-header>
 
-            <!-- Title only -->
-            <kirby-header title="Just a header" subtitle1="no max lines"></kirby-header>
-            <kirby-header title="Just a header" [titleMaxLines]="1" subtitle1="titleMaxLines=1"></kirby-header>
+      <!-- Medium and long titles -->
+      <kirby-header title="A medium length title that might need scaling on smaller screens" [titleMaxLines]="1" subtitle1="titleMaxLines=1, medium title"></kirby-header>
+      <kirby-header title="A medium length title that might need scaling on smaller screens" [titleMaxLines]="2" subtitle1="titleMaxLines=2, medium title"></kirby-header>
+      <kirby-header title="Fall prices consulting quarterly municipal appeal inverse expenses market value credit quality market exposure potential appeal funds debt downturn NASDAQ Fitch 401k appeal corporate bonds municipal Nikkei market index treasury lucrative holder fiat corporation funds default interest rollover 401k exchange traded funds dividends inverse credit investment capitalization" [titleMaxLines]="3" subtitle1="titleMaxLines=3, very long title"></kirby-header>
 
-            <!-- Medium and long titles -->
-            <kirby-header title="A medium length title that might need scaling on smaller screens" [titleMaxLines]="1" subtitle1="titleMaxLines=1, medium title"></kirby-header>
-            <kirby-header title="A medium length title that might need scaling on smaller screens" [titleMaxLines]="2" subtitle1="titleMaxLines=2, medium title"></kirby-header>
-            <kirby-header title="Fall prices consulting quarterly municipal appeal inverse expenses market value credit quality market exposure potential appeal funds debt downturn NASDAQ Fitch 401k appeal corporate bonds municipal Nikkei market index treasury lucrative holder fiat corporation funds default interest rollover 401k exchange traded funds dividends inverse credit investment capitalization" [titleMaxLines]="3" subtitle1="titleMaxLines=3, very long title"></kirby-header>
+      <!-- Key value: titleMaxLines scales the value -->
+      <kirby-header title="Savings" value="12.345,67" valueUnit="kr." subtitle1="key value, no max lines"></kirby-header>
+      <kirby-header title="Savings" value="12.345,67" valueUnit="kr." [titleMaxLines]="1" subtitle1="key value, titleMaxLines=1"></kirby-header>
+      <kirby-header title="Savings" value="1.234.567.890,12" valueUnit="kr." [titleMaxLines]="1" subtitle1="key value, long value, titleMaxLines=1"></kirby-header>
 
-            <!-- Key value: titleMaxLines scales the value -->
-            <kirby-header title="Savings" value="12.345,67" valueUnit="kr." subtitle1="key value, no max lines"></kirby-header>
-            <kirby-header title="Savings" value="12.345,67" valueUnit="kr." [titleMaxLines]="1" subtitle1="key value, titleMaxLines=1"></kirby-header>
-            <kirby-header title="Savings" value="1.234.567.890,12" valueUnit="kr." [titleMaxLines]="1" subtitle1="key value, long value, titleMaxLines=1"></kirby-header>
+      <!-- Centered -->
+      <kirby-header title="Just a header" [titleMaxLines]="1" [centered]="true" subtitle1="centered, titleMaxLines=1"></kirby-header>
+      <kirby-header title="Just a header" [centered]="true" subtitle1="centered, no max lines"></kirby-header>
 
-            <!-- Centered -->
-            <kirby-header title="Just a header" [titleMaxLines]="1" [centered]="true" subtitle1="centered, titleMaxLines=1"></kirby-header>
-            <kirby-header title="Just a header" [centered]="true" subtitle1="centered, no max lines"></kirby-header>
-
-            <!-- With flag -->
-            <kirby-header title="Just a header" [titleMaxLines]="1" subtitle1="with flag, titleMaxLines=1">
-              <kirby-flag themeColor="success">Active</kirby-flag>
-            </kirby-header>
-
-          </kirby-page-content>
-        </kirby-page>
-      </kirby-app>
+      <!-- With flag -->
+      <kirby-header title="Just a header" [titleMaxLines]="1" subtitle1="with flag, titleMaxLines=1">
+        <kirby-flag themeColor="success">Active</kirby-flag>
+      </kirby-header>
     `,
   }),
 };

--- a/libs/designsystem/header/src/header.component.stories.ts
+++ b/libs/designsystem/header/src/header.component.stories.ts
@@ -1,12 +1,7 @@
 import { type Meta, moduleMetadata, type StoryObj } from '@storybook/angular';
 
-import { RouterTestingModule } from '@angular/router/testing';
-
 import { HeaderComponent } from '@kirbydesign/designsystem/header';
 import { FlagComponent } from '@kirbydesign/designsystem/flag';
-import { ModalNavigationService } from '@kirbydesign/designsystem/modal';
-import { PageComponent, PageContentComponent } from '@kirbydesign/designsystem/page';
-import { AppComponent } from '@kirbydesign/designsystem/kirby-app';
 
 import { responsiveModes } from 'tools/storybook-config/shared-config';
 import { HeaderExampleComponent } from '~/app/examples/header-example/header-example.component';
@@ -16,16 +11,7 @@ const meta: Meta<HeaderComponent> = {
   title: 'Components / Header',
   decorators: [
     moduleMetadata({
-      providers: [ModalNavigationService],
-      imports: [
-        RouterTestingModule,
-        HeaderComponent,
-        HeaderExampleComponent,
-        AppComponent,
-        PageComponent,
-        PageContentComponent,
-        FlagComponent,
-      ],
+      imports: [HeaderComponent, HeaderExampleComponent, FlagComponent],
     }),
   ],
   parameters: {

--- a/libs/designsystem/shared/src/fit-heading/fit-heading.directive.ts
+++ b/libs/designsystem/shared/src/fit-heading/fit-heading.directive.ts
@@ -29,6 +29,8 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
   private hostElementClone: Element;
   private isScalingHeader: boolean; // used to prevent resizeObserver to trigger on font scaling by this.scaleHeader()
 
+  private originalSize: HeadingSize;
+
   private headingSizes: HeadingSize[] = [
     {
       name: 'h1',
@@ -56,7 +58,6 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     if (this.config && this.config.maxLines) {
-      this.lineClampHelper.setMaxLines(this.elementRef.nativeElement, this.config.maxLines);
       this.observeResize();
       this.isObservingHostElement = true;
     }
@@ -91,20 +92,31 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
     this.isScalingHeader = true;
 
     if (!this.hostElementClone) {
+      // Capture original CSS size before any scaling
+      const computed = getComputedStyle(this.elementRef.nativeElement);
+      this.originalSize = {
+        name: 'original',
+        fontSize: computed.fontSize,
+        lineHeight: computed.lineHeight,
+      };
+
+      // Skip line-clamp for elements with line-height: normal (e.g. key-value) — conflicts with flex layout
+      if (computed.lineHeight !== 'normal') {
+        this.lineClampHelper.setMaxLines(this.elementRef.nativeElement, this.config.maxLines);
+      }
+
       this.hostElementClone = this.generateHostElementClone();
       this.renderer.appendChild(this.elementRef.nativeElement.parentElement, this.hostElementClone);
     }
 
-    // Use the parent element's width to determine available space.
-    // Using the host element's own clientWidth causes a feedback loop:
-    // the element shrink-wraps to its text content, so when font scales down
-    // the element gets narrower, making the clone narrower, which causes
-    // unnecessary further downscaling.
+    // Use parent width to avoid feedback loop from shrink-wrapped element width
     const availableWidth = this.elementRef.nativeElement.parentElement.clientWidth;
     this.renderer.setStyle(this.hostElementClone, 'width', `${availableWidth}px`);
 
+    // Try original CSS size first, then scale down through heading sizes
+    const candidates = [this.originalSize, ...this.headingSizes];
     const fallbackSize = this.headingSizes[this.headingSizes.length - 1];
-    const fittedSize = this.headingSizes.find(this.canFitHeading.bind(this)) || fallbackSize;
+    const fittedSize = candidates.find(this.canFitHeading.bind(this)) || fallbackSize;
 
     this.setSize(this.elementRef.nativeElement, fittedSize);
     this.lineClampHelper.setLineHeight(this.elementRef.nativeElement, fittedSize.lineHeight);
@@ -113,14 +125,17 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
 
   private canFitHeading(size: HeadingSize) {
     this.setSize(this.hostElementClone, size);
-    // Use getComputedStyle to get the resolved line-height in pixels.
-    // The token line-height may be a unitless ratio (e.g. 1.1875) rather than
-    // a pixel value, so parseInt would return 1 and break the calculation.
+    // Resolve line-height to pixels via getComputedStyle (handles unitless ratios)
     const computedLineHeight = parseFloat(
       getComputedStyle(this.hostElementClone as HTMLElement).lineHeight
     );
-    const lines = this.hostElementClone.clientHeight / computedLineHeight;
-    return Math.round(lines) <= this.config.maxLines;
+    // Skip vertical check for line-height: normal (single-line content like values)
+    const fitsVertically = isNaN(computedLineHeight)
+      ? true
+      : Math.round(this.hostElementClone.clientHeight / computedLineHeight) <= this.config.maxLines;
+    // Check horizontal overflow for non-wrapping content (e.g. numbers)
+    const fitsHorizontally = this.hostElementClone.scrollWidth <= this.hostElementClone.clientWidth;
+    return fitsVertically && fitsHorizontally;
   }
 
   private generateHostElementClone(): Element {

--- a/libs/designsystem/shared/src/fit-heading/fit-heading.directive.ts
+++ b/libs/designsystem/shared/src/fit-heading/fit-heading.directive.ts
@@ -95,11 +95,13 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
       this.renderer.appendChild(this.elementRef.nativeElement.parentElement, this.hostElementClone);
     }
 
-    this.renderer.setStyle(
-      this.hostElementClone,
-      'width',
-      `${this.elementRef.nativeElement.clientWidth}px`
-    );
+    // Use the parent element's width to determine available space.
+    // Using the host element's own clientWidth causes a feedback loop:
+    // the element shrink-wraps to its text content, so when font scales down
+    // the element gets narrower, making the clone narrower, which causes
+    // unnecessary further downscaling.
+    const availableWidth = this.elementRef.nativeElement.parentElement.clientWidth;
+    this.renderer.setStyle(this.hostElementClone, 'width', `${availableWidth}px`);
 
     const fallbackSize = this.headingSizes[this.headingSizes.length - 1];
     const fittedSize = this.headingSizes.find(this.canFitHeading.bind(this)) || fallbackSize;
@@ -111,8 +113,14 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
 
   private canFitHeading(size: HeadingSize) {
     this.setSize(this.hostElementClone, size);
-    const lines = this.hostElementClone.clientHeight / parseInt(size.lineHeight);
-    return lines <= this.config.maxLines;
+    // Use getComputedStyle to get the resolved line-height in pixels.
+    // The token line-height may be a unitless ratio (e.g. 1.1875) rather than
+    // a pixel value, so parseInt would return 1 and break the calculation.
+    const computedLineHeight = parseFloat(
+      getComputedStyle(this.hostElementClone as HTMLElement).lineHeight
+    );
+    const lines = this.hostElementClone.clientHeight / computedLineHeight;
+    return Math.round(lines) <= this.config.maxLines;
   }
 
   private generateHostElementClone(): Element {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #3770 

## What is the new behavior?

`[titleMaxLines]` now correctly keeps the title at full size when the text fits within the configured number of lines. Scaling only occurs when the text overflows the viewport.

_This fixes two issues_:
1. A broken line-height calculation caused by the switch to responsive font-scaling tokens (unitless line-heights)
2. A width measurement feedback loop where the element's own shrink-wrapped width was used for the clone, causing font scaling to get stuck at the smallest size.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

