### PR TITLE
feat(range): add dual knob support with examples, storybook and updates

### DIFF
--- a/apps/cookbook/src/app/examples/range-example/examples/dual-knobs-pin.component.ts
+++ b/apps/cookbook/src/app/examples/range-example/examples/dual-knobs-pin.component.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+import { RangeComponent } from '@kirbydesign/designsystem/range';
+
+const config = {
+  selector: 'cookbook-range-dual-knobs-pin-example',
+  template: `<kirby-range
+  [dualKnobs]="true"
+  [pin]="true"
+  [value]="value"
+  minLabel="Min value"
+  maxLabel="Max value"
+  aria-label="Dual knob range with pin"
+  [min]="0"
+  [max]="100"
+></kirby-range>`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+  imports: [RangeComponent],
+})
+export class RangeDualKnobsPinExampleComponent {
+  template: string = config.template;
+  value = { lower: 10, upper: 90 };
+}

--- a/apps/cookbook/src/app/examples/range-example/examples/dual-knobs.component.ts
+++ b/apps/cookbook/src/app/examples/range-example/examples/dual-knobs.component.ts
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+import { RangeComponent } from '@kirbydesign/designsystem/range';
+
+const config = {
+  selector: 'cookbook-range-dual-knobs-example',
+  template: `<kirby-range
+  [dualKnobs]="true"
+  [value]="value"
+  minLabel="Min value"
+  maxLabel="Max value"
+  aria-label="Dual knob range"
+  [min]="0"
+  [max]="100"
+></kirby-range>`,
+};
+
+@Component({
+  selector: config.selector,
+  template: config.template,
+  imports: [RangeComponent],
+})
+export class RangeDualKnobsExampleComponent {
+  template: string = config.template;
+  value = { lower: 20, upper: 80 };
+}

--- a/apps/cookbook/src/app/examples/range-example/range-example.component.html
+++ b/apps/cookbook/src/app/examples/range-example/range-example.component.html
@@ -9,3 +9,11 @@
 <h2>Disabled Range using Reactive Forms</h2>
 
 <cookbook-range-disabled-form-example></cookbook-range-disabled-form-example>
+
+<h2>Dual Knobs</h2>
+
+<cookbook-range-dual-knobs-example></cookbook-range-dual-knobs-example>
+
+<h2>Dual Knobs with Pin</h2>
+
+<cookbook-range-dual-knobs-pin-example></cookbook-range-dual-knobs-pin-example>

--- a/apps/cookbook/src/app/examples/range-example/range-example.component.ts
+++ b/apps/cookbook/src/app/examples/range-example/range-example.component.ts
@@ -2,6 +2,8 @@ import { Component } from '@angular/core';
 import { RangeDefaultExampleComponent } from './examples/default.component';
 import { RangeStepExampleComponent } from './examples/step.component';
 import { RangeDisabledFormExampleComponent } from './examples/disabled.component';
+import { RangeDualKnobsExampleComponent } from './examples/dual-knobs.component';
+import { RangeDualKnobsPinExampleComponent } from './examples/dual-knobs-pin.component';
 
 @Component({
   selector: 'cookbook-range-example',
@@ -10,6 +12,8 @@ import { RangeDisabledFormExampleComponent } from './examples/disabled.component
     RangeDefaultExampleComponent,
     RangeStepExampleComponent,
     RangeDisabledFormExampleComponent,
+    RangeDualKnobsExampleComponent,
+    RangeDualKnobsPinExampleComponent,
   ],
 })
 export class RangeExampleComponent {}

--- a/apps/cookbook/src/app/showcase/range-showcase/range-showcase.component.html
+++ b/apps/cookbook/src/app/showcase/range-showcase/range-showcase.component.html
@@ -41,6 +41,31 @@
     ></cookbook-range-disabled-form-example>
   </cookbook-example-viewer>
 
+  <h2>Dual Knobs</h2>
+  <p>
+    Setting
+    <code>dualKnobs="true"</code>
+    renders two knobs — one for the lower bound and one for the upper bound. The bound value type
+    changes to
+    <code>&#123; lower: number; upper: number &#125;</code>
+    .
+  </p>
+  <cookbook-example-viewer [html]="dualKnobsExample.template">
+    <cookbook-range-dual-knobs-example #dualKnobsExample></cookbook-range-dual-knobs-example>
+  </cookbook-example-viewer>
+
+  <h2>Dual Knobs with Pin</h2>
+  <p>
+    Dual knobs can be combined with
+    <code>pin="true"</code>
+    to show the value for each knob while dragging.
+  </p>
+  <cookbook-example-viewer [html]="dualKnobsPinExample.template">
+    <cookbook-range-dual-knobs-pin-example
+      #dualKnobsPinExample
+    ></cookbook-range-dual-knobs-pin-example>
+  </cookbook-example-viewer>
+
   <h2>Importing</h2>
   <cookbook-import-viewer [imports]="'RangeComponent'"></cookbook-import-viewer>
 

--- a/apps/cookbook/src/app/showcase/range-showcase/range-showcase.component.ts
+++ b/apps/cookbook/src/app/showcase/range-showcase/range-showcase.component.ts
@@ -5,11 +5,14 @@ import { RangeStepExampleComponent } from '../../examples/range-example/examples
 import { RangePinExampleComponent } from '../../examples/range-example/examples/pin.component';
 import { CodeViewerComponent } from '../../shared/code-viewer/code-viewer.component';
 import { RangeDisabledFormExampleComponent } from '../../examples/range-example/examples/disabled.component';
+import { RangeDualKnobsExampleComponent } from '../../examples/range-example/examples/dual-knobs.component';
+import { RangeDualKnobsPinExampleComponent } from '../../examples/range-example/examples/dual-knobs-pin.component';
 import { ApiDescriptionPropertiesComponent } from '../../shared/api-description/api-description-properties/api-description-properties.component';
 import { ApiDescriptionEventsComponent } from '../../shared/api-description/api-description-events/api-description-events.component';
 import { ApiDescriptionProperty } from '~/app/shared/api-description/api-description-properties/api-description-properties.component';
 import { ApiDescriptionMethod } from '~/app/shared/api-description/api-description-methods/api-description-methods.component';
 import { ImportViewerComponent } from '~/app/shared/import-code-viewer/import-code-viewer.component';
+
 @Component({
   selector: 'cookbook-range-showcase',
   templateUrl: './range-showcase.component.html',
@@ -21,6 +24,8 @@ import { ImportViewerComponent } from '~/app/shared/import-code-viewer/import-co
     RangePinExampleComponent,
     CodeViewerComponent,
     RangeDisabledFormExampleComponent,
+    RangeDualKnobsExampleComponent,
+    RangeDualKnobsPinExampleComponent,
     ApiDescriptionPropertiesComponent,
     ApiDescriptionEventsComponent,
     ImportViewerComponent,
@@ -79,11 +84,18 @@ export class RangeShowcaseComponent {
       defaultValue: '0',
     },
     {
+      name: 'dualKnobs',
+      description:
+        '(Optional) If true, two knobs are rendered — one for the lower bound and one for the upper bound. The value becomes an object with `lower` and `upper` properties.',
+      type: ['boolean'],
+      defaultValue: 'false',
+    },
+    {
       name: 'value',
       description:
-        '(Optional) The value represented by the range component. Should only be used if Angular Forms (Template-driven or ReactiveForm) are not used',
+        '(Optional) The value represented by the range component. In single-knob mode this is a number; in dual-knob mode this is an object with `lower` and `upper` number properties. Should only be used if Angular Forms (Template-driven or ReactiveForm) are not used.',
       defaultValue: 'undefined',
-      type: ['number'],
+      type: ['number', '{ lower: number; upper: number }'],
     },
   ];
 
@@ -92,13 +104,13 @@ export class RangeShowcaseComponent {
       name: 'change',
       description:
         'Emitted when the user modifies the value by releasing the knob or moving the knob with the keyboard',
-      signature: '() => EventEmitter<number>',
+      signature: '() => EventEmitter<number | { lower: number; upper: number }>',
     },
     {
       name: 'move',
       description:
         'Emitted for each distinct change whenever the knob is moved by the user. Unlike the `change` event it fires continuously while the user is dragging the knob.',
-      signature: '() => EventEmitter<number>',
+      signature: '() => EventEmitter<number | { lower: number; upper: number }>',
     },
   ];
 }

--- a/libs/designsystem/range/src/range.component.html
+++ b/libs/designsystem/range/src/range.component.html
@@ -10,6 +10,7 @@
   [ticks]="ticks"
   [debounce]="debounce"
   [disabled]="disabled"
+  [dualKnobs]="dualKnobs"
 ></ion-range>
 
 @if (minLabel) {

--- a/libs/designsystem/range/src/range.component.scss
+++ b/libs/designsystem/range/src/range.component.scss
@@ -18,6 +18,15 @@ ion-range {
     transition: interaction-state.transition();
     box-shadow: $knob-shadow, var(--kirby-focus-ring-md-inset);
   }
+
+  // Dual knob: apply focus ring to the active (focused) knob
+  &.range-pressed-a::part(knob-a),
+  &:focus-visible::part(knob-a),
+  &.range-pressed-b::part(knob-b),
+  &:focus-visible::part(knob-b) {
+    transition: interaction-state.transition();
+    box-shadow: $knob-shadow, var(--kirby-focus-ring-md-inset);
+  }
   @include interaction-state.apply-hover {
     --knob-background: #{interaction-state.get-state-color('white', 'xxs')};
   }

--- a/libs/designsystem/range/src/range.component.spec.ts
+++ b/libs/designsystem/range/src/range.component.spec.ts
@@ -137,4 +137,68 @@ describe('RangeComponent', () => {
       });
     });
   });
+
+  describe('dual knobs', () => {
+    let spectator: SpectatorHost<RangeComponent, OnPushHostComponent>;
+    let formControl: FormControl;
+    let ionRange: HTMLIonRangeElement;
+
+    const createHost = createHostFactory({
+      component: RangeComponent,
+      host: OnPushHostComponent,
+      imports: [TestHelper.ionicModuleForTest, ReactiveFormsModule],
+    });
+
+    beforeEach(async () => {
+      formControl = new FormControl({ lower: 20, upper: 80 });
+      spectator = createHost(
+        '<kirby-range [formControl]="formControl" [min]="0" [max]="100" [dualKnobs]="true"></kirby-range>',
+        { hostProps: { formControl } }
+      );
+      ionRange = spectator.query('ion-range');
+      await TestHelper.whenReady(ionRange);
+    });
+
+    it('should create with dualKnobs enabled', () => {
+      expect(spectator.component.dualKnobs).toBeTrue();
+    });
+
+    it('should accept an object value with lower and upper', () => {
+      expect(spectator.component.value).toEqual({ lower: 20, upper: 80 });
+    });
+
+    it('should update value when form control value changes', () => {
+      formControl.setValue({ lower: 10, upper: 90 });
+      spectator.detectChanges();
+
+      expect(spectator.component.value).toEqual({ lower: 10, upper: 90 });
+    });
+
+    it('should emit change event with lower/upper object on value change', () => {
+      const changeSpy = jasmine.createSpy('change');
+      spectator.component.change.subscribe(changeSpy);
+
+      spectator.component._onRangeValueChange({ detail: { value: { lower: 30, upper: 70 } } });
+
+      expect(changeSpy).toHaveBeenCalledWith({ lower: 30, upper: 70 });
+    });
+
+    it('should emit move event with lower/upper object on knob move', () => {
+      const moveSpy = jasmine.createSpy('move');
+      spectator.component.move.subscribe(moveSpy);
+
+      spectator.component._onRangeKnobMove({ detail: { value: { lower: 15, upper: 85 } } });
+
+      expect(moveSpy).toHaveBeenCalledWith({ lower: 15, upper: 85 });
+    });
+
+    it('should mark component for check when dual-knob value is written', () => {
+      const cdr = spectator.component['cdr'];
+      spyOn(cdr, 'markForCheck');
+
+      spectator.component.writeValue({ lower: 5, upper: 95 });
+
+      expect(cdr.markForCheck).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/libs/designsystem/range/src/range.component.stories.ts
+++ b/libs/designsystem/range/src/range.component.stories.ts
@@ -6,6 +6,9 @@ import { TestHelper } from '@kirbydesign/designsystem/testing';
 const meta: Meta<RangeComponent> = {
   component: RangeComponent,
   title: 'Components / Range',
+  parameters: {
+    layout: 'padded',
+  },
 };
 export default meta;
 type Story = StoryObj<RangeComponent>;
@@ -24,12 +27,8 @@ export const Range: Story = {
     disabled: false,
   },
   argTypes: {
-    min: {
-      type: 'number',
-    },
-    max: {
-      type: 'number',
-    },
+    min: { type: 'number' },
+    max: { type: 'number' },
   },
 };
 
@@ -40,13 +39,13 @@ export const RangePin: Story = {
   },
   render: (args) => ({
     props: args,
+    // Pin only shows on drag interaction, but can be imitated with transform: scale(1) for testing.
+    // Scaling messes with Ionics translate styles that move it to the right position.
+    // But since we just want to verify its dimensions, we simply hide the knob and show just the pin.
     styles: [
-      // Pin only shows on drag interaction, but can be imitated with transform: scale(1) for testing.
-      // Scaling messes with Ionics translate styles that move it to the right position.
-      // But since we just want to verify its dimensions, we simply hide the knob and show just the pin.
       `
       kirby-range {
-        margin: var(--kirby-spacing-l);
+        margin-top: var(--kirby-spacing-l);
       }
 
       ::ng-deep ion-range::part(pin) {
@@ -70,14 +69,84 @@ export const Focused: Story = {
     min: 0,
     max: 100,
   },
-  render: (args) => ({
-    props: args,
-    template: `<kirby-range ${argsToTemplate(args)}></kirby-range>`,
-    styles: [':host { padding: 8px; }'],
-  }),
   play: async ({ canvasElement }) => {
     const range = canvasElement.querySelector('ion-range');
     await TestHelper.whenReady(range);
     (range as HTMLElement).focus();
+  },
+};
+
+export const DualKnobs: Story = {
+  args: {
+    dualKnobs: true,
+    value: { lower: 25, upper: 75 },
+    step: 1,
+    min: 0,
+    max: 100,
+    minLabel: '',
+    maxLabel: '',
+    debounce: 0,
+    pin: false,
+    ticks: false,
+    disabled: false,
+  },
+  argTypes: {
+    min: { type: 'number' },
+    max: { type: 'number' },
+  },
+};
+
+export const DualKnobsPin: Story = {
+  args: {
+    dualKnobs: true,
+    pin: true,
+    value: { lower: 20, upper: 80 },
+    min: 0,
+    max: 100,
+  },
+  render: (args) => ({
+    props: args,
+    styles: [
+      `
+      kirby-range {
+        margin-top: var(--kirby-spacing-l);
+      }
+
+      ::ng-deep ion-range::part(pin) {
+        transform: scale(1);
+      }
+
+      ::ng-deep ion-range::part(knob-a),
+      ::ng-deep ion-range::part(knob-b) {
+        visibility: hidden;
+      }
+      `,
+    ],
+    template: `<kirby-range ${argsToTemplate(args)}></kirby-range>`,
+  }),
+};
+
+export const DualKnobsTicks: Story = {
+  args: {
+    dualKnobs: true,
+    ticks: true,
+    value: { lower: 2, upper: 7 },
+    step: 1,
+    min: 0,
+    max: 9,
+    minLabel: '0',
+    maxLabel: '9',
+  },
+};
+
+export const DualKnobsDisabled: Story = {
+  args: {
+    dualKnobs: true,
+    disabled: true,
+    value: { lower: 30, upper: 70 },
+    min: 0,
+    max: 100,
+    minLabel: 'Min',
+    maxLabel: 'Max',
   },
 };

--- a/libs/designsystem/range/src/range.component.ts
+++ b/libs/designsystem/range/src/range.component.ts
@@ -17,6 +17,8 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { IonRange } from '@ionic/angular/standalone';
 import { forwardAttributes } from '@kirbydesign/designsystem/shared';
 
+export type RangeValue = number | { lower: number; upper: number };
+
 @Component({
   imports: [IonRange],
   selector: 'kirby-range',
@@ -42,24 +44,25 @@ export class RangeComponent implements OnChanges, OnInit, ControlValueAccessor, 
   @Input() ticks: boolean;
   @Input() disabled = false;
   @Input() pinFormatter: (value: number) => string | number = this.defaultPinFormatter;
+  @Input() dualKnobs = false;
   @Input()
-  set value(value: number) {
+  set value(value: RangeValue) {
     if (value !== this.currentValue) {
       this.currentValue = value;
       this.propagateChange(this.currentValue);
     }
   }
 
-  get value(): number {
+  get value(): RangeValue {
     return this.currentValue;
   }
 
-  @Output() change: EventEmitter<number> = new EventEmitter<number>();
-  @Output() move: EventEmitter<number> = new EventEmitter<number>();
+  @Output() change: EventEmitter<RangeValue> = new EventEmitter<RangeValue>();
+  @Output() move: EventEmitter<RangeValue> = new EventEmitter<RangeValue>();
 
   @ViewChild(IonRange, { static: true }) private ionRange: IonRange;
 
-  private currentValue: number;
+  private currentValue: RangeValue;
   private _attributesToForward = ['aria-label', 'aria-labelledby'];
 
   constructor(
@@ -83,12 +86,25 @@ export class RangeComponent implements OnChanges, OnInit, ControlValueAccessor, 
       this.step = (this.max - this.min) / 9;
     }
 
+    const ticks = this.getTicks();
+    const snapToNearestTick = (val: number) =>
+      ticks.reduce((a, b) => (Math.abs(b - val) < Math.abs(a - val) ? b : a));
+
     /*
-     * Set value to the nearest tick
+     * Set value to the nearest tick (supports both single and dual knob modes)
      */
-    this.value = this.getTicks().reduce((a, b) => {
-      return Math.abs(b - this.value) < Math.abs(a - this.value) ? b : a;
-    });
+    if (this.dualKnobs) {
+      const current = (this.currentValue as { lower: number; upper: number }) ?? {
+        lower: this.min,
+        upper: this.max,
+      };
+      this.value = {
+        lower: snapToNearestTick(current.lower),
+        upper: snapToNearestTick(current.upper),
+      };
+    } else {
+      this.value = snapToNearestTick(this.currentValue as number);
+    }
   }
 
   ngAfterViewInit(): void {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4565 (insert issue number here)

## What is the new behavior?
`kirby-range` has a new property `dualKnobs` which defaults to `false`

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] Needs investergation. It defaults to false, but also the value on kirby-range has changed from `number` to ` RangeValue = number | { lower: number; upper: number }`

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?
It's added to both cookbook and storybook, thus it can be previewed as part of the buildstep of this PR.

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

