### PR TITLE
Divider in shape="none" lists in outlined card

### DIFF
--- a/libs/designsystem/list/src/list.component.integration.spec.ts
+++ b/libs/designsystem/list/src/list.component.integration.spec.ts
@@ -184,6 +184,39 @@ describe('ListComponent', () => {
     });
   });
 
+  describe('with shape="none" inside outlined card', () => {
+    beforeEach(async () => {
+      spectator = createHost<ListComponent>(
+        `
+        <kirby-card variant="outlined">
+          <kirby-list [items]="[{ name: 'Item1' }, { name: 'Item2' }, { name: 'Item3' }]" shape="none">
+            <kirby-item *kirbyListItemTemplate="let item"><p>{{ item.name }}</p></kirby-item>
+          </kirby-list>
+        </kirby-card>
+        `
+      );
+      ionList = spectator.queryHost('ion-list');
+      await TestHelper.whenReady(ionList);
+      itemsInList = spectator.queryAll('ion-list ion-item');
+    });
+
+    it('should apply "medium" border color to all but last item when inside outlined card and list has shape "none"', () => {
+      const ionItemSlidingList = spectator.queryAll('ion-item-sliding:not(.last)'); // last item doesn't have border
+      expect(ionItemSlidingList.length).toBeGreaterThan(0);
+      ionItemSlidingList.forEach((item) => {
+        expect(item).toHaveComputedStyle({
+          'border-bottom-color': getColor('medium'),
+        });
+      });
+
+      const lastIonItemSlidingList = spectator.queryAll('ion-item-sliding.last');
+      expect(lastIonItemSlidingList.length).toBe(1);
+      expect(lastIonItemSlidingList[0]).toHaveComputedStyle({
+        'border-bottom-width': '0px',
+      });
+    });
+  });
+
   describe('with kirby-item inside kirby-card', () => {
     beforeEach(async () => {
       spectator = createHost<ListComponent>(

--- a/libs/designsystem/list/src/list.component.scss
+++ b/libs/designsystem/list/src/list.component.scss
@@ -263,6 +263,10 @@ kirby-list-item:last-of-type {
   --kirby-list-item-border-color: #{utils.get-color('background-color')};
 }
 
+:host-context(kirby-card.outlined) {
+  --kirby-list-item-border-color: #{utils.get-color('medium')};
+}
+
 :host-context(.item-spacing) {
   .list {
     kirby-list-item {


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4580 

## What is the new behavior?

The divider color is changed to `medium`, when the list is inside a outlined card.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

