### PR TITLE
Modal: Prevent router subscription during Angular teardown

### DIFF
--- a/libs/designsystem/modal/src/modal-navigation.service.ts
+++ b/libs/designsystem/modal/src/modal-navigation.service.ts
@@ -6,9 +6,10 @@ import {
   Params,
   Route,
   Router,
+  Event as RouterEvent,
   Routes,
 } from '@angular/router';
-import { EMPTY, firstValueFrom, Observable } from 'rxjs';
+import { defer, EMPTY, firstValueFrom, Observable, Subject } from 'rxjs';
 import { filter, map, pairwise, skipUntil, startWith, takeUntil } from 'rxjs/operators';
 
 import { ModalRouteActivation } from './modal.interfaces';
@@ -19,6 +20,14 @@ export class ModalNavigationService {
     private router: Router,
     private route: ActivatedRoute
   ) {}
+
+  // Angular Router unsubscribes its internal events Subject during dispose() (e.g. on TestBed teardown).
+  // Subscribing to a closed Subject throws ObjectUnsubscribedError, so route all subscriptions through
+  // this defer-wrapped stream that falls back to EMPTY when the underlying Subject is already closed.
+  private routerEvents$: Observable<RouterEvent> = defer(() => {
+    const events = this.router.events;
+    return (events as Subject<RouterEvent>).closed ? EMPTY : events;
+  });
 
   isModalRoute(url: string): boolean {
     return url.includes('(modal:');
@@ -204,7 +213,7 @@ export class ModalNavigationService {
     return previousModalRouteParent !== currentModalRouteParent;
   }
 
-  private navigationEndListener$ = this.router.events.pipe(
+  private navigationEndListener$ = this.routerEvents$.pipe(
     filter((event): event is NavigationEnd => event instanceof NavigationEnd)
   );
 
@@ -351,13 +360,13 @@ export class ModalNavigationService {
   }
 
   handleBrowserBackButton(modal: HTMLIonModalElement) {
-    const popstateNavigationStart$ = this.router.events.pipe(
+    const popstateNavigationStart$ = this.routerEvents$.pipe(
       filter(
         (event): event is NavigationStart =>
           event instanceof NavigationStart && event.navigationTrigger === 'popstate'
       )
     );
-    const navigationEnd$ = this.router.events.pipe(
+    const navigationEnd$ = this.routerEvents$.pipe(
       filter((event) => event instanceof NavigationEnd)
     );
     navigationEnd$


### PR DESCRIPTION
## Which issue does this PR close?

This PR solves an issue where, when the application shuts down, an unhandled error would be thrown, if a modal is in the process of closing.

This is due to a subscription on the events observable from the angular-router, which is a subject that angular unsubcribes, triggering errors when attempting to subscribe to it. This PR solves this by detecting that the subject is closed, returning an empty observable istead of an error.

## What is the new behavior?

<!-- Replace this paragraph with a description of the new behaviour after your pull request is merged -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

