### PR TITLE
Design Tokens: Migrate core, designsystem and extension components to CSS Custom Properties

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,6 +1,8 @@
 {
   "extends": ["stylelint-config-standard-scss", "stylelint-config-prettier-scss"],
+  "plugins": ["@kirbydesign/stylelint-plugin"],
   "rules": {
+    "kirby/use-design-tokens": true,
     "scss/at-mixin-pattern": [
       "^(-?_?[a-z][a-z0-9]*)(-[a-z0-9]+)*$",
       {

--- a/apps/cookbook/src/app/examples/card-example/examples/card-example-variant.scss
+++ b/apps/cookbook/src/app/examples/card-example/examples/card-example-variant.scss
@@ -1,6 +1,7 @@
 @use '@kirbydesign/core/src/scss/utils';
 @use './card-example.shared';
 
+/* stylelint-disable-next-line kirby/use-design-tokens */
 $card-gap: utils.size(
   's'
 ); // use scss variable instead of custom property here for container query compatability

--- a/apps/cookbook/src/app/examples/page-example/fixed-footer-tabs/tab/fixed-footer-tab-example.component.ts
+++ b/apps/cookbook/src/app/examples/page-example/fixed-footer-tabs/tab/fixed-footer-tab-example.component.ts
@@ -1,9 +1,11 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
-import { PageFooterComponent } from '@kirbydesign/designsystem';
-
-import { PageComponent, PageContentComponent } from '@kirbydesign/designsystem/page';
+import {
+  PageComponent,
+  PageContentComponent,
+  PageFooterComponent,
+} from '@kirbydesign/designsystem/page';
 import { NgTemplateOutlet } from '@angular/common';
 import { ButtonComponent } from '@kirbydesign/designsystem/button';
 import { IconComponent } from '@kirbydesign/designsystem/icon';
@@ -69,6 +71,7 @@ const config = {
     ItemComponent,
     ToggleComponent,
     PageContentComponent,
+    PageFooterComponent,
   ],
 })
 export class PageFixedFooterTabExampleComponent extends BasePageExampleComponent implements OnInit {

--- a/libs/core/src/badge/badge.element.styles.ts
+++ b/libs/core/src/badge/badge.element.styles.ts
@@ -24,8 +24,8 @@ export default css`
     justify-content: center;
     box-sizing: border-box;
     padding: 0.3em 0.5em;
-    min-height: var(--kirby-relative-spacing-s);
-    min-width: var(--kirby-relative-spacing-s);
+    min-height: var(--kirby-relative-size-s);
+    min-width: var(--kirby-relative-size-s);
   }
 
   :host([themecolor='white']) {
@@ -59,8 +59,8 @@ export default css`
     padding: initial;
     min-height: initial;
     min-width: initial;
-    height: var(--kirby-relative-spacing-xxs);
-    width: var(--kirby-relative-spacing-xxs);
+    height: var(--kirby-relative-size-xxs);
+    width: var(--kirby-relative-size-xxs);
   }
 
   ::slotted(kirby-icon) {

--- a/libs/core/src/badge/badge.element.styles.ts
+++ b/libs/core/src/badge/badge.element.styles.ts
@@ -24,8 +24,8 @@ export default css`
     justify-content: center;
     box-sizing: border-box;
     padding: 0.3em 0.5em;
-    min-height: var(--kirby-relative-size-s);
-    min-width: var(--kirby-relative-size-s);
+    min-height: var(--kirby-relative-spacing-s);
+    min-width: var(--kirby-relative-spacing-s);
   }
 
   :host([themecolor='white']) {
@@ -59,8 +59,8 @@ export default css`
     padding: initial;
     min-height: initial;
     min-width: initial;
-    height: var(--kirby-relative-size-xxs);
-    width: var(--kirby-relative-size-xxs);
+    height: var(--kirby-relative-spacing-xxs);
+    width: var(--kirby-relative-spacing-xxs);
   }
 
   ::slotted(kirby-icon) {

--- a/libs/core/src/helpers/design-token-helper.scss
+++ b/libs/core/src/helpers/design-token-helper.scss
@@ -39,7 +39,7 @@
 $styles: map.merge(
   meta.module-variables('variables'),
   (
-    // window.getComputedStyle() returns box-shadow in a specific format, so re-map elevations:
+    /* window.getComputedStyle() returns box-shadow in a specific format, so re-map elevations:*/
     'elevations': remap-elevation(variables.$elevations)
   )
 );

--- a/libs/core/src/scss/base/_design-tokens.scss
+++ b/libs/core/src/scss/base/_design-tokens.scss
@@ -84,9 +84,9 @@
   }
 }
 
-@mixin relative-spacings() {
+@mixin relative-sizes() {
   @each $name, $value in variables.$relative-sizes {
-    --kirby-relative-spacing-#{$name}: #{$value};
+    --kirby-relative-size-#{$name}: #{$value};
   }
 }
 
@@ -186,7 +186,7 @@
   @include spacings;
 
   /* RELATIVE SPACINGS */
-  @include relative-spacings;
+  @include relative-sizes;
 
   /* FAT FINGER SIZE */
   @include size-fat-finger;

--- a/libs/core/src/scss/base/_design-tokens.scss
+++ b/libs/core/src/scss/base/_design-tokens.scss
@@ -98,6 +98,12 @@
   }
 }
 
+@mixin page-content-max-widths() {
+  @each $name, $value in variables.$page-content-max-widths {
+    --kirby-page-content-max-width-#{$name}: #{$value};
+  }
+}
+
 @mixin breakpoints() {
   @each $name, $value in variables.$breakpoints {
     --kirby-breakpoint-#{$name}: #{$value};
@@ -189,6 +195,9 @@
 
   /* Z-INDEXES */
   @include z-layers;
+
+  /* PAGE CONTENT MAX-WIDTHS */
+  @include page-content-max-widths;
 
   /* BREAKPOINTS */
   @include breakpoints;

--- a/libs/core/src/scss/base/_design-tokens.scss
+++ b/libs/core/src/scss/base/_design-tokens.scss
@@ -62,6 +62,12 @@
   }
 }
 
+@mixin icon-font-sizes() {
+  @each $name, $value in variables.$icon-font-sizes {
+    --kirby-icon-font-size-#{$name}: #{$value};
+  }
+}
+
 @mixin font-weights() {
   @each $name, $value in variables.$font-weight {
     --kirby-font-weight-#{$name}: #{$value};
@@ -162,6 +168,9 @@
 
   /* FONT-SIZES */
   @include font-sizes;
+
+  /* ICON-FONT-SIZES */
+  @include icon-font-sizes;
 
   /* FONT-WEIGHT */
   @include font-weights;

--- a/libs/core/src/scss/base/_design-tokens.scss
+++ b/libs/core/src/scss/base/_design-tokens.scss
@@ -1,5 +1,3 @@
-@use 'sass:color';
-@use 'sass:map';
 @use 'sass:meta';
 @use '../themes/colors';
 @use 'variables';

--- a/libs/core/src/scss/base/_design-tokens.scss
+++ b/libs/core/src/scss/base/_design-tokens.scss
@@ -86,9 +86,9 @@
   }
 }
 
-@mixin relative-sizes() {
+@mixin relative-spacings() {
   @each $name, $value in variables.$relative-sizes {
-    --kirby-relative-size-#{$name}: #{$value};
+    --kirby-relative-spacing-#{$name}: #{$value};
   }
 }
 
@@ -188,7 +188,7 @@
   @include spacings;
 
   /* RELATIVE SPACINGS */
-  @include relative-sizes;
+  @include relative-spacings;
 
   /* FAT FINGER SIZE */
   @include size-fat-finger;

--- a/libs/core/src/scss/base/_functions.scss
+++ b/libs/core/src/scss/base/_functions.scss
@@ -206,13 +206,13 @@
 */
 
 @mixin section-header-typography() {
-  --padding-end: #{size('s')};
-  --padding-start: #{size('s')};
+  --padding-end: var(--kirby-spacing-s);
+  --padding-start: var(--kirby-spacing-s);
 
   @include slotted('[heading]') {
-    font-weight: font-weight('bold');
-    font-size: font-size('m');
-    line-height: line-height('m');
+    font-weight: var(--kirby-font-weight-bold);
+    font-size: var(--kirby-font-size-m);
+    line-height: var(--kirby-line-height-m);
     color: var(--kirby-section-header-color);
     margin: 0;
     white-space: nowrap;
@@ -221,26 +221,26 @@
   }
 
   @include slotted('h2[heading]', '.kirby-text-large[heading]') {
-    font-size: font-size('l');
-    line-height: line-height('l');
+    font-size: var(--kirby-font-size-l);
+    line-height: var(--kirby-line-height-l);
   }
 
   @include slotted('.kirby-text-medium[heading]') {
-    font-size: font-size('m');
-    line-height: line-height('m');
+    font-size: var(--kirby-font-size-m);
+    line-height: var(--kirby-line-height-m);
   }
 
   @include slotted('h4[heading]', 'h5[heading]', 'h6[heading]', '.kirby-text-normal[heading]') {
-    font-size: font-size('n');
-    line-height: line-height('n');
+    font-size: var(--kirby-font-size-n);
+    line-height: var(--kirby-line-height-n);
   }
 
   @include slotted('[detail]', '[label]') {
-    font-weight: font-weight('light');
-    font-size: font-size('s');
-    line-height: line-height('s');
+    font-weight: var(--kirby-font-weight-light);
+    font-size: var(--kirby-font-size-s);
+    line-height: var(--kirby-line-height-s);
     color: var(--kirby-section-header-color);
-    margin: size('xxxs') 0 size('xxs');
+    margin: var(--kirby-spacing-xxxs) 0 var(--kirby-spacing-xxs);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -270,5 +270,5 @@
   background-size: $icon-scaling-factor;
 
   // Place icon to the right of text, with icons own width + the actual spacing
-  padding-right: calc(#{$icon-scaling-factor} + #{size('xxxs')});
+  padding-right: calc(#{$icon-scaling-factor} + var(--kirby-spacing-xxxs));
 }

--- a/libs/core/src/scss/base/_functions.scss
+++ b/libs/core/src/scss/base/_functions.scss
@@ -1,7 +1,6 @@
 @use 'sass:list';
 @use 'sass:map';
 @use 'sass:math';
-@use 'sass:meta';
 @use 'sass:string';
 @use '../themes/colors';
 @use 'variables';

--- a/libs/core/src/scss/base/_html-table.scss
+++ b/libs/core/src/scss/base/_html-table.scss
@@ -8,7 +8,7 @@ $header-padding: 14px;
 $row-height: 44px;
 
 // Color variables
-$default-divider-color: utils.get-color('medium');
+$default-divider-color: var(--kirby-medium);
 $border-bottom: 1px solid var(--kirby-divider-color, #{$default-divider-color});
 
 table.kirby-table {
@@ -35,8 +35,8 @@ table.kirby-table {
     }
 
     &.active {
-      color: utils.get-text-color('black');
-      font-weight: utils.font-weight('bold');
+      color: var(--kirby-text-color-black);
+      font-weight: var(--kirby-font-weight-bold);
 
       & kirby-icon.sortable-icon {
         visibility: visible;
@@ -44,14 +44,14 @@ table.kirby-table {
     }
 
     text-align: left;
-    font-weight: utils.font-weight('normal');
-    font-size: utils.font-size('xs');
-    color: utils.get-text-color('semi-dark');
-    line-height: utils.line-height('xs');
-    padding: $header-padding utils.size('s');
+    font-weight: var(--kirby-font-weight-normal);
+    font-size: var(--kirby-font-size-xs);
+    color: var(--kirby-text-color-semi-dark);
+    line-height: var(--kirby-line-height-xs);
+    padding: $header-padding var(--kirby-spacing-s);
 
     &.sortable {
-      padding: utils.size('xxs') utils.size('s');
+      padding: var(--kirby-spacing-xxs) var(--kirby-spacing-s);
     }
 
     button {
@@ -97,7 +97,7 @@ table.kirby-table {
         &::before {
           display: block;
           content: attr(data-text);
-          font-weight: utils.font-weight('bold');
+          font-weight: var(--kirby-font-weight-bold);
           height: 0;
           overflow: hidden;
           visibility: hidden;
@@ -119,10 +119,10 @@ table.kirby-table {
 
   td {
     height: $row-height;
-    padding: utils.size('xxxs') utils.size('s');
-    font-weight: utils.font-weight('normal');
-    font-size: utils.font-size('s');
-    color: utils.get-text-color('black');
+    padding: var(--kirby-spacing-xxxs) var(--kirby-spacing-s);
+    font-weight: var(--kirby-font-weight-normal);
+    font-size: var(--kirby-font-size-s);
+    color: var(--kirby-text-color-black);
     vertical-align: middle;
 
     &.text-align-left {

--- a/libs/core/src/scss/base/_html-table.scss
+++ b/libs/core/src/scss/base/_html-table.scss
@@ -1,5 +1,4 @@
 @use '../interaction-state';
-@use '../utils';
 
 // Padding variables
 $header-padding: 14px;

--- a/libs/core/src/scss/base/_link.scss
+++ b/libs/core/src/scss/base/_link.scss
@@ -2,7 +2,7 @@
 @use '../utils';
 
 $_focus-ring-gap: 3px;
-$_focus-ring-border-radius: utils.border-radius('xxs');
+$_focus-ring-border-radius: var(--kirby-border-radius-xxs);
 
 /*
  * Link-styles (anchor tag with href or kirbyModalRouterLink directive)

--- a/libs/core/src/scss/base/_link.scss
+++ b/libs/core/src/scss/base/_link.scss
@@ -1,5 +1,4 @@
 @use '../interaction-state';
-@use '../utils';
 
 $_focus-ring-gap: 3px;
 $_focus-ring-border-radius: var(--kirby-border-radius-xxs);

--- a/libs/core/src/scss/base/_list.scss
+++ b/libs/core/src/scss/base/_list.scss
@@ -1,17 +1,17 @@
 @use '@kirbydesign/core/src/scss/utils';
 
-@mixin rounded($border-radius: utils.border-radius('n')) {
+@mixin rounded($border-radius: var(--kirby-border-radius-n)) {
   @include rounded-top($border-radius);
   @include rounded-bottom($border-radius);
 }
 
-@mixin rounded-top($border-radius: utils.border-radius('n')) {
+@mixin rounded-top($border-radius: var(--kirby-border-radius-n)) {
   border-top-left-radius: $border-radius;
   border-top-right-radius: $border-radius;
   overflow: hidden;
 }
 
-@mixin rounded-bottom($border-radius: utils.border-radius('n')) {
+@mixin rounded-bottom($border-radius: var(--kirby-border-radius-n)) {
   border-bottom-left-radius: $border-radius;
   border-bottom-right-radius: $border-radius;
   overflow: hidden;

--- a/libs/core/src/scss/base/_list.scss
+++ b/libs/core/src/scss/base/_list.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 @mixin rounded($border-radius: var(--kirby-border-radius-n)) {
   @include rounded-top($border-radius);
   @include rounded-bottom($border-radius);
@@ -40,8 +38,8 @@
 }
 
 /*
- * Utilities for styling lists and items within the list. 
- * These can be used to create list-like appearance of elements 
+ * Utilities for styling lists and items within the list.
+ * These can be used to create list-like appearance of elements
  * in use-cases where more freedom is needed than the list-component can offer.
  */
 

--- a/libs/core/src/scss/base/_list.scss
+++ b/libs/core/src/scss/base/_list.scss
@@ -18,14 +18,14 @@
 }
 
 @mixin shadow() {
-  box-shadow: utils.get-elevation(2);
+  box-shadow: var(--kirby-elevation-2);
 }
 
 @mixin first-item-padding() {
   /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
   > ::ng-deep {
     :first-child {
-      --item-padding-top: #{utils.size('xxs')};
+      --item-padding-top: var(--kirby-spacing-xxs);
     }
   }
 }
@@ -34,7 +34,7 @@
   /* stylelint-disable-next-line selector-pseudo-element-no-unknown */
   > ::ng-deep {
     :last-child {
-      --item-padding-bottom: #{utils.size('xxs')};
+      --item-padding-bottom: var(--kirby-spacing-xxs);
     }
   }
 }

--- a/libs/core/src/scss/components/_grid.scss
+++ b/libs/core/src/scss/components/_grid.scss
@@ -13,8 +13,8 @@ $grid-sizes-to-breakpoint-map: (
 
 .kirby-grid {
   --kirby-grid-columns: 12;
-  --kirby-grid-column-spacing: #{utils.size('m')};
-  --kirby-grid-row-spacing: #{utils.size('m')};
+  --kirby-grid-column-spacing: var(--kirby-spacing-m);
+  --kirby-grid-row-spacing: var(--kirby-spacing-m);
 
   box-sizing: border-box;
   display: flex;
@@ -34,32 +34,32 @@ $grid-sizes-to-breakpoint-map: (
 
   &[spacing='1'],
   &[data-spacing='1'] {
-    --kirby-grid-column-spacing: #{utils.size('xxs')};
-    --kirby-grid-row-spacing: #{utils.size('xxs')};
+    --kirby-grid-column-spacing: var(--kirby-spacing-xxs);
+    --kirby-grid-row-spacing: var(--kirby-spacing-xxs);
   }
 
   &[spacing='2'],
   &[data-spacing='2'] {
-    --kirby-grid-column-spacing: #{utils.size('s')};
-    --kirby-grid-row-spacing: #{utils.size('s')};
+    --kirby-grid-column-spacing: var(--kirby-spacing-s);
+    --kirby-grid-row-spacing: var(--kirby-spacing-s);
   }
 
   &[spacing='3'],
   &[data-spacing='3'] {
-    --kirby-grid-column-spacing: #{utils.size('m')};
-    --kirby-grid-row-spacing: #{utils.size('m')};
+    --kirby-grid-column-spacing: var(--kirby-spacing-m);
+    --kirby-grid-row-spacing: var(--kirby-spacing-m);
   }
 
   &[spacing='4'],
   &[data-spacing='4'] {
-    --kirby-grid-column-spacing: #{utils.size('l')};
-    --kirby-grid-row-spacing: #{utils.size('l')};
+    --kirby-grid-column-spacing: var(--kirby-spacing-l);
+    --kirby-grid-row-spacing: var(--kirby-spacing-l);
   }
 
   &[spacing='5'],
   &[data-spacing='5'] {
-    --kirby-grid-column-spacing: #{utils.size('xl')};
-    --kirby-grid-row-spacing: #{utils.size('xl')};
+    --kirby-grid-column-spacing: var(--kirby-spacing-xl);
+    --kirby-grid-row-spacing: var(--kirby-spacing-xl);
   }
 
   &[row-spacing='0'],
@@ -69,27 +69,27 @@ $grid-sizes-to-breakpoint-map: (
 
   &[row-spacing='1'],
   &[data-row-spacing='1'] {
-    --kirby-grid-row-spacing: #{utils.size('xxs')};
+    --kirby-grid-row-spacing: var(--kirby-spacing-xxs);
   }
 
   &[row-spacing='2'],
   &[data-row-spacing='2'] {
-    --kirby-grid-row-spacing: #{utils.size('s')};
+    --kirby-grid-row-spacing: var(--kirby-spacing-s);
   }
 
   &[row-spacing='3'],
   &[data-row-spacing='3'] {
-    --kirby-grid-row-spacing: #{utils.size('m')};
+    --kirby-grid-row-spacing: var(--kirby-spacing-m);
   }
 
   &[row-spacing='4'],
   &[data-row-spacing='4'] {
-    --kirby-grid-row-spacing: #{utils.size('l')};
+    --kirby-grid-row-spacing: var(--kirby-spacing-l);
   }
 
   &[row-spacing='5'],
   &[data-row-spacing='5'] {
-    --kirby-grid-row-spacing: #{utils.size('xl')};
+    --kirby-grid-row-spacing: var(--kirby-spacing-xl);
   }
 
   &[column-spacing='0'],
@@ -99,27 +99,27 @@ $grid-sizes-to-breakpoint-map: (
 
   &[column-spacing='1'],
   &[data-column-spacing='1'] {
-    --kirby-grid-column-spacing: #{utils.size('xxs')};
+    --kirby-grid-column-spacing: var(--kirby-spacing-xxs);
   }
 
   &[column-spacing='2'],
   &[data-column-spacing='2'] {
-    --kirby-grid-column-spacing: #{utils.size('s')};
+    --kirby-grid-column-spacing: var(--kirby-spacing-s);
   }
 
   &[column-spacing='3'],
   &[data-column-spacing='3'] {
-    --kirby-grid-column-spacing: #{utils.size('m')};
+    --kirby-grid-column-spacing: var(--kirby-spacing-m);
   }
 
   &[column-spacing='4'],
   &[data-column-spacing='4'] {
-    --kirby-grid-column-spacing: #{utils.size('l')};
+    --kirby-grid-column-spacing: var(--kirby-spacing-l);
   }
 
   &[column-spacing='5'],
   &[data-column-spacing='5'] {
-    --kirby-grid-column-spacing: #{utils.size('xl')};
+    --kirby-grid-column-spacing: var(--kirby-spacing-xl);
   }
 }
 

--- a/libs/core/src/scss/components/_overlays.scss
+++ b/libs/core/src/scss/components/_overlays.scss
@@ -20,8 +20,8 @@ $modal-heights: (
   m: 565px,
   l: 754px,
 );
-$modal-border-radius: utils.border-radius('xl');
-$modal-gutter: #{utils.size('xxl')};
+$modal-border-radius: var(--kirby-border-radius-xl);
+$modal-gutter: var(--kirby-spacing-xxl);
 $modal-header-height: 88px;
 $modal-expected-footer-height: 88px;
 $modal-min-content-height: 88px;
@@ -36,7 +36,9 @@ $modal-large-screen-min-height: $modal-header-height + $modal-expected-footer-he
 }
 
 @function get-drawer-additional-padding-top() {
+  // TODO(@kirby): migrate utils.size('l') — $modal-close-button-inner-height feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
   $modal-close-button-inner-height: utils.size('l'); // Todo: Move to / get from shared var
+  // TODO(@kirby): migrate utils.size('xxxs') — $modal-close-button-vertical-margin feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
   $modal-close-button-vertical-margin: utils.size('xxxs') * 2; // Todo: Move to / get from shared var
   $modal-header-vertical-padding: 3px * 2; // 3px defined by Ionic
   $modal-header-total-height: $modal-close-button-inner-height +
@@ -59,9 +61,9 @@ ion-modal.kirby-overlay {
 
   &.kirby-modal {
     --border-radius: 0;
-    --background: var(--kirby-modal-background, #{utils.get-color('background-color')});
+    --background: var(--kirby-modal-background, var(--kirby-background-color));
     --height: auto;
-    --box-shadow: #{utils.get-elevation(8)};
+    --box-shadow: var(--kirby-elevation-8);
 
     box-sizing: border-box;
 
@@ -76,7 +78,7 @@ ion-modal.kirby-overlay {
       @include utils.media('<medium') {
         @include bottom-drawer;
 
-        --kirby-modal-padding-top: calc(var(--kirby-safe-area-top, 0px) + #{utils.size('m')});
+        --kirby-modal-padding-top: calc(var(--kirby-safe-area-top, 0px) + var(--kirby-spacing-m));
 
         &.kirby-modal-full-height {
           --height: 100%;
@@ -159,21 +161,21 @@ ion-modal.kirby-overlay {
   }
 
   &.kirby-alert {
-    --background: #{utils.get-color('background-color')};
-    --border-radius: #{utils.border-radius('n')};
-    --box-shadow: #{utils.get-elevation(8)};
+    --background: var(--kirby-background-color);
+    --border-radius: var(--kirby-border-radius-n);
+    --box-shadow: var(--kirby-elevation-8);
     --max-width: #{utils.$alert-max-width};
     --height: auto;
   }
 }
 
 ion-modal {
-  --background: var(--kirby-modal-background, #{utils.get-color('background-color')});
+  --background: var(--kirby-modal-background, var(--kirby-background-color));
 }
 
 ion-loading.kirby-loading-overlay {
   --backdrop-opacity: #{utils.$loading-overlay-backdrop-opacity};
-  --ion-backdrop-color: #{utils.get-color('background-color')};
+  --ion-backdrop-color: var(--kirby-background-color);
 
   .loading-wrapper {
     --background: transparent;
@@ -190,17 +192,17 @@ ion-loading.kirby-loading-overlay {
   text-align: center;
 
   // Set default colors
-  --background: #{utils.get-color('success-tint')};
-  --color: #{utils.get-color('black')};
+  --background: var(--kirby-success-tint);
+  --color: var(--kirby-black);
   --button-color: var(--color);
 
   // For readability
   &.success {
-    --background: #{utils.get-color('success-tint')};
+    --background: var(--kirby-success-tint);
   }
 
   &.warning {
-    --background: #{utils.get-color('warning')};
+    --background: var(--kirby-warning);
   }
 }
 

--- a/libs/core/src/scss/components/_overlays.scss
+++ b/libs/core/src/scss/components/_overlays.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use 'sass:math';
 @use '../utils';
 
 /*
@@ -33,18 +32,6 @@ $modal-large-screen-min-height: $modal-header-height + $modal-expected-footer-he
   --min-height: #{utils.$drawer-default-height};
 
   align-items: flex-end;
-}
-
-@function get-drawer-additional-padding-top() {
-  // TODO(@kirby): migrate utils.size('l') — $modal-close-button-inner-height feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
-  $modal-close-button-inner-height: utils.size('l'); // Todo: Move to / get from shared var
-  // TODO(@kirby): migrate utils.size('xxxs') — $modal-close-button-vertical-margin feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
-  $modal-close-button-vertical-margin: utils.size('xxxs') * 2; // Todo: Move to / get from shared var
-  $modal-header-vertical-padding: 3px * 2; // 3px defined by Ionic
-  $modal-header-total-height: $modal-close-button-inner-height +
-    $modal-close-button-vertical-margin + $modal-header-vertical-padding;
-  $modal-header-vertical-center: math.round($modal-header-total-height * 0.5);
-  @return $modal-header-vertical-center;
 }
 
 body.allow-background-scroll {

--- a/libs/core/src/scss/interaction-state/_interaction-state.utilities.scss
+++ b/libs/core/src/scss/interaction-state/_interaction-state.utilities.scss
@@ -1,5 +1,4 @@
 @use 'sass:color';
-@use 'sass:list';
 @use 'sass:map';
 @use '../utils';
 

--- a/libs/core/src/scss/interaction-state/_interaction-state.utilities.scss
+++ b/libs/core/src/scss/interaction-state/_interaction-state.utilities.scss
@@ -24,7 +24,8 @@ $loudness-scale: (
 }
 
 @function get-state-color($variant, $loudness: $default-loudness-hover, $make-lighter: false) {
-  // TODO(@kirby): migrate utils.get-color($variant, $getValueOnly: true) — get-color() with $getValueOnly: true returns a raw value for SCSS color manipulation
+  // no Safari-15-safe CSS custom property equivalent, so kept as SCSS.
+  // stylelint-disable-next-line kirby/use-design-tokens
   $_background: utils.get-color($variant, $getValueOnly: true);
   $_lightness: 0% !default;
 

--- a/libs/core/src/scss/interaction-state/_interaction-state.utilities.scss
+++ b/libs/core/src/scss/interaction-state/_interaction-state.utilities.scss
@@ -24,6 +24,7 @@ $loudness-scale: (
 }
 
 @function get-state-color($variant, $loudness: $default-loudness-hover, $make-lighter: false) {
+  // TODO(@kirby): migrate utils.get-color($variant, $getValueOnly: true) — get-color() with $getValueOnly: true returns a raw value for SCSS color manipulation
   $_background: utils.get-color($variant, $getValueOnly: true);
   $_lightness: 0% !default;
 

--- a/libs/core/src/scss/interaction-state/_layer.scss
+++ b/libs/core/src/scss/interaction-state/_layer.scss
@@ -7,10 +7,11 @@
 // You can change move the content layer on top by declaring e.g.:
 //    --content-layer-z-index: calc(#{layer.$state-layer-z-index} + 1);
 // in a component that uses interaction state layer.
+// TODO(@kirby): migrate utils.z('default') — $_content-layer-z-index feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
 $_content-layer-z-index: utils.z('default');
 $state-layer-z-index: $_content-layer-z-index + 1;
-$_dark: utils.get-color('black');
-$_light: utils.get-color('black-contrast');
+$_dark: var(--kirby-black);
+$_light: var(--kirby-black-contrast);
 
 /// Prepare state layer and content layer for interaction state changes.
 /// Should be initialized before applying hover.

--- a/libs/core/src/scss/interaction-state/_layer.scss
+++ b/libs/core/src/scss/interaction-state/_layer.scss
@@ -1,15 +1,13 @@
 @use 'sass:math';
 @use 'sass:meta';
 @use 'interaction-state.utilities';
-@use '../utils';
 
 // Put state layer above content layer as default.
 // You can change move the content layer on top by declaring e.g.:
-//    --content-layer-z-index: calc(#{layer.$state-layer-z-index} + 1);
+//    --content-layer-z-index: calc(var(--kirby-z-index-default) + 1);
 // in a component that uses interaction state layer.
-// TODO(@kirby): migrate utils.z('default') — $_content-layer-z-index feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
-$_content-layer-z-index: utils.z('default');
-$state-layer-z-index: $_content-layer-z-index + 1;
+$_content-layer-z-index: var(--kirby-z-index-default);
+$state-layer-z-index: calc(var(--kirby-z-index-default) + 1);
 $_dark: var(--kirby-black);
 $_light: var(--kirby-black-contrast);
 

--- a/libs/core/src/scss/themes/_colors.scss
+++ b/libs/core/src/scss/themes/_colors.scss
@@ -1,6 +1,5 @@
 @use 'sass:color';
 @use 'sass:map';
-@use 'sass:meta';
 @use 'sass:math';
 
 $brand-colors: (

--- a/libs/core/src/scss/themes/_component-themes.scss
+++ b/libs/core/src/scss/themes/_component-themes.scss
@@ -24,7 +24,7 @@
   --kirby-inputs-placeholder-color: var(--kirby-semi-dark);
   --kirby-inputs-color-hover: var(--kirby-semi-dark);
   --kirby-inputs-elevation: none;
-  --kirby-divider-color: #{utils.get-color('background-color')};
+  --kirby-divider-color: var(--kirby-background-color);
 }
 
 @mixin apply-light-theme {
@@ -36,7 +36,7 @@
   --kirby-inputs-indicator-color: var(--kirby-white);
   --kirby-inputs-placeholder-color: var(--kirby-semi-dark);
   --kirby-inputs-color-hover: var(--kirby-semi-dark);
-  --kirby-divider-color: #{utils.get-color('medium')};
+  --kirby-divider-color: var(--kirby-medium);
 
   // Only set elevation on input components for light theme
   --kirby-inputs-elevation: var(--kirby-elevation-2);

--- a/libs/core/src/scss/themes/_component-themes.scss
+++ b/libs/core/src/scss/themes/_component-themes.scss
@@ -1,7 +1,3 @@
-@use 'sass:color';
-@use '../utils';
-@use '../interaction-state';
-
 @mixin apply-dark-theme {
   --kirby-inputs-background-color: var(--kirby-white-overlay);
   --kirby-inputs-background-color-hover: var(--kirby-white-overlay-30);

--- a/libs/core/src/scss/themes/_item-sliding.scss
+++ b/libs/core/src/scss/themes/_item-sliding.scss
@@ -1,18 +1,65 @@
-/* 
-  These styles are moved here as they are shared between 
-  the new kirby-item-sliding component and the old template driven 
-  list. This reduces the amount of duplication. 
+/*
+  These styles are moved here as they are shared between
+  the new kirby-item-sliding component and the old template driven
+  list. This reduces the amount of duplication.
 
-  When the old template driven list is deprecated however - this should 
+  When the old template driven list is deprecated however - this should
   just be used directly in item-sliding.component.scss.
  */
-@use '@kirbydesign/core/src/scss/utils';
 
 ion-item-option {
-  @each $color-name, $color-value in utils.$main-colors {
-    &.#{$color-name} {
-      background-color: #{utils.get-color($color-name)};
-      color: #{utils.get-color($color-name + '-contrast')};
-    }
+  &.primary {
+    background-color: var(--kirby-primary);
+    color: var(--kirby-primary-contrast);
+  }
+
+  &.secondary {
+    background-color: var(--kirby-secondary);
+    color: var(--kirby-secondary-contrast);
+  }
+
+  &.tertiary {
+    background-color: var(--kirby-tertiary);
+    color: var(--kirby-tertiary-contrast);
+  }
+
+  &.success {
+    background-color: var(--kirby-success);
+    color: var(--kirby-success-contrast);
+  }
+
+  &.warning {
+    background-color: var(--kirby-warning);
+    color: var(--kirby-warning-contrast);
+  }
+
+  &.danger {
+    background-color: var(--kirby-danger);
+    color: var(--kirby-danger-contrast);
+  }
+
+  &.white-overlay {
+    background-color: var(--kirby-white-overlay);
+    color: var(--kirby-white-overlay-contrast);
+  }
+
+  &.light {
+    background-color: var(--kirby-light);
+    color: var(--kirby-light-contrast);
+  }
+
+  &.medium {
+    background-color: var(--kirby-medium);
+    color: var(--kirby-medium-contrast);
+  }
+
+  &.dark {
+    background-color: var(--kirby-dark);
+    color: var(--kirby-dark-contrast);
+  }
+
+  &.dark-overlay {
+    background-color: var(--kirby-dark-overlay);
+    color: var(--kirby-dark-overlay-contrast);
   }
 }

--- a/libs/designsystem/accordion/src/accordion-item.component.scss
+++ b/libs/designsystem/accordion/src/accordion-item.component.scss
@@ -1,5 +1,4 @@
 @use '@kirbydesign/core/src/scss/interaction-state';
-@use '@kirbydesign/core/src/scss/utils';
 
 $divider-color: var(--kirby-medium);
 $padding: var(--kirby-spacing-s);

--- a/libs/designsystem/accordion/src/accordion-item.component.scss
+++ b/libs/designsystem/accordion/src/accordion-item.component.scss
@@ -1,8 +1,8 @@
 @use '@kirbydesign/core/src/scss/interaction-state';
 @use '@kirbydesign/core/src/scss/utils';
 
-$divider-color: utils.get-color('medium');
-$padding: utils.size('s');
+$divider-color: var(--kirby-medium);
+$padding: var(--kirby-spacing-s);
 
 :host {
   @include interaction-state.initialize-layer;
@@ -54,7 +54,7 @@ $padding: utils.size('s');
   & {
     display: flex;
     align-items: center;
-    gap: utils.size('xxs');
+    gap: var(--kirby-spacing-xxs);
     padding: $padding;
     user-select: none;
     width: 100%;
@@ -70,11 +70,11 @@ $padding: utils.size('s');
 .title {
   flex-grow: 2;
   display: flex;
-  font-size: utils.font-size('n');
+  font-size: var(--kirby-font-size-n);
 }
 
 .kirby-icon {
-  transition: transform utils.get-transition-duration('quick');
+  transition: transform var(--kirby-transition-duration-quick);
 }
 
 .content {
@@ -90,22 +90,22 @@ button[disabled] {
   pointer-events: none;
 
   .kirby-icon {
-    color: utils.get-color('semi-dark');
+    color: var(--kirby-semi-dark);
   }
 
   .title {
-    color: utils.get-text-color('semi-dark');
+    color: var(--kirby-text-color-semi-dark);
   }
 }
 
 button {
   // Enforce button text color to avoid inheriting native button color from browser
-  color: utils.get-text-color('black');
+  color: var(--kirby-text-color-black);
 }
 
 button[aria-expanded='true'] {
   .title {
-    font-weight: utils.font-weight('bold');
+    font-weight: var(--kirby-font-weight-bold);
   }
 
   .kirby-icon {
@@ -120,7 +120,7 @@ button[aria-expanded='true'] {
 }
 
 :host-context(kirby-card) {
-  border-color: utils.get-color('background-color');
+  border-color: var(--kirby-background-color);
 
   &:first-child {
     border-top: none;

--- a/libs/designsystem/action-group/src/action-group.component.scss
+++ b/libs/designsystem/action-group/src/action-group.component.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-wrap: wrap;
   position: relative;
-  gap: utils.size('xxs');
+  gap: var(--kirby-spacing-xxs);
 }
 
 :host(.align-end) {

--- a/libs/designsystem/avatar/src/avatar.component.scss
+++ b/libs/designsystem/avatar/src/avatar.component.scss
@@ -22,7 +22,7 @@ $badge-diameter: utils.$avatar-badge-size;
   --kirby-badge-position: absolute;
   --kirby-badge-right: #{get-badge-position($diameter-small)};
   --kirby-badge-top: #{get-badge-position($diameter-small)};
-  --kirby-badge-z-index: #{utils.z('avatar-badge')};
+  --kirby-badge-z-index: var(--kirby-z-index-avatar-badge);
 
   position: relative;
 }
@@ -31,23 +31,23 @@ $badge-diameter: utils.$avatar-badge-size;
   // default to size 'sm'
   width: $diameter-small;
   height: $diameter-small;
-  border-radius: utils.border-radius('circle');
+  border-radius: var(--kirby-border-radius-circle);
   overflow: hidden;
   position: relative;
   z-index: 1;
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: utils.get-color('white');
-  color: utils.get-color('light-contrast');
+  background-color: var(--kirby-white);
+  color: var(--kirby-light-contrast);
 
   &.stroke {
-    border: 1px solid utils.get-color('semi-light');
+    border: 1px solid var(--kirby-semi-light);
   }
 
   &.overlay::before {
     content: '';
-    background-color: utils.get-color('black');
+    background-color: var(--kirby-black);
     opacity: 0.05;
     width: 100%;
     height: 100%;
@@ -73,7 +73,7 @@ $badge-diameter: utils.$avatar-badge-size;
     border-radius: 8px;
 
     .avatar-text {
-      font-size: utils.font-size('s');
+      font-size: var(--kirby-font-size-s);
     }
   }
 }
@@ -87,7 +87,7 @@ $badge-diameter: utils.$avatar-badge-size;
     height: $diameter-small;
 
     .avatar-text {
-      font-size: utils.font-size('s');
+      font-size: var(--kirby-font-size-s);
     }
   }
 }
@@ -104,7 +104,7 @@ $badge-diameter: utils.$avatar-badge-size;
     height: $diameter-medium;
 
     .avatar-text {
-      font-size: utils.font-size('m');
+      font-size: var(--kirby-font-size-m);
     }
   }
 }
@@ -121,16 +121,16 @@ $badge-diameter: utils.$avatar-badge-size;
     height: $diameter-large;
 
     .avatar-text {
-      font-size: utils.font-size('xl');
+      font-size: var(--kirby-font-size-xl);
     }
   }
 }
 
 :host-context(kirby-item)[slot='start'] {
-  margin-inline-end: utils.size('xs');
+  margin-inline-end: var(--kirby-spacing-xs);
 
   &.xs {
-    margin-inline-end: utils.size('s');
+    margin-inline-end: var(--kirby-spacing-s);
   }
 }
 

--- a/libs/designsystem/avatar/src/avatar.component.scss
+++ b/libs/designsystem/avatar/src/avatar.component.scss
@@ -38,8 +38,8 @@ $badge-diameter: utils.$avatar-badge-size;
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: var(--kirby-white);
-  color: var(--kirby-light-contrast);
+  background-color: var(--kirby-avatar-background-color, var(--kirby-white));
+  color: var(--kirby-avatar-color, var(--kirby-light-contrast));
 
   &.stroke {
     border: 1px solid var(--kirby-semi-light);
@@ -134,20 +134,68 @@ $badge-diameter: utils.$avatar-badge-size;
   }
 }
 
-@each $color-name,
-  $color-value
-    in map.merge(
-      utils.$main-colors,
-      (
-        'white': utils.get-color('white'),
-        'semi-light': utils.get-color('semi-light'),
-      )
-    )
-{
-  :host(.#{$color-name}) {
-    .avatar {
-      background-color: utils.get-color($color-name);
-      color: utils.get-color($color-name + '-contrast');
-    }
-  }
+// Colors
+:host(.primary) {
+  --kirby-avatar-background-color: var(--kirby-primary);
+  --kirby-avatar-color: var(--kirby-primary-contrast);
+}
+
+:host(.secondary) {
+  --kirby-avatar-background-color: var(--kirby-secondary);
+  --kirby-avatar-color: var(--kirby-secondary-contrast);
+}
+
+:host(.tertiary) {
+  --kirby-avatar-background-color: var(--kirby-tertiary);
+  --kirby-avatar-color: var(--kirby-tertiary-contrast);
+}
+
+:host(.success) {
+  --kirby-avatar-background-color: var(--kirby-success);
+  --kirby-avatar-color: var(--kirby-success-contrast);
+}
+
+:host(.warning) {
+  --kirby-avatar-background-color: var(--kirby-warning);
+  --kirby-avatar-color: var(--kirby-warning-contrast);
+}
+
+:host(.danger) {
+  --kirby-avatar-background-color: var(--kirby-danger);
+  --kirby-avatar-color: var(--kirby-danger-contrast);
+}
+
+:host(.white-overlay) {
+  --kirby-avatar-background-color: var(--kirby-white-overlay);
+  --kirby-avatar-color: var(--kirby-white-overlay-contrast);
+}
+
+:host(.light) {
+  --kirby-avatar-background-color: var(--kirby-light);
+  --kirby-avatar-color: var(--kirby-light-contrast);
+}
+
+:host(.medium) {
+  --kirby-avatar-background-color: var(--kirby-medium);
+  --kirby-avatar-color: var(--kirby-medium-contrast);
+}
+
+:host(.dark) {
+  --kirby-avatar-background-color: var(--kirby-dark);
+  --kirby-avatar-color: var(--kirby-dark-contrast);
+}
+
+:host(.dark-overlay) {
+  --kirby-avatar-background-color: var(--kirby-dark-overlay);
+  --kirby-avatar-color: var(--kirby-dark-overlay-contrast);
+}
+
+:host(.white) {
+  --kirby-avatar-background-color: var(--kirby-white);
+  --kirby-avatar-color: var(--kirby-white-contrast);
+}
+
+:host(.semi-light) {
+  --kirby-avatar-background-color: var(--kirby-semi-light);
+  --kirby-avatar-color: var(--kirby-semi-light-contrast);
 }

--- a/libs/designsystem/avatar/src/avatar.component.stories.ts
+++ b/libs/designsystem/avatar/src/avatar.component.stories.ts
@@ -49,6 +49,68 @@ export const Default: Story = {
   },
 };
 
+const officialColors = ['white', 'light'];
+const backwardsCompatibilityColors = [
+  'success',
+  'warning',
+  'danger',
+  'primary',
+  'secondary',
+  'tertiary',
+  'medium',
+  'dark',
+  'semi-light',
+];
+
+export const ColorVariants: Story = {
+  render: () => ({
+    props: { officialColors, backwardsCompatibilityColors },
+    template: `
+      <p class="kirby-text-normal">
+        Only <strong>white</strong> and <strong>light</strong> are officially supported color
+        variants (the ones that designers use). The remaining variants are kept for
+        backwards compatibility and should not be used in new designs.
+      </p>
+
+      <h2 class="kirby-text-normal-bold">Official support</h2>
+      <div class="color-grid">
+        @for (color of officialColors; track color) {
+          <div class="color-item">
+            <kirby-avatar [themeColor]="color" [stroke]="true" text="A" size="md"></kirby-avatar>
+            <span class="kirby-text-xsmall">{{ color }}</span>
+          </div>
+        }
+      </div>
+
+      <h2 class="kirby-text-normal-bold">Backwards compatibility</h2>
+      <div class="color-grid">
+        @for (color of backwardsCompatibilityColors; track color) {
+          <div class="color-item">
+            <kirby-avatar [themeColor]="color" text="A" size="md"></kirby-avatar>
+            <span class="kirby-text-xsmall">{{ color }}</span>
+          </div>
+        }
+      </div>
+    `,
+    styles: [
+      `
+      .color-grid {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--kirby-spacing-m);
+        margin-bottom: var(--kirby-spacing-m);
+      }
+      .color-item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--kirby-spacing-xxs);
+      }
+    `,
+    ],
+  }),
+};
+
 export const CookbookExamples: Story = {
   render: () => ({
     template: `<cookbook-avatar-example></cookbook-avatar-example>`,

--- a/libs/designsystem/badge/src/badge.component.scss
+++ b/libs/designsystem/badge/src/badge.component.scss
@@ -17,11 +17,11 @@ $maximum-font-size: 10px * utils.$text-resize-threshold;
   display: inline-flex;
 
   ion-badge {
-    --background: var(--kirby-badge-background-color, #{utils.get-color('white')});
-    --color: var(--kirby-badge-color, #{utils.get-color('white-contrast')});
+    --background: var(--kirby-badge-background-color, var(--kirby-white));
+    --color: var(--kirby-badge-color, var(--kirby-white-contrast));
 
     box-sizing: border-box; // Fixes https://github.com/kirbydesign/designsystem/issues/537
-    border-radius: utils.border-radius('pill');
+    border-radius: var(--kirby-border-radius-pill);
     font-size: inherit;
     position: relative;
     box-shadow: var(--kirby-badge-elevation, none);
@@ -31,42 +31,42 @@ $maximum-font-size: 10px * utils.$text-resize-threshold;
 
   // Colors
   &.success ion-badge {
-    --color: #{utils.get-color('success-contrast')};
+    --color: var(--kirby-success-contrast);
   }
 
   &.success.sm ion-badge {
-    --background: #{utils.get-color('success-shade')};
+    --background: var(--kirby-success-shade);
   }
 
   &.success.md ion-badge {
-    --background: #{utils.get-color('success-tint')};
+    --background: var(--kirby-success-tint);
   }
 
   &.warning ion-badge {
-    --color: #{utils.get-color('warning-contrast')};
+    --color: var(--kirby-warning-contrast);
   }
 
   &.warning.sm ion-badge {
-    --background: #{utils.get-color('warning-shade')};
+    --background: var(--kirby-warning-shade);
   }
 
   &.warning.md ion-badge {
-    --background: #{utils.get-color('warning')};
+    --background: var(--kirby-warning);
   }
 
   &.danger ion-badge {
-    --color: #{utils.get-text-color('white')};
+    --color: var(--kirby-text-color-white);
   }
 
   &.danger.sm ion-badge {
-    --background: #{utils.get-color('danger')};
+    --background: var(--kirby-danger);
   }
 
   &.danger.md ion-badge {
-    --background: #{utils.get-color('danger-shade')};
+    --background: var(--kirby-danger-shade);
 
     &:has(kirby-icon) {
-      --background: #{utils.get-color('danger')};
+      --background: var(--kirby-danger);
     }
   }
 }

--- a/libs/designsystem/button/src/button.component.integration.spec.ts
+++ b/libs/designsystem/button/src/button.component.integration.spec.ts
@@ -114,6 +114,7 @@ describe('ButtonComponent in Kirby Page', () => {
     it('should render with correct size', async () => {
       await TestHelper.whenReady(ionToolbar);
       expect(actionButtonInHeader).toHaveComputedStyle({
+        width: '>=88px', // A text button is content-sized (min-width 88px)
         height: size('xl'),
       });
       expect(actionButtonInHeaderIconOnly).toHaveComputedStyle({

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -1,5 +1,4 @@
 @use 'sass:map';
-@use 'sass:meta';
 
 @use '@kirbydesign/core/src/scss/interaction-state';
 @use '@kirbydesign/core/src/scss/utils';

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -35,7 +35,7 @@ $button-margin: var(--kirby-spacing-xxxs);
 
     // use fixed size unless font-size grows too large, then let button
     // height adjust to font-size (effectively when text is resized to 150% and above)
-    height: max($button-xs-icon-only-size, utils.relative-size('s'));
+    height: max($button-xs-icon-only-size, var(--kirby-relative-spacing-s));
     min-width: button-width('xs');
   }
 
@@ -47,7 +47,7 @@ $button-margin: var(--kirby-spacing-xxxs);
   &.icon-only {
     // use fixed size unless font-size grows too large, then let button
     // height adjust to font-size (effectively when text is resized to 150% and above)
-    width: max($button-xs-icon-only-size, utils.relative-size('s'));
+    width: max($button-xs-icon-only-size, var(--kirby-relative-spacing-s));
     min-width: unset;
   }
 
@@ -381,14 +381,24 @@ $button-margin: var(--kirby-spacing-xxxs);
 /* clean-css ignore:end */
 
 :host-context(kirby-toggle-button) {
-  @each $color-name, $color-value in utils.$notification-colors {
-    &.#{$color-name} {
-      --kirby-button-background-color: #{utils.get-color($color-name)};
-      --kirby-button-color: #{utils.get-color($color-name + '-contrast')};
+  &.success {
+    --kirby-button-background-color: var(--kirby-success);
+    --kirby-button-color: var(--kirby-success-contrast);
+  }
 
-      @include interaction-state.apply-hover;
-      @include interaction-state.apply-active('s');
-    }
+  &.warning {
+    --kirby-button-background-color: var(--kirby-warning);
+    --kirby-button-color: var(--kirby-warning-contrast);
+  }
+
+  &.danger {
+    --kirby-button-background-color: var(--kirby-danger);
+    --kirby-button-color: var(--kirby-danger-contrast);
+  }
+
+  &:is(.success, .warning, .danger) {
+    @include interaction-state.apply-hover;
+    @include interaction-state.apply-active('s');
   }
 }
 

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -10,6 +10,8 @@ $button-width: (
   md: 88px,
   lg: 220px,
 ) !default;
+
+// TODO(@kirby): migrate utils.size('xxxs') — $button-margin feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
 $button-margin: utils.size('xxxs');
 
 @function button-width($key) {
@@ -22,6 +24,7 @@ $button-margin: utils.size('xxxs');
   * interactive elements. The maximum target size we can safely do is the button's
   * minimum width plus its margin on each side
   */
+  // TODO(@kirby): migrate utils.size('m') — $button-xs-icon-only-size feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
   $button-xs-icon-only-size: utils.size('m');
   $button-xs-click-area-size: $button-xs-icon-only-size + $button-margin * 2;
   @include utils.accessible-target-size($width: $button-xs-click-area-size);
@@ -29,9 +32,9 @@ $button-margin: utils.size('xxxs');
   // Wrap declarations to avoid mixing with nested rules.
   // See: https://sass-lang.com/documentation/breaking-changes/mixed-decls/
   & {
-    --kirby-icon-font-size: #{utils.icon-font-size('xs')};
+    --kirby-icon-font-size: var(--kirby-icon-font-size-xs);
 
-    font-size: utils.font-size('xs');
+    font-size: var(--kirby-font-size-xs);
 
     // use fixed size unless font-size grows too large, then let button
     // height adjust to font-size (effectively when text is resized to 150% and above)
@@ -40,8 +43,8 @@ $button-margin: utils.size('xxxs');
   }
 
   &:not(.icon-only) {
-    --kirby-button-padding-left: #{utils.size('xs')};
-    --kirby-button-padding-right: #{utils.size('xs')};
+    --kirby-button-padding-left: var(--kirby-spacing-xs);
+    --kirby-button-padding-right: var(--kirby-spacing-xs);
   }
 
   &.icon-only {
@@ -52,13 +55,13 @@ $button-margin: utils.size('xxxs');
   }
 
   &.icon-left {
-    --kirby-button-padding-left: #{utils.size('xxs')};
-    --kirby-icon-margin-right: #{utils.size('xxxs')};
+    --kirby-button-padding-left: var(--kirby-spacing-xxs);
+    --kirby-icon-margin-right: var(--kirby-spacing-xxxs);
   }
 
   &.icon-right {
-    --kirby-button-padding-right: #{utils.size('xxs')};
-    --kirby-icon-margin-left: #{utils.size('xxxs')};
+    --kirby-button-padding-right: var(--kirby-spacing-xxs);
+    --kirby-icon-margin-left: var(--kirby-spacing-xxxs);
   }
 
   &.icon-left,
@@ -68,28 +71,28 @@ $button-margin: utils.size('xxxs');
 }
 
 @mixin button-sm {
-  --kirby-icon-font-size: #{utils.size('s')};
+  --kirby-icon-font-size: var(--kirby-spacing-s);
 
-  font-size: utils.font-size('xs');
-  height: utils.size('l');
+  font-size: var(--kirby-font-size-xs);
+  height: var(--kirby-spacing-l);
   min-width: button-width('sm');
 
   &:not(.icon-only) {
-    --kirby-button-padding-left: #{utils.size('s')};
-    --kirby-button-padding-right: #{utils.size('s')};
+    --kirby-button-padding-left: var(--kirby-spacing-s);
+    --kirby-button-padding-right: var(--kirby-spacing-s);
   }
 
   &.icon-only {
-    width: utils.size('l');
+    width: var(--kirby-spacing-l);
     min-width: unset;
   }
 
   &.icon-left {
-    --kirby-button-padding-left: #{utils.size('xs')};
+    --kirby-button-padding-left: var(--kirby-spacing-xs);
   }
 
   &.icon-right {
-    --kirby-button-padding-right: #{utils.size('xs')};
+    --kirby-button-padding-right: var(--kirby-spacing-xs);
   }
 
   &.icon-left,
@@ -99,39 +102,39 @@ $button-margin: utils.size('xxxs');
 }
 
 @mixin button-lg {
-  font-size: utils.font-size('n');
-  height: utils.size('xxl');
+  font-size: var(--kirby-font-size-n);
+  height: var(--kirby-spacing-xxl);
   min-width: button-width('lg');
 
   &.icon-only {
-    width: utils.size('xxl');
+    width: var(--kirby-spacing-xxl);
     min-width: unset;
   }
 }
 
 @mixin button-no-decoration {
   --kirby-button-background-color: transparent;
-  --kirby-button-color: #{utils.get-color('black')};
+  --kirby-button-color: var(--kirby-black);
 
   @include interaction-state.apply-hover;
   @include interaction-state.apply-active('s');
 }
 
 @mixin button-attentionlevel1 {
-  --kirby-button-background-color: #{utils.get-color('primary')};
-  --kirby-button-color: #{utils.get-color('primary-contrast')};
+  --kirby-button-background-color: var(--kirby-primary);
+  --kirby-button-color: var(--kirby-primary-contrast);
 
   // The destructive class is only ever applied by kirby-alert.
   // Standalone destructive buttons are not a supported concept.
   &.destructive {
-    --kirby-button-background-color: #{utils.get-color('danger')};
-    --kirby-button-color: #{utils.get-color('danger-contrast')};
+    --kirby-button-background-color: var(--kirby-danger);
+    --kirby-button-color: var(--kirby-danger-contrast);
   }
 }
 
 @mixin button-attentionlevel2 {
-  --kirby-button-background-color: #{utils.get-color('black')};
-  --kirby-button-color: #{utils.get-color('black-contrast')};
+  --kirby-button-background-color: var(--kirby-black);
+  --kirby-button-color: var(--kirby-black-contrast);
 
   @include interaction-state.apply-hover('s', $make-lighter: true);
   @include interaction-state.apply-active('m', $make-lighter: true);
@@ -146,8 +149,8 @@ $button-margin: utils.size('xxxs');
 }
 
 :host {
-  --kirby-button-padding-left: #{utils.size('m')};
-  --kirby-button-padding-right: #{utils.size('m')};
+  --kirby-button-padding-left: var(--kirby-spacing-m);
+  --kirby-button-padding-right: var(--kirby-spacing-m);
 
   flex-shrink: 0;
 
@@ -177,7 +180,7 @@ $button-margin: utils.size('xxxs');
     font-family: var(--kirby-font-family);
     background-color: var(--kirby-button-background-color, initial);
     color: var(--kirby-button-color, inherit);
-    border-radius: utils.border-radius('pill');
+    border-radius: var(--kirby-border-radius-pill);
     box-sizing: border-box; // Ensure border is not added to button height
     display: inline-flex;
     flex-direction: row;
@@ -188,8 +191,8 @@ $button-margin: utils.size('xxxs');
     white-space: nowrap;
 
     // we default to 'md' size.
-    font-size: utils.font-size('s');
-    height: utils.size('xl');
+    font-size: var(--kirby-font-size-s);
+    height: var(--kirby-spacing-xl);
     min-width: button-width('md');
     padding: 0;
     margin: $button-margin;
@@ -206,17 +209,17 @@ $button-margin: utils.size('xxxs');
   }
 
   &.icon-left {
-    --kirby-icon-margin-right: #{utils.size('xxs')};
-    --kirby-button-padding-left: #{utils.size('xs')};
-    --kirby-button-padding-right: #{utils.size('s')};
+    --kirby-icon-margin-right: var(--kirby-spacing-xxs);
+    --kirby-button-padding-left: var(--kirby-spacing-xs);
+    --kirby-button-padding-right: var(--kirby-spacing-s);
 
     padding: 0;
   }
 
   &.icon-right {
-    --kirby-icon-margin-left: #{utils.size('xxs')};
-    --kirby-button-padding-left: #{utils.size('s')};
-    --kirby-button-padding-right: #{utils.size('xs')};
+    --kirby-icon-margin-left: var(--kirby-spacing-xxs);
+    --kirby-button-padding-left: var(--kirby-spacing-s);
+    --kirby-button-padding-right: var(--kirby-spacing-xs);
 
     padding: 0;
   }
@@ -225,7 +228,7 @@ $button-margin: utils.size('xxxs');
     --kirby-button-padding-left: 0;
     --kirby-button-padding-right: 0;
 
-    width: utils.size('xl');
+    width: var(--kirby-spacing-xl);
     padding: 0;
     min-width: unset;
 
@@ -275,12 +278,12 @@ $button-margin: utils.size('xxxs');
 
   &:disabled,
   &[aria-disabled='true'] {
-    color: utils.get-color('semi-dark-shade');
+    color: var(--kirby-semi-dark-shade);
     border-color: transparent;
     pointer-events: none;
 
     &:not(.no-decoration) {
-      background-color: utils.get-color('semi-light');
+      background-color: var(--kirby-semi-light);
     }
   }
 
@@ -292,7 +295,7 @@ $button-margin: utils.size('xxxs');
     min-width: unset;
 
     &:not(:disabled) {
-      box-shadow: utils.get-elevation(8);
+      box-shadow: var(--kirby-elevation-8);
     }
   }
 }
@@ -303,15 +306,15 @@ $button-margin: utils.size('xxxs');
 
 :host-context(.kirby-color-brightness-dark) {
   &.no-decoration {
-    --kirby-button-color: #{utils.get-color('white')};
+    --kirby-button-color: var(--kirby-white);
 
     @include interaction-state.apply-hover('xs', $make-lighter: true);
     @include interaction-state.apply-active('m', $make-lighter: true);
   }
 
   &.attention-level2 {
-    --kirby-button-background-color: #{utils.get-color('white')};
-    --kirby-button-color: #{utils.get-color('white-contrast')};
+    --kirby-button-background-color: var(--kirby-white);
+    --kirby-button-color: var(--kirby-white-contrast);
 
     @include interaction-state.apply-hover;
     @include interaction-state.apply-active('s');
@@ -324,7 +327,7 @@ $button-margin: utils.size('xxxs');
 }
 
 :host-context(kirby-item)[slot='end'] {
-  margin-inline: utils.size('s') 0;
+  margin-inline: var(--kirby-spacing-s) 0;
 }
 
 :host-context(kirby-dropdown) {
@@ -340,11 +343,11 @@ $button-margin: utils.size('xxxs');
 
 /* clean-css ignore:start */
 :host-context(ion-toolbar ion-buttons.legacy-actions) {
-  font-size: utils.font-size('s');
-  height: utils.size('xl');
+  font-size: var(--kirby-font-size-s);
+  height: var(--kirby-spacing-xl);
 
   &.icon-only {
-    width: utils.size('xl');
+    width: var(--kirby-spacing-xl);
 
     &.no-decoration,
     &.attention-level1,

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -10,9 +10,7 @@ $button-width: (
   md: 88px,
   lg: 220px,
 ) !default;
-
-// TODO(@kirby): migrate utils.size('xxxs') — $button-margin feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
-$button-margin: utils.size('xxxs');
+$button-margin: var(--kirby-spacing-xxxs);
 
 @function button-width($key) {
   @return map.get($button-width, $key);
@@ -24,9 +22,8 @@ $button-margin: utils.size('xxxs');
   * interactive elements. The maximum target size we can safely do is the button's
   * minimum width plus its margin on each side
   */
-  // TODO(@kirby): migrate utils.size('m') — $button-xs-icon-only-size feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
-  $button-xs-icon-only-size: utils.size('m');
-  $button-xs-click-area-size: $button-xs-icon-only-size + $button-margin * 2;
+  $button-xs-icon-only-size: var(--kirby-spacing-m);
+  $button-xs-click-area-size: calc(#{$button-xs-icon-only-size} + #{$button-margin} * 2);
   @include utils.accessible-target-size($width: $button-xs-click-area-size);
 
   // Wrap declarations to avoid mixing with nested rules.

--- a/libs/designsystem/button/src/button.component.scss
+++ b/libs/designsystem/button/src/button.component.scss
@@ -34,7 +34,7 @@ $button-margin: var(--kirby-spacing-xxxs);
 
     // use fixed size unless font-size grows too large, then let button
     // height adjust to font-size (effectively when text is resized to 150% and above)
-    height: max($button-xs-icon-only-size, var(--kirby-relative-spacing-s));
+    height: max($button-xs-icon-only-size, var(--kirby-relative-size-s));
     min-width: button-width('xs');
   }
 
@@ -46,7 +46,7 @@ $button-margin: var(--kirby-spacing-xxxs);
   &.icon-only {
     // use fixed size unless font-size grows too large, then let button
     // height adjust to font-size (effectively when text is resized to 150% and above)
-    width: max($button-xs-icon-only-size, var(--kirby-relative-spacing-s));
+    width: max($button-xs-icon-only-size, var(--kirby-relative-size-s));
     min-width: unset;
   }
 

--- a/libs/designsystem/calendar/src/calendar.component.scss
+++ b/libs/designsystem/calendar/src/calendar.component.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/interaction-state';
-
 $month-navigator-width: 80px;
 
 :host {

--- a/libs/designsystem/calendar/src/calendar.component.scss
+++ b/libs/designsystem/calendar/src/calendar.component.scss
@@ -4,14 +4,14 @@
 $month-navigator-width: 80px;
 
 :host {
-  font-size: utils.font-size('n');
+  font-size: var(--kirby-font-size-n);
 }
 
 table {
   width: 100%;
   border-collapse: collapse;
   user-select: none;
-  margin-bottom: utils.size('xxs');
+  margin-bottom: var(--kirby-spacing-xxs);
 }
 
 th,
@@ -20,17 +20,17 @@ td {
   padding: 0;
 
   &:first-child {
-    padding-left: utils.size('xxs');
+    padding-left: var(--kirby-spacing-xxs);
   }
 
   &:last-child {
-    padding-right: utils.size('xxs');
+    padding-right: var(--kirby-spacing-xxs);
   }
 }
 
 th {
   height: 50px;
-  border-bottom: 1px solid utils.get-color('background-color');
+  border-bottom: 1px solid var(--kirby-background-color);
 }
 
 .header,
@@ -42,7 +42,7 @@ td {
 .header {
   display: flex;
   justify-content: space-between;
-  margin: utils.size('xxs');
+  margin: var(--kirby-spacing-xxs);
   margin-bottom: 0;
 }
 
@@ -55,10 +55,10 @@ td {
 
 .month-and-year {
   user-select: none;
-  font-weight: utils.font-weight('bold');
+  font-weight: var(--kirby-font-weight-bold);
 
   .month {
-    margin-right: utils.size('xxs');
+    margin-right: var(--kirby-spacing-xxs);
   }
 }
 
@@ -69,7 +69,7 @@ td {
 
   .month-and-year {
     width: $month-navigator-width;
-    margin: 0 utils.size('xxs');
+    margin: 0 var(--kirby-spacing-xxs);
     text-align: center;
   }
 
@@ -79,6 +79,7 @@ td {
 }
 
 .day {
+  // TODO(@kirby): migrate utils.size('xl') — $day-width feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
   $day-width: utils.size('xl');
 
   display: inline-flex;
@@ -89,12 +90,12 @@ td {
   min-height: $day-width;
   width: $day-width;
   height: $day-width;
-  margin: utils.size('xxxs') 0;
-  font-size: utils.font-size('n');
+  margin: var(--kirby-spacing-xxxs) 0;
+  font-size: var(--kirby-font-size-n);
 
   &:focus {
     // In narrow viewports where buttons sit side-by-side, ensure focus ring is on top of adjacent buttons.
-    z-index: utils.z('default');
+    z-index: var(--kirby-z-index-default);
   }
 }
 
@@ -104,14 +105,14 @@ button[aria-disabled='true'] {
 }
 
 .day.selectable:not(.current-month, .selected) {
-  color: #{utils.get-text-color('semi-dark')};
+  color: var(--kirby-text-color-semi-dark);
 }
 
 .day.today {
-  border: 1px solid utils.get-color('semi-dark');
+  border: 1px solid var(--kirby-semi-dark);
 }
 
 .day.selected {
-  color: utils.get-color('black-contrast');
-  background-color: utils.get-color('black');
+  color: var(--kirby-black-contrast);
+  background-color: var(--kirby-black);
 }

--- a/libs/designsystem/calendar/src/calendar.component.scss
+++ b/libs/designsystem/calendar/src/calendar.component.scss
@@ -1,5 +1,4 @@
 @use '@kirbydesign/core/src/scss/interaction-state';
-@use '@kirbydesign/core/src/scss/utils';
 
 $month-navigator-width: 80px;
 
@@ -79,13 +78,12 @@ td {
 }
 
 .day {
-  // TODO(@kirby): migrate utils.size('xl') — $day-width feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
-  $day-width: utils.size('xl');
+  $day-width: var(--kirby-spacing-xl);
 
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: $day-width * 0.5;
+  border-radius: calc(#{$day-width} * 0.5);
   min-width: $day-width;
   min-height: $day-width;
   width: $day-width;

--- a/libs/designsystem/card/src/card-footer/card-footer.component.scss
+++ b/libs/designsystem/card/src/card-footer/card-footer.component.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 :host {
   display: block;
   padding: var(--kirby-spacing-s);

--- a/libs/designsystem/card/src/card-footer/card-footer.component.scss
+++ b/libs/designsystem/card/src/card-footer/card-footer.component.scss
@@ -2,7 +2,7 @@
 
 :host {
   display: block;
-  padding: utils.size('s');
+  padding: var(--kirby-spacing-s);
   padding: 0;
   border-bottom-left-radius: inherit;
   border-bottom-right-radius: inherit;
@@ -14,7 +14,7 @@
   transform: translate3d(0, 0, 0);
 
   &.has-padding {
-    padding: utils.size('s');
+    padding: var(--kirby-spacing-s);
   }
 }
 

--- a/libs/designsystem/card/src/card-header/card-header.component.scss
+++ b/libs/designsystem/card/src/card-header/card-header.component.scss
@@ -12,54 +12,54 @@
   line-height: normal;
 
   &.has-padding {
-    padding: var(--kirby-internal-card-header-padding, utils.size('s'));
+    padding: var(--kirby-internal-card-header-padding, var(--kirby-spacing-s));
   }
 
   // Flagged card headers
   &.success {
-    --kirby-card-header-background-color: #{utils.get-color('success-tint')};
+    --kirby-card-header-background-color: var(--kirby-success-tint);
   }
 
   &.warning {
-    --kirby-card-header-background-color: #{utils.get-color('warning-tint')};
+    --kirby-card-header-background-color: var(--kirby-warning-tint);
   }
 
   &.danger {
-    --kirby-card-header-background-color: #{utils.get-color('danger-tint')};
+    --kirby-card-header-background-color: var(--kirby-danger-tint);
   }
 
   &.info {
-    --kirby-card-header-background-color: #{utils.get-color('semi-light')};
+    --kirby-card-header-background-color: var(--kirby-semi-light);
   }
 
-  --kirby-card-header-color: #{utils.get-color('black')};
+  --kirby-card-header-color: var(--kirby-black);
 }
 
 .title {
-  margin-bottom: var(--kirby-internal-card-header-margin-bottom, utils.size('s'));
+  margin-bottom: var(--kirby-internal-card-header-margin-bottom, var(--kirby-spacing-s));
   line-height: var(--kirby-internal-card-header-line-height);
 
   &.bold {
-    font-weight: utils.font-weight('bold');
+    font-weight: var(--kirby-font-weight-bold);
   }
 }
 
 .subtitle {
-  font-size: utils.font-size('s');
+  font-size: var(--kirby-font-size-s);
   margin-bottom: 0;
 }
 
 :host:has(.subtitle) .title {
-  margin-top: utils.size(
-    'xxxs'
+  margin-top: var(
+    --kirby-spacing-xxxs
   ); // when subtitle is present, we want a bit more spacious look, therefore top margin here
 }
 
 :host(.flagged) {
-  --kirby-internal-card-header-padding: #{utils.size('xxxxs')} #{utils.size('xxs')};
+  --kirby-internal-card-header-padding: var(--kirby-spacing-xxxxs) var(--kirby-spacing-xxs);
 
   p {
-    --kirby-internal-card-header-line-height: #{utils.line-height('n')};
+    --kirby-internal-card-header-line-height: var(--kirby-line-height-n);
     --kirby-internal-card-header-margin-bottom: 0px;
   }
 }

--- a/libs/designsystem/card/src/card-header/card-header.component.scss
+++ b/libs/designsystem/card/src/card-header/card-header.component.scss
@@ -1,6 +1,3 @@
-@use 'sass:meta';
-@use '@kirbydesign/core/src/scss/utils';
-
 :host {
   display: block;
   border-top-left-radius: var(--kirby-border-radius-n);

--- a/libs/designsystem/card/src/card.component.scss
+++ b/libs/designsystem/card/src/card.component.scss
@@ -131,9 +131,59 @@ $default-border-outline: 1px solid var(--kirby-medium);
   height: 100%;
 }
 
-@each $color-name, $color-value in utils.$main-colors {
-  :host(.#{$color-name}):not(.outlined) {
-    --kirby-card-main-background-color: #{utils.get-color($color-name)};
-    --kirby-card-main-color: #{utils.get-color($color-name + '-contrast')};
+:host(:not(.outlined)) {
+  &.primary {
+    --kirby-card-main-background-color: var(--kirby-primary);
+    --kirby-card-main-color: var(--kirby-primary-contrast);
+  }
+
+  &.secondary {
+    --kirby-card-main-background-color: var(--kirby-secondary);
+    --kirby-card-main-color: var(--kirby-secondary-contrast);
+  }
+
+  &.tertiary {
+    --kirby-card-main-background-color: var(--kirby-tertiary);
+    --kirby-card-main-color: var(--kirby-tertiary-contrast);
+  }
+
+  &.success {
+    --kirby-card-main-background-color: var(--kirby-success);
+    --kirby-card-main-color: var(--kirby-success-contrast);
+  }
+
+  &.warning {
+    --kirby-card-main-background-color: var(--kirby-warning);
+    --kirby-card-main-color: var(--kirby-warning-contrast);
+  }
+
+  &.danger {
+    --kirby-card-main-background-color: var(--kirby-danger);
+    --kirby-card-main-color: var(--kirby-danger-contrast);
+  }
+
+  &.white-overlay {
+    --kirby-card-main-background-color: var(--kirby-white-overlay);
+    --kirby-card-main-color: var(--kirby-white-overlay-contrast);
+  }
+
+  &.light {
+    --kirby-card-main-background-color: var(--kirby-light);
+    --kirby-card-main-color: var(--kirby-light-contrast);
+  }
+
+  &.medium {
+    --kirby-card-main-background-color: var(--kirby-medium);
+    --kirby-card-main-color: var(--kirby-medium-contrast);
+  }
+
+  &.dark {
+    --kirby-card-main-background-color: var(--kirby-dark);
+    --kirby-card-main-color: var(--kirby-dark-contrast);
+  }
+
+  &.dark-overlay {
+    --kirby-card-main-background-color: var(--kirby-dark-overlay);
+    --kirby-card-main-color: var(--kirby-dark-overlay-contrast);
   }
 }

--- a/libs/designsystem/card/src/card.component.scss
+++ b/libs/designsystem/card/src/card.component.scss
@@ -2,13 +2,13 @@
 @use '@kirbydesign/core/src/scss/utils';
 @use '@kirbydesign/core/src/scss/themes';
 
-$default-border-outline: 1px solid utils.get-color('medium');
+$default-border-outline: 1px solid var(--kirby-medium);
 
 :host {
-  --kirby-card-main-background-color: #{utils.get-color('white')};
-  --kirby-card-main-color: #{utils.get-color('white-contrast')};
-  --kirby-card-footer-background-color: #{utils.get-color('white')};
-  --kirby-card-footer-color: #{utils.get-color('white-contrast')};
+  --kirby-card-main-background-color: var(--kirby-white);
+  --kirby-card-main-color: var(--kirby-white-contrast);
+  --kirby-card-footer-background-color: var(--kirby-white);
+  --kirby-card-footer-color: var(--kirby-white-contrast);
 
   @include themes.apply-white-theme;
 
@@ -35,8 +35,8 @@ $default-border-outline: 1px solid utils.get-color('medium');
   // See: https://sass-lang.com/documentation/breaking-changes/mixed-decls/
   /* stylelint-disable no-duplicate-selectors */
   & {
-    border-radius: utils.border-radius('n');
-    box-shadow: utils.get-elevation(2);
+    border-radius: var(--kirby-border-radius-n);
+    box-shadow: var(--kirby-elevation-2);
     color: var(--kirby-card-main-color);
     background-color: var(--kirby-card-main-background-color);
     background-image: var(--kirby-card-background-image);
@@ -49,7 +49,7 @@ $default-border-outline: 1px solid utils.get-color('medium');
     justify-content: space-between;
     overflow: hidden;
     position: relative;
-    z-index: utils.z('default');
+    z-index: var(--kirby-z-index-default);
     width: var(--kirby-card-width, auto);
   }
   /* stylelint-enable no-duplicate-selectors */
@@ -70,8 +70,8 @@ $default-border-outline: 1px solid utils.get-color('medium');
         border-block-end: var(--kirby-card-border, $default-border-outline);
         border-inline-start: var(--kirby-card-border, $default-border-outline);
         border-inline-end: var(--kirby-card-border, $default-border-outline);
-        border-bottom-left-radius: utils.border-radius('n');
-        border-bottom-right-radius: utils.border-radius('n');
+        border-bottom-left-radius: var(--kirby-border-radius-n);
+        border-bottom-right-radius: var(--kirby-border-radius-n);
       }
     }
   }
@@ -83,7 +83,7 @@ $default-border-outline: 1px solid utils.get-color('medium');
 
     &:focus-visible {
       transition: interaction-state.transition();
-      box-shadow: utils.get-elevation(2), var(--kirby-focus-ring-md-inset);
+      box-shadow: var(--kirby-elevation-2), var(--kirby-focus-ring-md-inset);
     }
 
     // Wrap declarations to avoid mixing with nested rules.
@@ -109,9 +109,9 @@ $default-border-outline: 1px solid utils.get-color('medium');
   }
 
   &.padding {
-    padding-top: var(--kirby-card-padding-top, utils.size('s'));
-    padding-bottom: var(--kirby-card-padding-bottom, utils.size('s'));
-    padding-inline: utils.size('s');
+    padding-top: var(--kirby-card-padding-top, var(--kirby-spacing-s));
+    padding-bottom: var(--kirby-card-padding-bottom, var(--kirby-spacing-s));
+    padding-inline: var(--kirby-spacing-s);
   }
 }
 

--- a/libs/designsystem/checkbox/src/checkbox.component.scss
+++ b/libs/designsystem/checkbox/src/checkbox.component.scss
@@ -99,7 +99,7 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
   &.xs {
     ion-checkbox::part(label) {
       line-height: var(
-        --kirby-relative-spacing-s
+        --kirby-relative-size-s
       ); // using relative spacing as we want line-height to be exactly 1 rem
 
       font-size: var(--kirby-font-size-s);
@@ -121,7 +121,7 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
        * We style the native wrapper to make sure it has the same height as the container
        * so the checkbox can be properly start-aligned with multiline labels
        */
-        height: var(--kirby-relative-spacing-s);
+        height: var(--kirby-relative-size-s);
       }
     }
   }
@@ -190,7 +190,7 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
        * We style the native wrapper to make sure it has the same height as the container
        * so the checkbox can be properly start-aligned with multiline labels
        */
-      height: var(--kirby-relative-spacing-m);
+      height: var(--kirby-relative-size-m);
     }
 
     // Overrides for kirby-checkbox inside kirby-item

--- a/libs/designsystem/checkbox/src/checkbox.component.scss
+++ b/libs/designsystem/checkbox/src/checkbox.component.scss
@@ -12,9 +12,9 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
   display: flex;
 
   &.attention-level1 ion-checkbox {
-    --checkmark-color: #{utils.get-color('black')};
-    --checkbox-background-checked: #{utils.get-color('success')};
-    --border-color-checked: #{utils.get-color('success')};
+    --checkmark-color: var(--kirby-black);
+    --checkbox-background-checked: var(--kirby-success);
+    --border-color-checked: var(--kirby-success);
 
     @include interaction-state.apply-hover {
       --checkbox-background-checked: #{interaction-state.get-state-color('success', 's')};
@@ -27,9 +27,9 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
   }
 
   &.attention-level2 ion-checkbox {
-    --checkmark-color: #{utils.get-color('white')};
-    --checkbox-background-checked: #{utils.get-color('black')};
-    --border-color-checked: #{utils.get-color('black')};
+    --checkmark-color: var(--kirby-white);
+    --checkbox-background-checked: var(--kirby-black);
+    --border-color-checked: var(--kirby-black);
 
     @include interaction-state.apply-hover {
       --checkbox-background-checked: #{interaction-state.get-state-color(
@@ -59,18 +59,18 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
   }
 
   &.error ion-checkbox {
-    --border-color: #{utils.get-color('danger')};
+    --border-color: var(--kirby-danger);
   }
 
   &[disabled] {
-    color: #{utils.get-text-color('semi-dark')};
+    color: var(--kirby-text-color-semi-dark);
 
     ion-checkbox {
-      --checkmark-color: #{utils.get-color('semi-dark')};
-      --checkbox-background: #{utils.get-color('semi-light')};
-      --checkbox-background-checked: #{utils.get-color('semi-light')};
-      --border-color: #{utils.get-color('medium')};
-      --border-color-checked: #{utils.get-color('medium')};
+      --checkmark-color: var(--kirby-semi-dark);
+      --checkbox-background: var(--kirby-semi-light);
+      --checkbox-background-checked: var(--kirby-semi-light);
+      --border-color: var(--kirby-medium);
+      --border-color-checked: var(--kirby-medium);
 
       &::part(label-text-wrapper) {
         opacity: 1; // Reset Ionic disabled style
@@ -102,13 +102,13 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
         's'
       ); // using relative spacing as we want line-height to be exactly 1 rem
 
-      font-size: utils.font-size('s');
+      font-size: var(--kirby-font-size-s);
     }
 
     ion-checkbox {
       --size: #{$checkbox-icon-size-xs};
-      --border-radius: #{utils.size('xxxs')};
-      --kirby-checkbox-container-padding: #{utils.size('xxxxs')};
+      --border-radius: var(--kirby-spacing-xxxs);
+      --kirby-checkbox-container-padding: var(--kirby-spacing-xxxxs);
 
       &::part(container) {
         padding: var(
@@ -159,11 +159,11 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
         border-color #{interaction-state.$default-transition-duration} linear,
         background-color #{interaction-state.$default-transition-duration} linear;
       --size: #{$checkbox-icon-size};
-      --checkmark-width: #{utils.size('xxxs')};
-      --kirby-checkbox-container-padding: #{utils.size('xxxs')};
-      --checkbox-background: #{utils.get-color('white')};
+      --checkmark-width: var(--kirby-spacing-xxxs);
+      --kirby-checkbox-container-padding: var(--kirby-spacing-xxxs);
+      --checkbox-background: var(--kirby-white);
       --border-width: 1px;
-      --border-color: #{utils.get-color('semi-dark')};
+      --border-color: var(--kirby-semi-dark);
       --border-radius: #{$border-radius};
     }
     /* stylelint-enable no-duplicate-selectors */
@@ -177,7 +177,7 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
     &::part(label) {
       align-items: start;
       padding-inline: $spacing-to-edge;
-      line-height: utils.line-height('n');
+      line-height: var(--kirby-line-height-n);
     }
 
     &::part(label-text-wrapper) {
@@ -249,7 +249,7 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
   }
 
   :host-context(kirby-item) {
-    z-index: utils.z('default'); // Makes whole kirby-item clickable above item-inner.
+    z-index: var(--kirby-z-index-default); // Makes whole kirby-item clickable above item-inner.
 
     ion-checkbox {
       margin: 0;

--- a/libs/designsystem/checkbox/src/checkbox.component.scss
+++ b/libs/designsystem/checkbox/src/checkbox.component.scss
@@ -98,8 +98,8 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
 
   &.xs {
     ion-checkbox::part(label) {
-      line-height: utils.relative-size(
-        's'
+      line-height: var(
+        --kirby-relative-spacing-s
       ); // using relative spacing as we want line-height to be exactly 1 rem
 
       font-size: var(--kirby-font-size-s);
@@ -121,7 +121,7 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
        * We style the native wrapper to make sure it has the same height as the container
        * so the checkbox can be properly start-aligned with multiline labels
        */
-        height: utils.relative-size('s');
+        height: var(--kirby-relative-spacing-s);
       }
     }
   }
@@ -190,7 +190,7 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
        * We style the native wrapper to make sure it has the same height as the container
        * so the checkbox can be properly start-aligned with multiline labels
        */
-      height: utils.relative-size('m');
+      height: var(--kirby-relative-spacing-m);
     }
 
     // Overrides for kirby-checkbox inside kirby-item

--- a/libs/designsystem/divider/src/divider.component.scss
+++ b/libs/designsystem/divider/src/divider.component.scss
@@ -1,10 +1,10 @@
 @use '@kirbydesign/core/src/scss/utils';
 
 hr {
-  margin-top: utils.size('xxs');
-  margin-bottom: utils.size('xxs');
+  margin-top: var(--kirby-spacing-xxs);
+  margin-bottom: var(--kirby-spacing-xxs);
   border: 0;
-  border-top: 1px solid var(--kirby-divider-color, utils.get-color('medium'));
+  border-top: 1px solid var(--kirby-divider-color, var(--kirby-medium));
 
   &.no-margin {
     margin-top: 0;

--- a/libs/designsystem/divider/src/divider.component.scss
+++ b/libs/designsystem/divider/src/divider.component.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 hr {
   margin-top: var(--kirby-spacing-xxs);
   margin-bottom: var(--kirby-spacing-xxs);

--- a/libs/designsystem/dropdown/src/dropdown.component.scss
+++ b/libs/designsystem/dropdown/src/dropdown.component.scss
@@ -2,6 +2,8 @@
 @use '@kirbydesign/core/src/scss/utils';
 
 $dropdown-max-height: 8 * utils.$dropdown-item-height;
+
+// TODO(@kirby): migrate utils.size('s') — $margin-horizontal-total feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
 $margin-horizontal-total: 2 * utils.size('s');
 $min-screen-width-small: 320px;
 $min-screen-width: 375px;
@@ -11,7 +13,7 @@ $min-screen-width: 375px;
     transition: interaction-state.transition();
     box-shadow: var(--kirby-focus-ring-md-inset);
     outline: none;
-    border-radius: utils.border-radius('pill');
+    border-radius: var(--kirby-border-radius-pill);
   }
 
   // Wrap declarations to avoid mixing with nested rules.
@@ -41,7 +43,7 @@ $min-screen-width: 375px;
   &.error,
   &.ng-touched.ng-invalid {
     > button {
-      outline-color: utils.get-color('danger');
+      outline-color: var(--kirby-danger);
     }
   }
 
@@ -61,7 +63,7 @@ $min-screen-width: 375px;
 
   &.is-open {
     > button {
-      box-shadow: utils.get-elevation(4);
+      box-shadow: var(--kirby-elevation-4);
     }
   }
 }
@@ -73,7 +75,7 @@ kirby-popover {
 kirby-card {
   max-height: $dropdown-max-height;
   overflow-y: auto;
-  box-shadow: utils.get-elevation(4);
+  box-shadow: var(--kirby-elevation-4);
   max-width: calc(100vw - #{$margin-horizontal-total});
   min-width: $min-screen-width-small - $margin-horizontal-total;
   @include utils.media('>xsmall') {
@@ -91,7 +93,7 @@ kirby-card {
     /* stylelint-disable no-duplicate-selectors */
     & {
       border-color: transparent;
-      font-weight: utils.font-weight('bold');
+      font-weight: var(--kirby-font-weight-bold);
       font-size: initial;
     }
     /* stylelint-enable no-duplicate-selectors */

--- a/libs/designsystem/dropdown/src/dropdown.component.scss
+++ b/libs/designsystem/dropdown/src/dropdown.component.scss
@@ -2,9 +2,7 @@
 @use '@kirbydesign/core/src/scss/utils';
 
 $dropdown-max-height: 8 * utils.$dropdown-item-height;
-
-// TODO(@kirby): migrate utils.size('s') — $margin-horizontal-total feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
-$margin-horizontal-total: 2 * utils.size('s');
+$margin-horizontal-total: calc(2 * var(--kirby-spacing-s));
 $min-screen-width-small: 320px;
 $min-screen-width: 375px;
 
@@ -77,9 +75,9 @@ kirby-card {
   overflow-y: auto;
   box-shadow: var(--kirby-elevation-4);
   max-width: calc(100vw - #{$margin-horizontal-total});
-  min-width: $min-screen-width-small - $margin-horizontal-total;
+  min-width: calc(#{$min-screen-width-small} - #{$margin-horizontal-total});
   @include utils.media('>xsmall') {
-    min-width: $min-screen-width - $margin-horizontal-total;
+    min-width: calc(#{$min-screen-width} - #{$margin-horizontal-total});
   }
 }
 

--- a/libs/designsystem/empty-state/src/empty-state.component.scss
+++ b/libs/designsystem/empty-state/src/empty-state.component.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 .message-container {
   max-width: 330px;
   margin: auto;
@@ -20,12 +18,12 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  border: var(--kirby-spacing-xxxs) solid var(--kirby-medium);
+  border: var(--kirby-spacing-xxxs) solid var(--kirby-empty-state-color, var(--kirby-medium));
   border-radius: var(--kirby-border-radius-circle);
 }
 
 kirby-icon {
-  color: var(--kirby-medium);
+  color: var(--kirby-empty-state-color, var(--kirby-medium));
 }
 
 .title {
@@ -37,14 +35,47 @@ p.subtitle {
   white-space: pre-wrap;
 }
 
-@each $color-name, $color-value in utils.$main-colors {
-  :host(.#{$color-name}) {
-    .icon-outline {
-      border-color: #{utils.get-color($color-name)};
-    }
+// Colors
+:host(.primary) {
+  --kirby-empty-state-color: var(--kirby-primary);
+}
 
-    kirby-icon {
-      color: #{utils.get-color($color-name)};
-    }
-  }
+:host(.secondary) {
+  --kirby-empty-state-color: var(--kirby-secondary);
+}
+
+:host(.tertiary) {
+  --kirby-empty-state-color: var(--kirby-tertiary);
+}
+
+:host(.success) {
+  --kirby-empty-state-color: var(--kirby-success);
+}
+
+:host(.warning) {
+  --kirby-empty-state-color: var(--kirby-warning);
+}
+
+:host(.danger) {
+  --kirby-empty-state-color: var(--kirby-danger);
+}
+
+:host(.white-overlay) {
+  --kirby-empty-state-color: var(--kirby-white-overlay);
+}
+
+:host(.light) {
+  --kirby-empty-state-color: var(--kirby-light);
+}
+
+:host(.medium) {
+  --kirby-empty-state-color: var(--kirby-medium);
+}
+
+:host(.dark) {
+  --kirby-empty-state-color: var(--kirby-dark);
+}
+
+:host(.dark-overlay) {
+  --kirby-empty-state-color: var(--kirby-dark-overlay);
 }

--- a/libs/designsystem/empty-state/src/empty-state.component.scss
+++ b/libs/designsystem/empty-state/src/empty-state.component.scss
@@ -10,8 +10,7 @@
 }
 
 .icon-outline {
-  // TODO(@kirby): migrate utils.size('xxl') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
-  $icon-size: utils.size('xxl') * 2;
+  $icon-size: calc(var(--kirby-spacing-xxl) * 2);
 
   width: $icon-size;
   height: $icon-size;

--- a/libs/designsystem/empty-state/src/empty-state.component.scss
+++ b/libs/designsystem/empty-state/src/empty-state.component.scss
@@ -10,30 +10,31 @@
 }
 
 .icon-outline {
+  // TODO(@kirby): migrate utils.size('xxl') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
   $icon-size: utils.size('xxl') * 2;
 
   width: $icon-size;
   height: $icon-size;
   margin-left: auto;
   margin-right: auto;
-  margin-bottom: utils.size('m');
+  margin-bottom: var(--kirby-spacing-m);
   display: flex;
   flex-direction: column;
   justify-content: center;
-  border: utils.size('xxxs') solid utils.get-color('medium');
-  border-radius: utils.border-radius('circle');
+  border: var(--kirby-spacing-xxxs) solid var(--kirby-medium);
+  border-radius: var(--kirby-border-radius-circle);
 }
 
 kirby-icon {
-  color: utils.get-color('medium');
+  color: var(--kirby-medium);
 }
 
 .title {
-  margin-bottom: utils.size('xxs');
+  margin-bottom: var(--kirby-spacing-xxs);
 }
 
 p.subtitle {
-  margin-bottom: utils.size('m');
+  margin-bottom: var(--kirby-spacing-m);
   white-space: pre-wrap;
 }
 

--- a/libs/designsystem/fab-sheet/src/fab-sheet.component.scss
+++ b/libs/designsystem/fab-sheet/src/fab-sheet.component.scss
@@ -1,7 +1,7 @@
 @use '@kirbydesign/core/src/scss/interaction-state';
 @use '@kirbydesign/core/src/scss/utils';
 
-$fab-sheet-margin: utils.size('s');
+$fab-sheet-margin: var(--kirby-spacing-s);
 
 :host {
   --kirby-action-sheet-margin-horizontal: #{$fab-sheet-margin};
@@ -26,14 +26,14 @@ ion-fab-button {
     transition: interaction-state.transition();
     box-shadow: var(--kirby-focus-ring-md-inset);
     outline: none;
-    border-radius: utils.border-radius('pill');
+    border-radius: var(--kirby-border-radius-pill);
   }
 
   // Wrap declarations to avoid mixing with nested rules.
   // See: https://sass-lang.com/documentation/breaking-changes/mixed-decls/
   /* stylelint-disable no-duplicate-selectors */
   & {
-    --box-shadow: #{utils.get-elevation(4)};
+    --box-shadow: var(--kirby-elevation-4);
 
     width: 64px;
     height: 64px;
@@ -42,7 +42,7 @@ ion-fab-button {
   /* stylelint-enable no-duplicate-selectors */
 
   &[disabled] {
-    --background: #{utils.get-color('semi-light')};
+    --background: var(--kirby-semi-light);
     --box-shadow: none;
 
     opacity: 1;

--- a/libs/designsystem/flag/src/flag.component.scss
+++ b/libs/designsystem/flag/src/flag.component.scss
@@ -4,48 +4,52 @@
 @use 'sass:meta';
 @use '@kirbydesign/core/src/scss/utils';
 
+// TODO(@kirby): migrate utils.size('xxxs') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
+
 $padding-block-xs: utils.size('xxxs') - 1px;
-$padding-block-sm: utils.size('xxxs');
+$padding-block-sm: var(--kirby-spacing-xxxs);
+
+// TODO(@kirby): migrate utils.size('xxxs') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
 $padding-block-md: utils.size('xxxs') + 1px;
 
 :host {
   display: inline-block;
   background-color: var(--kirby-flag-background-color, transparent);
-  color: var(--kirby-flag-color, utils.get-color('white-contrast'));
-  border: 1px solid var(--kirby-flag-border-color, utils.get-color('medium'));
-  border-radius: utils.border-radius('xs');
-  font-size: utils.font-size('n');
-  padding: $padding-block-md utils.size('xxs');
-  font-weight: utils.font-weight('medium');
+  color: var(--kirby-flag-color, var(--kirby-white-contrast));
+  border: 1px solid var(--kirby-flag-border-color, var(--kirby-medium));
+  border-radius: var(--kirby-border-radius-xs);
+  font-size: var(--kirby-font-size-n);
+  padding: $padding-block-md var(--kirby-spacing-xxs);
+  font-weight: var(--kirby-font-weight-medium);
   line-height: 1;
 
   &.sm {
-    font-size: utils.font-size('s');
+    font-size: var(--kirby-font-size-s);
     padding-block: $padding-block-sm;
   }
 
   &.xs {
-    font-size: utils.font-size('xs');
-    padding: $padding-block-xs utils.size('xxxs');
+    font-size: var(--kirby-font-size-xs);
+    padding: $padding-block-xs var(--kirby-spacing-xxxs);
   }
 
   // Colors
   &.success {
-    --kirby-flag-background-color: #{utils.get-color('success-tint')};
+    --kirby-flag-background-color: var(--kirby-success-tint);
   }
 
   &.warning {
-    --kirby-flag-background-color: #{utils.get-color('warning-tint')};
+    --kirby-flag-background-color: var(--kirby-warning-tint);
   }
 
   &.danger {
-    --kirby-flag-background-color: #{utils.get-color('danger-tint')};
+    --kirby-flag-background-color: var(--kirby-danger-tint);
   }
 
   &.semi-light {
-    --kirby-flag-background-color: #{utils.get-color('semi-light')};
+    --kirby-flag-background-color: var(--kirby-semi-light);
   }
 
   --kirby-flag-border-color: var(--kirby-flag-background-color);
-  --kirby-flag-color: #{utils.get-color('black')};
+  --kirby-flag-color: var(--kirby-black);
 }

--- a/libs/designsystem/flag/src/flag.component.scss
+++ b/libs/designsystem/flag/src/flag.component.scss
@@ -4,13 +4,9 @@
 @use 'sass:meta';
 @use '@kirbydesign/core/src/scss/utils';
 
-// TODO(@kirby): migrate utils.size('xxxs') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
-
-$padding-block-xs: utils.size('xxxs') - 1px;
+$padding-block-xs: calc(var(--kirby-spacing-xxxs) - 1px);
 $padding-block-sm: var(--kirby-spacing-xxxs);
-
-// TODO(@kirby): migrate utils.size('xxxs') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
-$padding-block-md: utils.size('xxxs') + 1px;
+$padding-block-md: calc(var(--kirby-spacing-xxxs) + 1px);
 
 :host {
   display: inline-block;

--- a/libs/designsystem/flag/src/flag.component.scss
+++ b/libs/designsystem/flag/src/flag.component.scss
@@ -1,9 +1,3 @@
-@use 'sass:list';
-@use 'sass:map';
-@use 'sass:math';
-@use 'sass:meta';
-@use '@kirbydesign/core/src/scss/utils';
-
 $padding-block-xs: calc(var(--kirby-spacing-xxxs) - 1px);
 $padding-block-sm: var(--kirby-spacing-xxxs);
 $padding-block-md: calc(var(--kirby-spacing-xxxs) + 1px);

--- a/libs/designsystem/form-field/src/_form-field-inputs.shared.scss
+++ b/libs/designsystem/form-field/src/_form-field-inputs.shared.scss
@@ -1,14 +1,8 @@
-@use '@kirbydesign/core/src/scss/utils';
 @use '@kirbydesign/core/src/scss/interaction-state';
 
 $form-field-input-font-family: var(--kirby-font-family);
-
-// TODO(@kirby): migrate utils.line-height('n') — $form-field-input-line-height feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
-$form-field-input-line-height: utils.line-height('n');
-
-// TODO(@kirby): migrate by converting the input.component.scss calculation to CSS calc().
-// stylelint-disable-next-line kirby/use-design-tokens
-$form-field-input-padding: utils.size('s');
+$form-field-input-line-height: var(--kirby-line-height-n);
+$form-field-input-padding: var(--kirby-spacing-s);
 $form-field-label-height: 24px;
 
 :host(.error) {
@@ -104,7 +98,7 @@ $form-field-label-height: 24px;
   // ::-webkit-date-and-time-value seems to match regardless of feature query
   :host(input[type='date']::-webkit-date-and-time-value) {
     // Ensure consistent height
-    min-height: #{$form-field-input-line-height + em};
+    min-height: calc(#{$form-field-input-line-height} * 1em);
 
     // Left align date input text
     text-align: start;

--- a/libs/designsystem/form-field/src/_form-field-inputs.shared.scss
+++ b/libs/designsystem/form-field/src/_form-field-inputs.shared.scss
@@ -2,12 +2,17 @@
 @use '@kirbydesign/core/src/scss/interaction-state';
 
 $form-field-input-font-family: var(--kirby-font-family);
+
+// TODO(@kirby): migrate utils.line-height('n') — $form-field-input-line-height feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
 $form-field-input-line-height: utils.line-height('n');
+
+// TODO(@kirby): migrate by converting the input.component.scss calculation to CSS calc().
+// stylelint-disable-next-line kirby/use-design-tokens
 $form-field-input-padding: utils.size('s');
 $form-field-label-height: 24px;
 
 :host(.error) {
-  border: 1px solid utils.get-color('danger');
+  border: 1px solid var(--kirby-danger);
   padding: calc(
     #{$form-field-input-padding} - 1px
   ); // subtract border width from padding to maintain overall height
@@ -41,7 +46,7 @@ $form-field-label-height: 24px;
 :host {
   &:focus-visible {
     transition: interaction-state.transition();
-    box-shadow: utils.get-elevation(2), var(--kirby-focus-ring-md-inset);
+    box-shadow: var(--kirby-elevation-2), var(--kirby-focus-ring-md-inset);
   }
 
   // Wrap declarations to avoid mixing with nested rules.
@@ -69,7 +74,7 @@ $form-field-label-height: 24px;
     outline: none;
     margin: 0;
     appearance: none;
-    border-radius: utils.border-radius('n');
+    border-radius: var(--kirby-border-radius-n);
     box-shadow: var(--kirby-inputs-elevation);
     padding: $form-field-input-padding;
     width: 100%;
@@ -84,8 +89,8 @@ $form-field-label-height: 24px;
   }
 
   &:disabled {
-    background-color: utils.get-color('light-tint');
-    color: utils.get-text-color('semi-dark');
+    background-color: var(--kirby-light-tint);
+    color: var(--kirby-text-color-semi-dark);
     box-shadow: none;
   }
 

--- a/libs/designsystem/form-field/src/form-field-message/form-field-message.component.scss
+++ b/libs/designsystem/form-field/src/form-field-message/form-field-message.component.scss
@@ -1,12 +1,10 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 :host {
   font-style: italic;
   font-size: var(--kirby-font-size-xs);
   font-weight: var(--kirby-font-weight-normal);
   font-stretch: normal;
   line-height: var(--kirby-line-height-xs);
-  min-height: utils.relative-size('s');
+  min-height: var(--kirby-relative-spacing-s);
   letter-spacing: normal;
   color: var(--kirby-text-color-black);
 }

--- a/libs/designsystem/form-field/src/form-field-message/form-field-message.component.scss
+++ b/libs/designsystem/form-field/src/form-field-message/form-field-message.component.scss
@@ -2,11 +2,11 @@
 
 :host {
   font-style: italic;
-  font-size: utils.font-size('xs');
-  font-weight: utils.font-weight('normal');
+  font-size: var(--kirby-font-size-xs);
+  font-weight: var(--kirby-font-weight-normal);
   font-stretch: normal;
-  line-height: utils.line-height('xs');
+  line-height: var(--kirby-line-height-xs);
   min-height: utils.relative-size('s');
   letter-spacing: normal;
-  color: utils.get-text-color('black');
+  color: var(--kirby-text-color-black);
 }

--- a/libs/designsystem/form-field/src/form-field-message/form-field-message.component.scss
+++ b/libs/designsystem/form-field/src/form-field-message/form-field-message.component.scss
@@ -4,7 +4,7 @@
   font-weight: var(--kirby-font-weight-normal);
   font-stretch: normal;
   line-height: var(--kirby-line-height-xs);
-  min-height: var(--kirby-relative-spacing-s);
+  min-height: var(--kirby-relative-size-s);
   letter-spacing: normal;
   color: var(--kirby-text-color-black);
 }

--- a/libs/designsystem/form-field/src/form-field.component.scss
+++ b/libs/designsystem/form-field/src/form-field.component.scss
@@ -1,4 +1,3 @@
-@use '@kirbydesign/core/src/scss/interaction-state';
 @use '@kirbydesign/core/src/scss/utils';
 
 :host {

--- a/libs/designsystem/form-field/src/form-field.component.scss
+++ b/libs/designsystem/form-field/src/form-field.component.scss
@@ -4,7 +4,7 @@
 :host {
   display: block;
   position: relative; // Ensures correct position of cloned child input when Ionic scrollAssist is enabled
-  margin-bottom: utils.size('s');
+  margin-bottom: var(--kirby-spacing-s);
 }
 
 :host-context(kirby-item) {
@@ -14,7 +14,7 @@
 .texts {
   display: flex;
   justify-content: space-between;
-  padding: 2px utils.size('s') 0 utils.size('s');
+  padding: 2px var(--kirby-spacing-s) 0 var(--kirby-spacing-s);
 
   .message {
     flex: 75%;
@@ -41,11 +41,11 @@ label {
 
 .text {
   display: block;
-  font-size: utils.font-size('s');
-  font-weight: utils.font-weight('light');
-  line-height: utils.line-height('s');
-  margin-bottom: utils.size('xxxs');
-  padding: 0 utils.size('s');
+  font-size: var(--kirby-font-size-s);
+  font-weight: var(--kirby-font-weight-light);
+  line-height: var(--kirby-line-height-s);
+  margin-bottom: var(--kirby-spacing-xxxs);
+  padding: 0 var(--kirby-spacing-s);
 }
 
 .affix-container {
@@ -60,17 +60,17 @@ label {
   }
 
   .prefix {
-    left: utils.size('xs');
-    z-index: utils.z('default');
+    left: var(--kirby-spacing-xs);
+    z-index: var(--kirby-z-index-default);
   }
 
   .suffix {
-    right: utils.size('xs');
+    right: var(--kirby-spacing-xs);
   }
 
   .semi-dark-text {
     @include utils.slotted(span, h1, h2, h3, h4, h5, h6, p, data) {
-      color: utils.get-text-color('semi-dark');
+      color: var(--kirby-text-color-semi-dark);
     }
   }
 }

--- a/libs/designsystem/form-field/src/input/input.component.scss
+++ b/libs/designsystem/form-field/src/input/input.component.scss
@@ -59,7 +59,7 @@ $padding-block-size-md: shared.$form-field-input-padding * 0.5;
 }
 
 :host(.md) {
-  border-radius: utils.border-radius('l');
+  border-radius: var(--kirby-border-radius-l);
   padding-block: $padding-block-size-md;
 
   &.error {
@@ -72,7 +72,7 @@ $padding-block-size-md: shared.$form-field-input-padding * 0.5;
 /* clean-css ignore:start */
 :host-context(kirby-item kirby-form-field[slot='end']) {
   &[type='number'] {
-    font-weight: utils.font-weight('bold');
+    font-weight: var(--kirby-font-weight-bold);
   }
 }
 

--- a/libs/designsystem/form-field/src/input/input.component.scss
+++ b/libs/designsystem/form-field/src/input/input.component.scss
@@ -1,8 +1,7 @@
 @use '../form-field-inputs.shared' as shared;
 @use '@kirbydesign/core/src/scss/interaction-state';
-@use '@kirbydesign/core/src/scss/utils';
 
-$padding-block-size-md: shared.$form-field-input-padding * 0.5;
+$padding-block-size-md: calc(#{shared.$form-field-input-padding} * 0.5);
 
 :host {
   &:not(:disabled) {

--- a/libs/designsystem/header/src/header.component.scss
+++ b/libs/designsystem/header/src/header.component.scss
@@ -1,15 +1,21 @@
 @use 'sass:map';
 @use '@kirbydesign/core/src/scss/utils';
 
+// TODO(@kirby): migrate utils.size('s') — $margin-inline feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
+
 $margin-inline: utils.size('s');
+
+// TODO(@kirby): migrate utils.size('xxs') — $actions-margin-inline feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
 $actions-margin-inline: utils.size('xxs');
+
+// TODO(@kirby): migrate utils.size('xxl') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
 $column-gap: utils.size('xxl') - $margin-inline - $actions-margin-inline;
 
 :host {
   display: flex;
   flex-direction: column;
-  margin-top: utils.size('s');
-  margin-bottom: utils.size('l');
+  margin-top: var(--kirby-spacing-s);
+  margin-bottom: var(--kirby-spacing-l);
 
   @include utils.media('<medium') {
     /*
@@ -19,12 +25,12 @@ $column-gap: utils.size('xxl') - $margin-inline - $actions-margin-inline;
     */
     /* stylelint-disable selector-pseudo-element-no-unknown */
     &:has(> .avatar::ng-deep) {
-      margin-top: utils.size('xxs');
+      margin-top: var(--kirby-spacing-xxs);
     }
   }
 
   @include utils.media('>=medium') {
-    margin-top: utils.size('m');
+    margin-top: var(--kirby-spacing-m);
   }
 }
 
@@ -99,7 +105,7 @@ $column-gap: utils.size('xxl') - $margin-inline - $actions-margin-inline;
 }
 
 .actions {
-  margin-top: utils.size('m');
+  margin-top: var(--kirby-spacing-m);
   margin-inline: $actions-margin-inline;
 
   @include utils.media('<medium') {
@@ -138,19 +144,19 @@ $column-gap: utils.size('xxl') - $margin-inline - $actions-margin-inline;
 }
 
 .avatar {
-  margin-bottom: utils.size('s');
+  margin-bottom: var(--kirby-spacing-s);
 }
 
 .flag {
-  margin-bottom: utils.size('xxxs');
+  margin-bottom: var(--kirby-spacing-xxxs);
 }
 
 .flag .custom-flag {
-  margin-block: utils.size('xxxs');
+  margin-block: var(--kirby-spacing-xxxs);
 }
 
 .title {
-  margin-bottom: utils.size('xxxxs');
+  margin-bottom: var(--kirby-spacing-xxxxs);
 
   &.clickable {
     cursor: pointer;
@@ -171,13 +177,13 @@ $column-gap: utils.size('xxl') - $margin-inline - $actions-margin-inline;
   display: flex;
   align-items: baseline;
   max-width: 100%;
-  margin-bottom: utils.size('xxxs');
+  margin-bottom: var(--kirby-spacing-xxxs);
 }
 
 .value-unit {
   font-weight: initial;
-  color: utils.get-text-color('semi-dark');
-  margin-left: utils.size('xxxs');
+  color: var(--kirby-text-color-semi-dark);
+  margin-left: var(--kirby-spacing-xxxs);
   font-size: 50%;
 }
 
@@ -194,5 +200,5 @@ $column-gap: utils.size('xxl') - $margin-inline - $actions-margin-inline;
 }
 
 .custom-section {
-  margin-top: utils.size('xxs');
+  margin-top: var(--kirby-spacing-xxs);
 }

--- a/libs/designsystem/header/src/header.component.scss
+++ b/libs/designsystem/header/src/header.component.scss
@@ -1,4 +1,3 @@
-@use 'sass:map';
 @use '@kirbydesign/core/src/scss/utils';
 
 $margin-inline: var(--kirby-spacing-s);

--- a/libs/designsystem/header/src/header.component.scss
+++ b/libs/designsystem/header/src/header.component.scss
@@ -1,15 +1,9 @@
 @use 'sass:map';
 @use '@kirbydesign/core/src/scss/utils';
 
-// TODO(@kirby): migrate utils.size('s') — $margin-inline feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
-
-$margin-inline: utils.size('s');
-
-// TODO(@kirby): migrate utils.size('xxs') — $actions-margin-inline feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
-$actions-margin-inline: utils.size('xxs');
-
-// TODO(@kirby): migrate utils.size('xxl') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
-$column-gap: utils.size('xxl') - $margin-inline - $actions-margin-inline;
+$margin-inline: var(--kirby-spacing-s);
+$actions-margin-inline: var(--kirby-spacing-xxs);
+$column-gap: calc(var(--kirby-spacing-xxl) - #{$margin-inline} - #{$actions-margin-inline});
 
 :host {
   display: flex;

--- a/libs/designsystem/icon/src/icon.component.scss
+++ b/libs/designsystem/icon/src/icon.component.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 :host {
   display: inline-flex;
   align-items: center;
@@ -30,10 +28,48 @@
   --kirby-icon-font-size: var(--kirby-icon-font-size-lg);
 }
 
-@each $color-name, $color-value in utils.$main-colors {
-  :host(.#{$color-name}) {
-    color: utils.get-color($color-name);
-  }
+:host(.primary) {
+  color: var(--kirby-primary);
+}
+
+:host(.secondary) {
+  color: var(--kirby-secondary);
+}
+
+:host(.tertiary) {
+  color: var(--kirby-tertiary);
+}
+
+:host(.success) {
+  color: var(--kirby-success);
+}
+
+:host(.warning) {
+  color: var(--kirby-warning);
+}
+
+:host(.danger) {
+  color: var(--kirby-danger);
+}
+
+:host(.white-overlay) {
+  color: var(--kirby-white-overlay);
+}
+
+:host(.light) {
+  color: var(--kirby-light);
+}
+
+:host(.medium) {
+  color: var(--kirby-medium);
+}
+
+:host(.dark) {
+  color: var(--kirby-dark);
+}
+
+:host(.dark-overlay) {
+  color: var(--kirby-dark-overlay);
 }
 
 :host-context(kirby-item) {

--- a/libs/designsystem/icon/src/icon.component.scss
+++ b/libs/designsystem/icon/src/icon.component.scss
@@ -4,7 +4,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: var(--kirby-icon-font-size, utils.icon-font-size('sm'));
+  font-size: var(--kirby-icon-font-size, var(--kirby-icon-font-size-sm));
   margin-left: var(--kirby-icon-margin-left, unset);
   margin-right: var(--kirby-icon-margin-right, unset);
 
@@ -15,19 +15,19 @@
 }
 
 :host(.xs) {
-  --kirby-icon-font-size: #{utils.icon-font-size('xs')};
+  --kirby-icon-font-size: var(--kirby-icon-font-size-xs);
 }
 
 :host(.sm) {
-  --kirby-icon-font-size: #{utils.icon-font-size('sm')};
+  --kirby-icon-font-size: var(--kirby-icon-font-size-sm);
 }
 
 :host(.md) {
-  --kirby-icon-font-size: #{utils.icon-font-size('md')};
+  --kirby-icon-font-size: var(--kirby-icon-font-size-md);
 }
 
 :host(.lg) {
-  --kirby-icon-font-size: #{utils.icon-font-size('lg')};
+  --kirby-icon-font-size: var(--kirby-icon-font-size-lg);
 }
 
 @each $color-name, $color-value in utils.$main-colors {
@@ -38,11 +38,11 @@
 
 :host-context(kirby-item) {
   &[slot='start'] {
-    margin-inline-end: utils.size('xxs');
+    margin-inline-end: var(--kirby-spacing-xxs);
   }
 
   &[slot='end'] {
-    margin-inline-start: utils.size('xxs');
+    margin-inline-start: var(--kirby-spacing-xxs);
   }
 }
 

--- a/libs/designsystem/item-sliding/src/item-sliding.shared.scss
+++ b/libs/designsystem/item-sliding/src/item-sliding.shared.scss
@@ -6,13 +6,60 @@
   When the old template driven list is deprecated however - this should 
   just be used directly in item-sliding.component.scss.
  */
-@use '@kirbydesign/core/src/scss/utils';
 
 ion-item-option {
-  @each $color-name, $color-value in utils.$main-colors {
-    &.#{$color-name} {
-      background-color: #{utils.get-color($color-name)};
-      color: #{utils.get-color($color-name + '-contrast')};
-    }
+  &.primary {
+    background-color: var(--kirby-primary);
+    color: var(--kirby-primary-contrast);
+  }
+
+  &.secondary {
+    background-color: var(--kirby-secondary);
+    color: var(--kirby-secondary-contrast);
+  }
+
+  &.tertiary {
+    background-color: var(--kirby-tertiary);
+    color: var(--kirby-tertiary-contrast);
+  }
+
+  &.success {
+    background-color: var(--kirby-success);
+    color: var(--kirby-success-contrast);
+  }
+
+  &.warning {
+    background-color: var(--kirby-warning);
+    color: var(--kirby-warning-contrast);
+  }
+
+  &.danger {
+    background-color: var(--kirby-danger);
+    color: var(--kirby-danger-contrast);
+  }
+
+  &.white-overlay {
+    background-color: var(--kirby-white-overlay);
+    color: var(--kirby-white-overlay-contrast);
+  }
+
+  &.light {
+    background-color: var(--kirby-light);
+    color: var(--kirby-light-contrast);
+  }
+
+  &.medium {
+    background-color: var(--kirby-medium);
+    color: var(--kirby-medium-contrast);
+  }
+
+  &.dark {
+    background-color: var(--kirby-dark);
+    color: var(--kirby-dark-contrast);
+  }
+
+  &.dark-overlay {
+    background-color: var(--kirby-dark-overlay);
+    color: var(--kirby-dark-overlay-contrast);
   }
 }

--- a/libs/designsystem/item/src/_item.utils.scss
+++ b/libs/designsystem/item/src/_item.utils.scss
@@ -146,7 +146,9 @@ $no-layout-change-components: 'kirby-checkbox, kirby-radio, kirby-toggle, [kirby
           }
 
           .disclosure {
-            top: calc(var(--item-padding-top) + $start-slot-content-margin + utils.size('xxs'));
+            top: calc(
+              var(--item-padding-top) + $start-slot-content-margin + var(--kirby-spacing-xxs)
+            );
           }
         }
 

--- a/libs/designsystem/item/src/_item.utils.scss
+++ b/libs/designsystem/item/src/_item.utils.scss
@@ -1,5 +1,4 @@
 @use 'sass:list';
-@use 'sass:math';
 
 @use '@kirbydesign/core/src/scss/utils';
 @use '@kirbydesign/core/src/scss/base/item-typography';

--- a/libs/designsystem/item/src/_item.utils.scss
+++ b/libs/designsystem/item/src/_item.utils.scss
@@ -23,7 +23,7 @@ $base-typography-selectors: (':where(.kirby-item-title)');
 
 @mixin item-typography() {
   @include utils.slotted(item-typography.$slotted-text-elements) {
-    color: utils.get-text-color('black');
+    color: var(--kirby-text-color-black);
     display: block;
     margin: 0;
     white-space: nowrap;
@@ -34,13 +34,13 @@ $base-typography-selectors: (':where(.kirby-item-title)');
   /* Needs to come before the base typography styles to allow for p.kirby-item-title to be applied
      as the selectors have the same specificity */
   @include utils.slotted(':where(p)') {
-    font-size: utils.font-size('s');
-    line-height: utils.line-height('s');
+    font-size: var(--kirby-font-size-s);
+    line-height: var(--kirby-line-height-s);
   }
 
   @include utils.slotted($base-typography-selectors) {
-    font-size: utils.font-size('n');
-    line-height: utils.line-height('n');
+    font-size: var(--kirby-font-size-n);
+    line-height: var(--kirby-line-height-n);
     font-weight: normal;
   }
 
@@ -51,16 +51,16 @@ $base-typography-selectors: (':where(.kirby-item-title)');
     '.kirby-item-detail',
     '.kirby-item-disclosure'
   ) {
-    font-size: utils.font-size('xs');
-    line-height: utils.line-height('xs');
+    font-size: var(--kirby-font-size-xs);
+    line-height: var(--kirby-line-height-xs);
   }
 
   @include utils.slotted('[subtitle]:not(:last-child)', '.kirby-item-subtitle:not(:last-child)') {
-    margin-bottom: utils.size('xxxs');
+    margin-bottom: var(--kirby-spacing-xxxs);
   }
 
   @include utils.slotted('[detail]', '.kirby-item-detail', '.kirby-item-disclosure') {
-    color: utils.get-text-color('semi-dark');
+    color: var(--kirby-text-color-semi-dark);
   }
 
   @include utils.slotted('.kirby-item-disclosure') {
@@ -101,14 +101,16 @@ $no-layout-change-components: 'kirby-checkbox, kirby-radio, kirby-toggle, [kirby
   @include when-text-resized-on-narrow-viewport {
     @include when-layout-change-needed {
       $start-slot-content: '[slot="start"]:not(.outside)';
-      $end-slot-content: '[slot="end"]:not(.disclosure):not(.icon-only)';
+      $end-slot-content: '[slot="end"]:not(.disclosure)';
       $end-slot-content-only: ':not(:has(#{$start-slot-content})):has(#{$end-slot-content})';
       $line-center: 0.5lh;
-      $disclosure-radius: utils.size('xs');
+      $disclosure-radius: var(--kirby-spacing-xs);
+
+      // TODO(@kirby): migrate utils.size('xxxs') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
       $badge-radius: utils.size('xxxs') * 0.5;
-      $start-slot-content-margin: utils.size('xxxxs');
-      $outside-slot-offset: utils.size(
-        's'
+      $start-slot-content-margin: var(--kirby-spacing-xxxxs);
+      $outside-slot-offset: var(
+        --kirby-spacing-s
       ); // best guess for what might work with different start slot content (e.g. small avatar)
 
       // Apply text clamp if text is scaled
@@ -124,9 +126,11 @@ $no-layout-change-components: 'kirby-checkbox, kirby-radio, kirby-toggle, [kirby
       // if there is either start or end slot (or both), change layout to better fit scaled text, with row layout etc.
       ion-item:has(#{$start-slot-content}),
       ion-item:has(#{$end-slot-content}) {
-        --item-padding-top: #{utils.size('xxs')};
+        --item-padding-top: var(--kirby-spacing-xxs);
         --inner-padding-top: 0;
-        --inner-padding-end: #{utils.size('l')}; // Make space for disclosure indicator in item-end
+        --inner-padding-end: var(
+          --kirby-spacing-l
+        ); // Make space for disclosure indicator in item-end
 
         @include utils.slotted('[slot="end"]') {
           margin-inline-start: initial;
@@ -134,11 +138,18 @@ $no-layout-change-components: 'kirby-checkbox, kirby-radio, kirby-toggle, [kirby
 
         &::part(item-inner) {
           position: initial;
-          gap: utils.size('xs');
+          gap: var(--kirby-spacing-xs);
         }
 
-        &::part(input-wrapper) {
-          justify-content: center;
+        // center disclosure and badge vertically with start slot content
+        ion-item:has(#{$start-slot-content}) {
+          .outside {
+            top: calc(var(--item-padding-top) + $start-slot-content-margin + $outside-slot-offset);
+          }
+
+          .disclosure {
+            top: calc(var(--item-padding-top) + $start-slot-content-margin + utils.size('xxs'));
+          }
         }
 
         &::part(native) {
@@ -148,10 +159,10 @@ $no-layout-change-components: 'kirby-checkbox, kirby-radio, kirby-toggle, [kirby
 
         .disclosure {
           position: absolute;
-          right: utils.size('xxs');
+          right: var(--kirby-spacing-xxs);
           top: calc(var(--item-padding-top) + $line-center - $disclosure-radius);
-          font-size: utils.font-size('n');
-          line-height: utils.line-height('n');
+          font-size: var(--kirby-font-size-n);
+          line-height: var(--kirby-line-height-n);
         }
       }
 
@@ -162,7 +173,9 @@ $no-layout-change-components: 'kirby-checkbox, kirby-radio, kirby-toggle, [kirby
         }
 
         .disclosure {
-          top: calc(var(--item-padding-top) + $start-slot-content-margin + utils.size('xxs'));
+          top: calc(
+            var(--item-padding-top) + $start-slot-content-margin + var(--kirby-spacing-xxs)
+          );
         }
       }
 
@@ -212,7 +225,7 @@ $no-layout-change-components: 'kirby-checkbox, kirby-radio, kirby-toggle, [kirby
       @include utils.slotted('.kirby-item-disclosure') {
         position: absolute;
         top: var(--padding-top, 0);
-        right: utils.size('s');
+        right: var(--kirby-spacing-s);
         margin-left: 0;
       }
     }

--- a/libs/designsystem/item/src/_item.utils.scss
+++ b/libs/designsystem/item/src/_item.utils.scss
@@ -105,9 +105,7 @@ $no-layout-change-components: 'kirby-checkbox, kirby-radio, kirby-toggle, [kirby
       $end-slot-content-only: ':not(:has(#{$start-slot-content})):has(#{$end-slot-content})';
       $line-center: 0.5lh;
       $disclosure-radius: var(--kirby-spacing-xs);
-
-      // TODO(@kirby): migrate utils.size('xxxs') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
-      $badge-radius: utils.size('xxxs') * 0.5;
+      $badge-radius: calc(var(--kirby-spacing-xxxs) * 0.5);
       $start-slot-content-margin: var(--kirby-spacing-xxxxs);
       $outside-slot-offset: var(
         --kirby-spacing-s

--- a/libs/designsystem/item/src/_item.utils.scss
+++ b/libs/designsystem/item/src/_item.utils.scss
@@ -138,17 +138,8 @@ $no-layout-change-components: 'kirby-checkbox, kirby-radio, kirby-toggle, [kirby
           gap: var(--kirby-spacing-xs);
         }
 
-        // center disclosure and badge vertically with start slot content
-        ion-item:has(#{$start-slot-content}) {
-          .outside {
-            top: calc(var(--item-padding-top) + $start-slot-content-margin + $outside-slot-offset);
-          }
-
-          .disclosure {
-            top: calc(
-              var(--item-padding-top) + $start-slot-content-margin + var(--kirby-spacing-xxs)
-            );
-          }
+        &::part(input-wrapper) {
+          justify-content: center;
         }
 
         &::part(native) {

--- a/libs/designsystem/item/src/item.component.scss
+++ b/libs/designsystem/item/src/item.component.scss
@@ -45,9 +45,7 @@ ion-item {
       var(--kirby-content-border-bottom-radius, 0);
 
     &:focus-visible {
-      box-shadow:
-        0 0 0 2px utils.$focus-ring-color inset,
-        0 0 0 4px var(--kirby-white) inset;
+      box-shadow: var(--kirby-focus-ring-md-inset);
     }
   }
 

--- a/libs/designsystem/item/src/item.component.scss
+++ b/libs/designsystem/item/src/item.component.scss
@@ -4,7 +4,7 @@
 @use 'item.utils';
 
 $fixed-badge-font-size: 10px;
-$outside-slot-width: utils.relative-size('s');
+$outside-slot-width: var(--kirby-relative-spacing-s);
 
 :host {
   display: block;

--- a/libs/designsystem/item/src/item.component.scss
+++ b/libs/designsystem/item/src/item.component.scss
@@ -4,7 +4,7 @@
 @use 'item.utils';
 
 $fixed-badge-font-size: 10px;
-$outside-slot-width: var(--kirby-relative-spacing-s);
+$outside-slot-width: var(--kirby-relative-size-s);
 
 :host {
   display: block;

--- a/libs/designsystem/item/src/item.component.scss
+++ b/libs/designsystem/item/src/item.component.scss
@@ -21,8 +21,8 @@ $outside-slot-width: utils.relative-size('s');
     --min-height: #{map.get(utils.$item-heights, 'xs')};
 
     &:not(:has(kirby-checkbox, kirby-radio)) {
-      --inner-padding-top: #{utils.size('xxxs')};
-      --inner-padding-bottom: #{utils.size('xxxs')};
+      --inner-padding-top: var(--kirby-spacing-xxxs);
+      --inner-padding-bottom: var(--kirby-spacing-xxxs);
     }
   }
 
@@ -33,7 +33,7 @@ $outside-slot-width: utils.relative-size('s');
     width: $outside-slot-width;
     margin: 0;
     position: absolute;
-    left: utils.size('xxxs');
+    left: var(--kirby-spacing-xxxs);
     z-index: 1;
   }
 }
@@ -47,7 +47,7 @@ ion-item {
     &:focus-visible {
       box-shadow:
         0 0 0 2px utils.$focus-ring-color inset,
-        0 0 0 4px utils.get-color('white') inset;
+        0 0 0 4px var(--kirby-white) inset;
     }
   }
 
@@ -61,22 +61,19 @@ ion-item {
     --padding-top: var(--item-padding-top, 0px);
     --padding-bottom: var(--item-padding-bottom, 0px);
     --min-height: #{map.get(utils.$item-heights, 'm')};
-    --padding-start: #{utils.size('s')};
-    --inner-padding-top: #{utils.size('xxs')};
-    --inner-padding-bottom: #{utils.size('xxs')};
-    --inner-padding-end: #{utils.size('s')};
-    --background: var(--kirby-item-background, #{utils.get-color('white')});
+    --padding-start: var(--kirby-spacing-s);
+    --inner-padding-top: var(--kirby-spacing-xxs);
+    --inner-padding-bottom: var(--kirby-spacing-xxs);
+    --inner-padding-end: var(--kirby-spacing-s);
+    --background: var(--kirby-item-background, var(--kirby-white));
 
     // WORKAROUND: Needed to fix ignored click on scrollend
     // https://github.com/ionic-team/ionic-framework/issues/21871
     --background-activated-opacity: 0.99;
-    --background-focused: var(
-      --kirby-item-background-focused,
-      #{utils.get-color('background-color')}
-    );
+    --background-focused: var(--kirby-item-background-focused, var(--kirby-background-color));
     --background-focused-opacity: 1;
 
-    font-size: utils.font-size('n');
+    font-size: var(--kirby-font-size-n);
   }
   /* stylelint-enable no-duplicate-selectors */
 
@@ -97,11 +94,11 @@ ion-item {
   }
 
   @include utils.slotted('time[slot="end"]') {
-    margin-inline-start: utils.size('xs');
+    margin-inline-start: var(--kirby-spacing-xs);
   }
 
   @include utils.slotted('data[slot="end"]', '[detail][slot="end"], ion-reorder[slot="end"]') {
-    margin-inline-start: utils.size('s');
+    margin-inline-start: var(--kirby-spacing-s);
   }
 
   @include item.item-typography;
@@ -112,7 +109,7 @@ ion-item {
   }
 
   @include utils.slotted('input[slot="end"], kirby-form-field[slot="end"] input') {
-    margin-inline-start: utils.size('s');
+    margin-inline-start: var(--kirby-spacing-s);
     width: auto;
     text-align: end;
   }
@@ -142,10 +139,10 @@ ion-item {
 }
 
 .disclosure {
-  --kirby-icon-font-size: #{utils.size('m')}; // do not scale disclosure with font-size
+  --kirby-icon-font-size: var(--kirby-spacing-m); // do not scale disclosure with font-size
 
-  padding-left: #{utils.size('xxxs')};
-  color: #{utils.get-color('semi-dark')};
+  padding-left: var(--kirby-spacing-xxxs);
+  color: var(--kirby-semi-dark);
 
   /*
     display: inline-flex; is used to make sure the span.disclosure element
@@ -156,7 +153,7 @@ ion-item {
   align-items: center;
 
   & kirby-icon {
-    transition: transform utils.get-transition-duration('quick');
+    transition: transform var(--kirby-transition-duration-quick);
 
     &.rotate {
       transform: rotate(180deg);
@@ -189,14 +186,14 @@ ion-item {
 :host-context(kirby-list .selected) {
   ion-item {
     @include utils.slotted(h1, h2, h3, h4, h5, h6, p, data) {
-      font-weight: utils.font-weight('bold');
+      font-weight: var(--kirby-font-weight-bold);
     }
   }
 }
 
 :host(.disclosure) {
   ion-item {
-    --inner-padding-end: #{utils.size('xxs')};
+    --inner-padding-end: var(--kirby-spacing-xxs);
   }
 }
 

--- a/libs/designsystem/item/src/label/label.component.scss
+++ b/libs/designsystem/item/src/label/label.component.scss
@@ -16,7 +16,7 @@
     }
 
     @include utils.slotted(':not(:first-child)') {
-      margin-left: utils.size('xs');
+      margin-left: var(--kirby-spacing-xs);
     }
   }
 }
@@ -32,7 +32,7 @@
 
 :host([slot='end']) ion-label {
   @include utils.slotted(data, '[detail]') {
-    margin-inline-start: utils.size('s');
+    margin-inline-start: var(--kirby-spacing-s);
   }
 }
 
@@ -47,7 +47,7 @@
     'p:not([detail]):not(.kirby-item-detail)',
     'data:not([detail]):not(.kirby-item-detail)'
   ) {
-    font-weight: utils.font-weight('bold');
+    font-weight: var(--kirby-font-weight-bold);
   }
 }
 

--- a/libs/designsystem/list/src/list-experimental/list-experimental.component.scss
+++ b/libs/designsystem/list/src/list-experimental/list-experimental.component.scss
@@ -1,4 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
 @use '@kirbydesign/core/src/scss/base/list';
 
 :host {

--- a/libs/designsystem/list/src/list-header/list-header.component.scss
+++ b/libs/designsystem/list/src/list-header/list-header.component.scss
@@ -6,5 +6,5 @@
   flex-direction: row;
   justify-content: space-between;
   width: 100%;
-  padding: utils.size('m');
+  padding: var(--kirby-spacing-m);
 }

--- a/libs/designsystem/list/src/list-header/list-header.component.scss
+++ b/libs/designsystem/list/src/list-header/list-header.component.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 :host {
   background-color: transparent;
   display: flex;

--- a/libs/designsystem/list/src/list-item/list-item.component.scss
+++ b/libs/designsystem/list/src/list-item/list-item.component.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 $divider-color: var(--kirby-list-item-border-color, var(--kirby-background-color));
 
 :host {

--- a/libs/designsystem/list/src/list-item/list-item.component.scss
+++ b/libs/designsystem/list/src/list-item/list-item.component.scss
@@ -1,6 +1,6 @@
 @use '@kirbydesign/core/src/scss/utils';
 
-$divider-color: var(--kirby-list-item-border-color, #{utils.get-color('background-color')});
+$divider-color: var(--kirby-list-item-border-color, var(--kirby-background-color));
 
 :host {
   overflow: hidden;

--- a/libs/designsystem/list/src/list.component.scss
+++ b/libs/designsystem/list/src/list.component.scss
@@ -1,5 +1,3 @@
-@use 'sass:map';
-@use '@kirbydesign/core/src/scss/utils';
 @use '@kirbydesign/core/src/scss/themes';
 
 $divider-color: var(--kirby-background-color);
@@ -69,23 +67,21 @@ ion-item-sliding {
     transform: translate3d(0, 0, 0);
   }
 
-  $list-colors: ('light'); // add supported list item theme colors here
-  @each $color-name, $color-value in $list-colors {
-    &.#{$color-name} {
-      @include themes.apply-light-theme;
+  // Supported list item theme colors. Add more `&.<color-name>` rules here as needed.
+  &.light {
+    @include themes.apply-light-theme;
 
-      --kirby-item-background: #{utils.get-color($color-name)};
-      --kirby-item-background-activated: #{utils.get-color($color-name + '-shade')};
-      --kirby-item-background-focused: #{utils.get-color($color-name + '-shade')};
-      --kirby-item-background-hover: #{utils.get-color($color-name + '-tint')};
+    --kirby-item-background: var(--kirby-light);
+    --kirby-item-background-activated: var(--kirby-light-shade);
+    --kirby-item-background-focused: var(--kirby-light-shade);
+    --kirby-item-background-hover: var(--kirby-light-tint);
 
-      ion-item {
-        --background: #{utils.get-color($color-name)};
-        --color: #{utils.get-color($color-name + '-contrast')};
-        --background-activated: #{utils.get-color($color-name + '-shade')};
-        --background-focused: #{utils.get-color($color-name + '-shade')};
-        --background-hover: #{utils.get-color($color-name + '-tint')};
-      }
+    ion-item {
+      --background: var(--kirby-light);
+      --color: var(--kirby-light-contrast);
+      --background-activated: var(--kirby-light-shade);
+      --background-focused: var(--kirby-light-shade);
+      --background-hover: var(--kirby-light-tint);
     }
   }
 }
@@ -280,8 +276,43 @@ kirby-list-item:last-of-type {
   }
 }
 
-@each $sizeName, $size in utils.$sizes {
-  .stand-alone-bottom-margin-#{$sizeName} {
-    margin-bottom: $size;
-  }
+// Bottom-margin utilities for stand-alone items.
+.stand-alone-bottom-margin-xxxxs {
+  margin-bottom: var(--kirby-spacing-xxxxs);
+}
+
+.stand-alone-bottom-margin-xxxs {
+  margin-bottom: var(--kirby-spacing-xxxs);
+}
+
+.stand-alone-bottom-margin-xxs {
+  margin-bottom: var(--kirby-spacing-xxs);
+}
+
+.stand-alone-bottom-margin-xs {
+  margin-bottom: var(--kirby-spacing-xs);
+}
+
+.stand-alone-bottom-margin-sm {
+  margin-bottom: var(--kirby-spacing-s);
+}
+
+.stand-alone-bottom-margin-md {
+  margin-bottom: var(--kirby-spacing-m);
+}
+
+.stand-alone-bottom-margin-lg {
+  margin-bottom: var(--kirby-spacing-l);
+}
+
+.stand-alone-bottom-margin-xl {
+  margin-bottom: var(--kirby-spacing-xl);
+}
+
+.stand-alone-bottom-margin-xxl {
+  margin-bottom: var(--kirby-spacing-xxl);
+}
+
+.stand-alone-bottom-margin-xxxl {
+  margin-bottom: var(--kirby-spacing-xxxl);
 }

--- a/libs/designsystem/list/src/list.component.scss
+++ b/libs/designsystem/list/src/list.component.scss
@@ -2,9 +2,9 @@
 @use '@kirbydesign/core/src/scss/utils';
 @use '@kirbydesign/core/src/scss/themes';
 
-$divider-color: utils.get-color('background-color');
-$shadow: utils.get-elevation(2);
-$item-height: utils.size('xxxl');
+$divider-color: var(--kirby-background-color);
+$shadow: var(--kirby-elevation-2);
+$item-height: var(--kirby-spacing-xxxl);
 
 :host {
   display: block;
@@ -29,7 +29,7 @@ $item-height: utils.size('xxxl');
 }
 
 ion-list-header {
-  background-color: utils.get-color('white');
+  background-color: var(--kirby-white);
   border-bottom: 1px solid $divider-color;
   padding: 0;
   text-transform: inherit;
@@ -41,20 +41,20 @@ ion-list-header {
 }
 
 ion-item {
-  --background: #{utils.get-color('white')};
-  --background-activated: #{utils.get-color('white-shade')};
-  --background-hover: #{utils.get-color('background-color')};
-  --background-focused: #{utils.get-color('background-color')};
+  --background: var(--kirby-white);
+  --background-activated: var(--kirby-white-shade);
+  --background-hover: var(--kirby-background-color);
+  --background-focused: var(--kirby-background-color);
   --inner-border-width: 0;
   --ion-safe-area-right: 0;
   --min-height: #{$item-height};
-  --padding-bottom: #{utils.size('xxs')};
-  --padding-end: #{utils.size('s')};
-  --padding-start: #{utils.size('s')};
-  --padding-top: #{utils.size('xxs')};
+  --padding-bottom: var(--kirby-spacing-xxs);
+  --padding-end: var(--kirby-spacing-s);
+  --padding-start: var(--kirby-spacing-s);
+  --padding-top: var(--kirby-spacing-xxs);
 
   display: flex;
-  font-size: utils.font-size('s');
+  font-size: var(--kirby-font-size-s);
   min-height: $item-height;
   overflow: visible;
   width: 100%;
@@ -91,7 +91,7 @@ ion-item-sliding {
 }
 
 ion-item-group {
-  margin-bottom: utils.size('m');
+  margin-bottom: var(--kirby-spacing-m);
 
   &:last-of-type {
     margin-bottom: 0;
@@ -105,14 +105,14 @@ ion-item-divider {
   background-color: transparent;
   border-color: transparent;
   min-height: 0;
-  padding: 0 utils.size('s') utils.size('xxs') utils.size('s');
+  padding: 0 var(--kirby-spacing-s) var(--kirby-spacing-xxs) var(--kirby-spacing-s);
   font-weight: inherit;
 }
 
 .footer {
   @include themes.apply-white-theme;
 
-  background-color: utils.get-color('white');
+  background-color: var(--kirby-white);
   border-top: 1px solid $divider-color;
   display: flex;
   align-items: center;
@@ -123,13 +123,13 @@ ion-item-divider {
 .no-more-items,
 .loading {
   width: 100%;
-  padding: utils.size('m') 0;
+  padding: var(--kirby-spacing-m) 0;
   text-align: center;
 }
 
 .swipe-action {
   display: flex;
-  color: #{utils.get-color('black')};
+  color: var(--kirby-black);
   background-color: transparent;
 
   ion-item-option {
@@ -255,22 +255,22 @@ kirby-list-item:last-of-type {
     border-radius: unset;
 
     --kirby-item-background: transparent;
-    --kirby-list-item-border-color: #{utils.get-color('medium')};
+    --kirby-list-item-border-color: var(--kirby-medium);
   }
 }
 
 :host-context(kirby-card) {
-  --kirby-list-item-border-color: #{utils.get-color('background-color')};
+  --kirby-list-item-border-color: var(--kirby-background-color);
 }
 
 :host-context(kirby-card.outlined) {
-  --kirby-list-item-border-color: #{utils.get-color('medium')};
+  --kirby-list-item-border-color: var(--kirby-medium);
 }
 
 :host-context(.item-spacing) {
   .list {
     kirby-list-item {
-      margin-bottom: utils.size('s');
+      margin-bottom: var(--kirby-spacing-s);
 
       & > ion-item,
       &:last-child {

--- a/libs/designsystem/loading-overlay/src/loading-overlay.component.scss
+++ b/libs/designsystem/loading-overlay/src/loading-overlay.component.scss
@@ -2,7 +2,7 @@
 
 :host {
   display: block;
-  min-height: utils.size('l');
+  min-height: var(--kirby-spacing-l);
 }
 
 .overlay-wrapper {
@@ -16,13 +16,14 @@
     height: 100%;
     width: 100%;
     position: absolute;
-    z-index: utils.z('loading-overlay');
+    z-index: var(--kirby-z-index-loading-overlay);
     display: flex;
     background: transparent;
     justify-content: center;
     place-items: center;
 
     &.backdrop {
+      // TODO(@kirby): migrate utils.get-color('background-color', $getValueOnly: true) — get-color() with $getValueOnly: true returns a raw value for SCSS color manipulation
       background-color: rgba(
         utils.get-color('background-color', $getValueOnly: true),
         utils.$loading-overlay-backdrop-opacity
@@ -30,6 +31,8 @@
     }
 
     &.hide-content {
+      // TODO(@kirby): migrate utils.get-color('background-color', $getValueOnly: true) — get-color() with $getValueOnly: true returns a raw value for SCSS color manipulation
+
       background-color: rgba(utils.get-color('background-color', $getValueOnly: true), 1);
     }
 

--- a/libs/designsystem/loading-overlay/src/loading-overlay.component.scss
+++ b/libs/designsystem/loading-overlay/src/loading-overlay.component.scss
@@ -23,7 +23,8 @@
     place-items: center;
 
     &.backdrop {
-      // TODO(@kirby): migrate utils.get-color('background-color', $getValueOnly: true) — get-color() with $getValueOnly: true returns a raw value for SCSS color manipulation
+      // no Safari-15-safe CSS custom property equivalent, so kept as SCSS.
+      // stylelint-disable-next-line kirby/use-design-tokens
       background-color: rgba(
         utils.get-color('background-color', $getValueOnly: true),
         utils.$loading-overlay-backdrop-opacity
@@ -31,14 +32,14 @@
     }
 
     &.hide-content {
-      // TODO(@kirby): migrate utils.get-color('background-color', $getValueOnly: true) — get-color() with $getValueOnly: true returns a raw value for SCSS color manipulation
-
+      // no Safari-15-safe CSS custom property equivalent, so kept as SCSS.
+      // stylelint-disable-next-line kirby/use-design-tokens
       background-color: rgba(utils.get-color('background-color', $getValueOnly: true), 1);
     }
 
     .spinner {
-      width: utils.size(l);
-      height: utils.size(l);
+      width: var(--kirby-spacing-l);
+      height: var(--kirby-spacing-l);
     }
   }
 }

--- a/libs/designsystem/menu/src/menu.component.scss
+++ b/libs/designsystem/menu/src/menu.component.scss
@@ -1,5 +1,4 @@
 @use '@kirbydesign/core/src/scss/utils';
-@use '@kirbydesign/core/src/scss/interaction-state';
 
 $dropdown-max-height: 8 * utils.$dropdown-item-height;
 $min-screen-width: 240px;

--- a/libs/designsystem/menu/src/menu.component.scss
+++ b/libs/designsystem/menu/src/menu.component.scss
@@ -16,7 +16,7 @@ $max-screen-width-small: 460px;
 kirby-card {
   max-height: $dropdown-max-height;
   overflow-y: auto;
-  box-shadow: utils.get-elevation(4);
+  box-shadow: var(--kirby-elevation-4);
   min-width: $min-screen-width;
   max-width: $max-screen-width-small;
 }

--- a/libs/designsystem/modal/src/modal-wrapper/compact/modal-compact-wrapper.component.scss
+++ b/libs/designsystem/modal/src/modal-wrapper/compact/modal-compact-wrapper.component.scss
@@ -4,5 +4,5 @@
 
 :host {
   display: block;
-  padding: utils.size('m') utils.size('s');
+  padding: var(--kirby-spacing-m) var(--kirby-spacing-s);
 }

--- a/libs/designsystem/modal/src/modal-wrapper/compact/modal-compact-wrapper.component.scss
+++ b/libs/designsystem/modal/src/modal-wrapper/compact/modal-compact-wrapper.component.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 // Global modal styling can be found at scss/base/_ionic.scss
 
 :host {

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.scss
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.scss
@@ -39,10 +39,12 @@ $toolbar-bottom-border-width: 1px;
 
 @mixin toolbar-phablet-or-bigger() {
   @include utils.media('>=medium') {
-    --padding-start: #{utils.size('m')};
-    --padding-end: #{utils.size('m')};
+    --padding-start: var(--kirby-spacing-m);
+    --padding-end: var(--kirby-spacing-m);
+
+    // TODO(@kirby): migrate utils.size('m') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
     --padding-bottom: #{utils.size('m') - $toolbar-bottom-border-width};
-    --padding-top: #{utils.size('m')};
+    --padding-top: var(--kirby-spacing-m);
 
     padding-inline: 0;
   }
@@ -52,16 +54,18 @@ ion-header {
   box-sizing: border-box;
 
   ion-toolbar {
-    --padding-start: #{utils.size('xxs')};
-    --padding-end: #{utils.size('xxs')};
+    --padding-start: var(--kirby-spacing-xxs);
+    --padding-end: var(--kirby-spacing-xxs);
+
+    // TODO(@kirby): migrate utils.size('xxs') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
     --padding-bottom: #{utils.size('xxs') - $toolbar-bottom-border-width};
-    --padding-top: #{utils.size('xxs')};
+    --padding-top: var(--kirby-spacing-xxs);
     --border-width: 0;
     --background: transparent;
-    --color: var(--kirby-modal-color, #{utils.get-color('black')});
+    --color: var(--kirby-modal-color, var(--kirby-black));
 
     border-bottom: $toolbar-bottom-border-width solid transparent;
-    transition: border-color utils.get-transition-duration('quick') linear;
+    transition: border-color var(--kirby-transition-duration-quick) linear;
 
     @include toolbar-phablet-or-bigger;
 
@@ -81,7 +85,7 @@ ion-header {
 
   &.drawer ion-header ion-toolbar {
     @include utils.media('<medium') {
-      --padding-top: #{utils.size('s')};
+      --padding-top: var(--kirby-spacing-s);
 
       // Prevent iOS safe-area padding-top on drawer flavor
       // as this is already applied on the top-level modal itself
@@ -95,12 +99,12 @@ ion-header {
 
 @include utils.media('>=medium') {
   ion-header ion-toolbar {
-    border-bottom-color: utils.get-color('medium');
+    border-bottom-color: var(--kirby-medium);
   }
 }
 
 ion-header.content-scrolled ion-toolbar {
-  border-bottom-color: utils.get-color('medium');
+  border-bottom-color: var(--kirby-medium);
 }
 
 :host-context(ion-modal.no-header-area-border) {
@@ -136,18 +140,18 @@ ion-header.content-scrolled ion-toolbar {
 ion-title {
   box-sizing: border-box;
   padding-inline: calc(48px + var(--padding-start)) calc(48px + var(--padding-end));
-  font-size: utils.font-size('n');
-  font-weight: utils.font-weight('bold');
+  font-size: var(--kirby-font-size-n);
+  font-weight: var(--kirby-font-weight-bold);
   outline: none;
 }
 
 ion-content {
   --background: transparent;
-  --color: var(--kirby-modal-color, #{utils.get-color('black')});
-  --padding-top: #{utils.size('m')};
+  --color: var(--kirby-modal-color, var(--kirby-black));
+  --padding-top: var(--kirby-spacing-m);
   --padding-bottom: calc(var(--kirby-spacing-m) + var(--kirby-modal-safe-area-bottom));
-  --padding-start: #{utils.size('s')};
-  --padding-end: #{utils.size('s')};
+  --padding-start: var(--kirby-spacing-s);
+  --padding-end: var(--kirby-spacing-s);
 
   display: flex;
   flex-direction: column;
@@ -170,24 +174,24 @@ ion-content {
 /* clean-css ignore:start */
 @include utils.media('>=medium') {
   ion-content {
-    --padding-start: #{utils.size('xxl')};
-    --padding-end: #{utils.size('xxl')};
+    --padding-start: var(--kirby-spacing-xxl);
+    --padding-end: var(--kirby-spacing-xxl);
   }
 }
 
 :host(.collapsible-title) {
   ion-content ion-toolbar:first-of-type {
     --padding-top: 0px;
-    --padding-bottom: #{utils.size('l')};
-    --padding-start: #{utils.size('xxs')};
-    --padding-end: #{utils.size('xxs')};
+    --padding-bottom: var(--kirby-spacing-l);
+    --padding-start: var(--kirby-spacing-xxs);
+    --padding-end: var(--kirby-spacing-xxs);
 
     // no border for header element when collapsible title is in the content area
     border: none;
 
     @include utils.media('>=medium') {
-      --padding-start: #{utils.size('s')};
-      --padding-end: #{utils.size('s')};
+      --padding-start: var(--kirby-spacing-s);
+      --padding-end: var(--kirby-spacing-s);
     }
   }
 }

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.scss
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.scss
@@ -41,9 +41,7 @@ $toolbar-bottom-border-width: 1px;
   @include utils.media('>=medium') {
     --padding-start: var(--kirby-spacing-m);
     --padding-end: var(--kirby-spacing-m);
-
-    // TODO(@kirby): migrate utils.size('m') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
-    --padding-bottom: #{utils.size('m') - $toolbar-bottom-border-width};
+    --padding-bottom: calc(var(--kirby-spacing-m) - #{$toolbar-bottom-border-width});
     --padding-top: var(--kirby-spacing-m);
 
     padding-inline: 0;
@@ -56,9 +54,7 @@ ion-header {
   ion-toolbar {
     --padding-start: var(--kirby-spacing-xxs);
     --padding-end: var(--kirby-spacing-xxs);
-
-    // TODO(@kirby): migrate utils.size('xxs') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
-    --padding-bottom: #{utils.size('xxs') - $toolbar-bottom-border-width};
+    --padding-bottom: calc(var(--kirby-spacing-xxs) - #{$toolbar-bottom-border-width});
     --padding-top: var(--kirby-spacing-xxs);
     --border-width: 0;
     --background: transparent;

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
@@ -113,8 +113,6 @@ describe('ModalWrapperComponent', () => {
         expect(ionContentToolbarElement).not.toBeUndefined();
         await TestHelper.whenReady([ionContentElement, ionContentToolbarElement]);
 
-        await TestHelper.whenReady([ionContentElement, ionContentToolbarElement]);
-
         expect(ionContentToolbarElement).toHaveComputedStyle({
           'padding-top': '0px',
           '--padding-top': '0px',

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
@@ -113,6 +113,8 @@ describe('ModalWrapperComponent', () => {
         expect(ionContentToolbarElement).not.toBeUndefined();
         await TestHelper.whenReady([ionContentElement, ionContentToolbarElement]);
 
+        await TestHelper.whenReady([ionContentElement, ionContentToolbarElement]);
+
         expect(ionContentToolbarElement).toHaveComputedStyle({
           'padding-top': '0px',
           '--padding-top': '0px',

--- a/libs/designsystem/modal/src/modal/action-sheet/action-sheet.component.scss
+++ b/libs/designsystem/modal/src/modal/action-sheet/action-sheet.component.scss
@@ -1,8 +1,8 @@
 @use '@kirbydesign/core/src/scss/interaction-state';
 @use '@kirbydesign/core/src/scss/utils';
 
-$margin-horizontal: utils.size('l');
-$margin-horizontal-narrow: utils.size('s');
+$margin-horizontal: var(--kirby-spacing-l);
+$margin-horizontal-narrow: var(--kirby-spacing-s);
 $max-width: 375px;
 
 :host {
@@ -45,14 +45,14 @@ $max-width: 375px;
 kirby-card {
   align-self: stretch;
   pointer-events: auto;
-  box-shadow: utils.get-elevation(8);
+  box-shadow: var(--kirby-elevation-8);
 
   button[kirby-button] {
     margin: 0;
     border-radius: 0;
 
     &:not(:focus) {
-      border-top: 1px solid utils.get-color('background-color');
+      border-top: 1px solid var(--kirby-background-color);
     }
   }
 }
@@ -60,16 +60,16 @@ kirby-card {
 .cancel-btn {
   &:focus-visible {
     transition: interaction-state.transition();
-    box-shadow: utils.get-elevation(8), var(--kirby-focus-ring-md-inset);
+    box-shadow: var(--kirby-elevation-8), var(--kirby-focus-ring-md-inset);
   }
 
   // Wrap declarations to avoid mixing with nested rules.
   // See: https://sass-lang.com/documentation/breaking-changes/mixed-decls/
   /* stylelint-disable no-duplicate-selectors */
   & {
-    font-weight: utils.font-weight('bold');
-    margin-top: utils.size('s');
-    margin-bottom: utils.size('m');
+    font-weight: var(--kirby-font-weight-bold);
+    margin-top: var(--kirby-spacing-s);
+    margin-bottom: var(--kirby-spacing-m);
     pointer-events: auto;
   }
   /* stylelint-enable no-duplicate-selectors */

--- a/libs/designsystem/modal/src/modal/alert/alert.component.scss
+++ b/libs/designsystem/modal/src/modal/alert/alert.component.scss
@@ -1,4 +1,3 @@
-@use 'sass:math';
 @use '@kirbydesign/core/src/scss/utils';
 
 $column-gap: var(--kirby-spacing-xxs);

--- a/libs/designsystem/modal/src/modal/alert/alert.component.scss
+++ b/libs/designsystem/modal/src/modal/alert/alert.component.scss
@@ -19,7 +19,7 @@ article {
   flex-wrap: wrap;
 
   button {
-    flex: 0 1 calc(50% - #{math.div($column-gap, 2)});
+    flex: 0 1 calc(50% - calc($column-gap / 2));
     margin-inline: 0;
 
     &:not(:only-child) {

--- a/libs/designsystem/modal/src/modal/alert/alert.component.scss
+++ b/libs/designsystem/modal/src/modal/alert/alert.component.scss
@@ -1,14 +1,14 @@
 @use 'sass:math';
 @use '@kirbydesign/core/src/scss/utils';
 
-$column-gap: utils.size('xxs');
+$column-gap: var(--kirby-spacing-xxs);
 
 article {
   overflow: hidden;
-  padding: utils.size('s');
-  padding-top: utils.size('m');
+  padding: var(--kirby-spacing-s);
+  padding-top: var(--kirby-spacing-m);
   @include utils.media('<=xsmall') {
-    padding: utils.size('xxs');
+    padding: var(--kirby-spacing-xxs);
   }
 }
 

--- a/libs/designsystem/modal/src/modal/footer/modal-footer.component.scss
+++ b/libs/designsystem/modal/src/modal/footer/modal-footer.component.scss
@@ -4,18 +4,18 @@
 ion-footer {
   @include themes.apply-white-theme;
 
-  box-shadow: utils.get-elevation(8);
+  box-shadow: var(--kirby-elevation-8);
   box-sizing: inherit;
   display: flex;
   justify-content: var(--kirby-modal-footer-justify-content, center);
   align-items: center;
-  background-color: var(--kirby-modal-footer-background, utils.get-color('white'));
-  color: var(--kirby-modal-footer-color, utils.get-color('white-contrast'));
-  padding: utils.size('s');
-  padding-bottom: calc(#{utils.size('xs')} + var(--kirby-modal-safe-area-bottom));
+  background-color: var(--kirby-modal-footer-background, var(--kirby-white));
+  color: var(--kirby-modal-footer-color, var(--kirby-white-contrast));
+  padding: var(--kirby-spacing-s);
+  padding-bottom: calc(var(--kirby-spacing-xs) + var(--kirby-modal-safe-area-bottom));
 
   @include utils.media('>=medium') {
-    padding: utils.size('m');
+    padding: var(--kirby-spacing-m);
   }
 }
 
@@ -33,7 +33,7 @@ ion-footer {
 :host(.light) ion-footer {
   @include themes.apply-light-theme;
 
-  background-color: utils.get-color('background-color');
+  background-color: var(--kirby-background-color);
 }
 
 :host(.inline) ion-footer {

--- a/libs/designsystem/page/src/page-footer/page-footer.component.scss
+++ b/libs/designsystem/page/src/page-footer/page-footer.component.scss
@@ -1,12 +1,12 @@
 @use '@kirbydesign/core/src/scss/utils';
 @use '@kirbydesign/core/src/scss/themes';
 
-$padding-horizontal: utils.size('s');
-$padding-vertical: utils.size('xxs');
+$padding-horizontal: var(--kirby-spacing-s);
+$padding-vertical: var(--kirby-spacing-xxs);
 
 :host {
   display: block;
-  background-color: utils.get-color('white');
+  background-color: var(--kirby-white);
   @include themes.apply-white-theme;
 
   .wrapper {
@@ -18,7 +18,8 @@ $padding-vertical: utils.size('xxs');
     &.padding {
       padding: $padding-vertical $padding-horizontal;
       padding-bottom: calc(
-        #{$padding-vertical} + var(--kirby-page-footer-safe-area-bottom, var(--kirby-safe-area-bottom))
+        #{$padding-vertical} +
+          var(--kirby-page-footer-safe-area-bottom, var(--kirby-safe-area-bottom))
       );
     }
   }

--- a/libs/designsystem/page/src/page-footer/page-footer.component.scss
+++ b/libs/designsystem/page/src/page-footer/page-footer.component.scss
@@ -1,4 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
 @use '@kirbydesign/core/src/scss/themes';
 
 $padding-horizontal: var(--kirby-spacing-s);
@@ -11,7 +10,7 @@ $padding-vertical: var(--kirby-spacing-xxs);
 
   .wrapper {
     position: relative;
-    max-width: var(--page-content-max-width, utils.$page-content-max-width-default);
+    max-width: var(--page-content-max-width, var(--kirby-page-content-max-width-default));
     margin: 0 auto;
     padding-bottom: var(--kirby-page-footer-safe-area-bottom, var(--kirby-safe-area-bottom));
 

--- a/libs/designsystem/page/src/page.component.scss
+++ b/libs/designsystem/page/src/page.component.scss
@@ -3,48 +3,50 @@
 @use '@kirbydesign/core/src/scss/interaction-state';
 @use '@kirbydesign/core/src/scss/utils';
 
-$ion-content-padding-top: utils.size('xs');
+$ion-content-padding-top: var(--kirby-spacing-xs);
 
 /*
  * Page Header
  */
 
-$toolbar-transition-duration-in: utils.get-transition-duration('quick');
+$toolbar-transition-duration-in: var(--kirby-transition-duration-quick);
 $toolbar-transition-duration-out: 50ms;
 $toolbar-transition: background-color $toolbar-transition-duration-out linear;
+
+// TODO(@kirby): migrate utils.get-color('background-color', $getValueOnly: true) — get-color() with $getValueOnly: true returns a raw value for SCSS color manipulation
 $toolbar-shaded-background: color.mix(
   #000,
   utils.get-color('background-color', $getValueOnly: true),
   1.1%
 );
-$toolbar-button-size: utils.size('xl');
-$toolbar-button-spacing: utils.size('xxs');
+$toolbar-button-size: var(--kirby-spacing-xl);
+$toolbar-button-spacing: var(--kirby-spacing-xxs);
 $toolbar-max-font-size: 18px * 1.2;
 
 ion-header,
 ion-toolbar {
   box-sizing: border-box;
 
-  --background: #{utils.get-color('background-color')};
+  --background: var(--kirby-background-color);
 }
 
 ion-title h1 {
-  font-size: min(utils.font-size('m'), $toolbar-max-font-size);
+  font-size: min(var(--kirby-font-size-m), $toolbar-max-font-size);
 }
 
 ion-toolbar {
   --border-width: 0 !important;
-  --padding-start: #{utils.size('s')};
-  --padding-end: #{utils.size('s')};
+  --padding-start: var(--kirby-spacing-s);
+  --padding-end: var(--kirby-spacing-s);
   --padding-top: 0;
   --padding-bottom: 0;
-  --ion-toolbar-color: #{utils.get-color('black')};
-  --min-height: #{utils.size('xxxl')};
+  --ion-toolbar-color: var(--kirby-black);
+  --min-height: var(--kirby-spacing-xxxl);
 
   @include utils.media('>=medium') {
-    --padding-start: #{utils.size('m')};
-    --padding-end: #{utils.size('m')};
-    --min-height: #{utils.size('xxxxxl')};
+    --padding-start: var(--kirby-spacing-m);
+    --padding-end: var(--kirby-spacing-m);
+    --min-height: var(--kirby-spacing-xxxxxl);
   }
 
   /*
@@ -76,7 +78,7 @@ ion-toolbar {
     }
 
     &:not(.content-pinned)::before {
-      background-color: utils.get-color('medium');
+      background-color: var(--kirby-medium);
     }
   }
 
@@ -109,8 +111,8 @@ ion-toolbar {
 
   ion-title {
     box-sizing: border-box;
-    font-size: utils.font-size('n');
-    font-weight: utils.font-weight('normal');
+    font-size: var(--kirby-font-size-n);
+    font-weight: var(--kirby-font-weight-normal);
     padding-inline: calc(
       var(--action-buttons-width, $toolbar-button-size + $toolbar-button-spacing) +
         var(--padding-start)
@@ -139,11 +141,11 @@ ion-toolbar {
       display: flex;
       align-items: center;
       justify-content: center;
-      min-height: #{utils.size('xxxl')};
+      min-height: var(--kirby-spacing-xxxl);
       scale: 0;
       transition-property: opacity, transform;
       transition-duration: 150ms;
-      transition-timing-function: utils.get-transition-easing('enter-exit');
+      transition-timing-function: var(--kirby-transition-easing-enter-exit);
       transform: translateY(10px);
 
       span.clickable {
@@ -187,8 +189,8 @@ ion-back-button {
   // See: https://sass-lang.com/documentation/breaking-changes/mixed-decls/
   /* stylelint-disable no-duplicate-selectors */
   & {
-    --color: #{utils.get-color('black')};
-    --background: #{utils.get-color('white')};
+    --color: var(--kirby-black);
+    --background: var(--kirby-white);
     --icon-font-size: 24px;
 
     height: $toolbar-button-size;
@@ -209,7 +211,7 @@ ion-back-button {
 
   &::part(native) {
     opacity: 1; // required for interaction states to work
-    border-radius: utils.border-radius('pill');
+    border-radius: var(--kirby-border-radius-pill);
     overflow: hidden; // required for border radius to work
   }
 
@@ -234,9 +236,9 @@ ion-back-button {
 }
 
 .page-header {
-  margin-left: utils.size('s');
-  margin-top: utils.size('xxs');
-  margin-bottom: var(--kirby-page-title-margin-bottom, #{utils.size('xl')});
+  margin-left: var(--kirby-spacing-s);
+  margin-top: var(--kirby-spacing-xxs);
+  margin-bottom: var(--kirby-page-title-margin-bottom, var(--kirby-spacing-xl));
 
   .page-title {
     &.has-actions {
@@ -256,7 +258,7 @@ ion-back-button {
   }
 
   .page-subtitle {
-    margin-top: #{utils.size('xxs')};
+    margin-top: var(--kirby-spacing-xxs);
   }
 
   &.text-center {
@@ -276,15 +278,15 @@ ion-content {
   --padding-top: #{$ion-content-padding-top};
   --padding-start: var(
     --page-content-padding-start,
-    calc(#{utils.size('s')} + var(--ion-safe-area-left))
+    calc(var(--kirby-spacing-s) + var(--ion-safe-area-left))
   );
-  --padding-end: var(--page-content-padding-end, #{utils.size('s')});
-  --background: #{utils.get-color('background-color')};
-  --color: #{utils.get-color('black')};
+  --padding-end: var(--page-content-padding-end, var(--kirby-spacing-s));
+  --background: var(--kirby-background-color);
+  --color: var(--kirby-black);
 
   @include utils.media('>=medium') {
-    --padding-start: var(--page-content-padding-start, #{utils.size('xxl')});
-    --padding-end: var(--page-content-padding-end, #{utils.size('xxl')});
+    --padding-start: var(--page-content-padding-start, var(--kirby-spacing-xxl));
+    --padding-end: var(--page-content-padding-end, var(--kirby-spacing-xxl));
   }
 
   &.has-header {
@@ -292,14 +294,20 @@ ion-content {
   }
 
   &.max-width-lg {
+    // TODO(@kirby): migrate utils.get-page-content-max-width('lg') — get-page-content-max-width() has no direct CSS custom property equivalent
+
     --page-content-max-width: #{utils.get-page-content-max-width('lg')};
   }
 
   &.max-width-xl {
+    // TODO(@kirby): migrate utils.get-page-content-max-width('xl') — get-page-content-max-width() has no direct CSS custom property equivalent
+
     --page-content-max-width: #{utils.get-page-content-max-width('xl')};
   }
 
   &.max-width-full {
+    // TODO(@kirby): migrate utils.get-page-content-max-width('full') — get-page-content-max-width() has no direct CSS custom property equivalent
+
     --page-content-max-width: #{utils.get-page-content-max-width('full')};
   }
 
@@ -310,7 +318,7 @@ ion-content {
   .content-inner {
     max-width: var(--page-content-max-width, utils.$page-content-max-width-default);
     margin: 0 auto;
-    padding-bottom: utils.size('xl');
+    padding-bottom: var(--kirby-spacing-xl);
 
     // Prevents flickering on navigation back animation on ios
     transform: translateZ(0);
@@ -344,8 +352,8 @@ ion-content {
   left: 0;
   right: 0;
   padding-top: 1px;
-  margin-block-end: utils.size('m');
-  z-index: utils.z('sticky-content');
+  margin-block-end: var(--kirby-spacing-m);
+  z-index: var(--kirby-z-index-sticky-content);
 
   div {
     max-width: var(--page-content-max-width, utils.$page-content-max-width-default);
@@ -386,7 +394,7 @@ ion-content {
 
     &::after {
       /* Divider - pinned */
-      background-color: utils.get-color('medium');
+      background-color: var(--kirby-medium);
     }
   }
 }

--- a/libs/designsystem/page/src/page.component.scss
+++ b/libs/designsystem/page/src/page.component.scss
@@ -13,7 +13,7 @@ $toolbar-transition-duration-in: var(--kirby-transition-duration-quick);
 $toolbar-transition-duration-out: 50ms;
 $toolbar-transition: background-color $toolbar-transition-duration-out linear;
 
-// TODO(@kirby): migrate utils.get-color('background-color', $getValueOnly: true) — get-color() with $getValueOnly: true returns a raw value for SCSS color manipulation
+// stylelint-disable-next-line kirby/use-design-tokens
 $toolbar-shaded-background: color.mix(
   #000,
   utils.get-color('background-color', $getValueOnly: true),
@@ -231,7 +231,7 @@ ion-back-button {
  * Page Header
  */
 .page-header-container {
-  max-width: var(--page-content-max-width, utils.$page-content-max-width-default);
+  max-width: var(--page-content-max-width, var(--kirby-page-content-max-width-default));
   margin: 0 auto;
 }
 
@@ -294,21 +294,15 @@ ion-content {
   }
 
   &.max-width-lg {
-    // TODO(@kirby): migrate utils.get-page-content-max-width('lg') — get-page-content-max-width() has no direct CSS custom property equivalent
-
-    --page-content-max-width: #{utils.get-page-content-max-width('lg')};
+    --page-content-max-width: var(--kirby-page-content-max-width-lg);
   }
 
   &.max-width-xl {
-    // TODO(@kirby): migrate utils.get-page-content-max-width('xl') — get-page-content-max-width() has no direct CSS custom property equivalent
-
-    --page-content-max-width: #{utils.get-page-content-max-width('xl')};
+    --page-content-max-width: var(--kirby-page-content-max-width-xl);
   }
 
   &.max-width-full {
-    // TODO(@kirby): migrate utils.get-page-content-max-width('full') — get-page-content-max-width() has no direct CSS custom property equivalent
-
-    --page-content-max-width: #{utils.get-page-content-max-width('full')};
+    --page-content-max-width: var(--kirby-page-content-max-width-full);
   }
 
   &::part(scroll) {
@@ -316,7 +310,7 @@ ion-content {
   }
 
   .content-inner {
-    max-width: var(--page-content-max-width, utils.$page-content-max-width-default);
+    max-width: var(--page-content-max-width, var(--kirby-page-content-max-width-default));
     margin: 0 auto;
     padding-bottom: var(--kirby-spacing-xl);
 
@@ -356,7 +350,7 @@ ion-content {
   z-index: var(--kirby-z-index-sticky-content);
 
   div {
-    max-width: var(--page-content-max-width, utils.$page-content-max-width-default);
+    max-width: var(--page-content-max-width, var(--kirby-page-content-max-width-default));
     margin: 0 auto;
   }
 

--- a/libs/designsystem/page/src/page.component.scss
+++ b/libs/designsystem/page/src/page.component.scss
@@ -1,5 +1,4 @@
 @use 'sass:color';
-@use 'sass:map';
 @use '@kirbydesign/core/src/scss/interaction-state';
 @use '@kirbydesign/core/src/scss/utils';
 

--- a/libs/designsystem/page/src/page.component.scss
+++ b/libs/designsystem/page/src/page.component.scss
@@ -13,6 +13,7 @@ $toolbar-transition-duration-in: var(--kirby-transition-duration-quick);
 $toolbar-transition-duration-out: 50ms;
 $toolbar-transition: background-color $toolbar-transition-duration-out linear;
 
+// no color-mix or other Safari-15-safe CSS custom property equivalent, so kept as SCSS.
 // stylelint-disable-next-line kirby/use-design-tokens
 $toolbar-shaded-background: color.mix(
   #000,

--- a/libs/designsystem/popover/src/popover.component.scss
+++ b/libs/designsystem/popover/src/popover.component.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 :host {
   display: none;
   position: fixed;

--- a/libs/designsystem/popover/src/popover.component.scss
+++ b/libs/designsystem/popover/src/popover.component.scss
@@ -4,7 +4,7 @@
   display: none;
   position: fixed;
   inset: 0;
-  z-index: utils.z('popover');
+  z-index: var(--kirby-z-index-popover);
 }
 
 :host(.is-opening) {
@@ -18,6 +18,6 @@
 
 .wrapper {
   position: fixed;
-  margin-top: utils.size('xxxs');
-  margin-bottom: utils.size('xxxs');
+  margin-top: var(--kirby-spacing-xxxs);
+  margin-bottom: var(--kirby-spacing-xxxs);
 }

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 svg {
   rotate: -90deg;
 }

--- a/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
+++ b/libs/designsystem/progress-circle/src/progress-circle-ring.component.scss
@@ -5,30 +5,30 @@ svg {
 }
 
 .circle {
-  stroke: utils.get-color('semi-light');
+  stroke: var(--kirby-semi-light);
 }
 
 :host {
   // Colors
   &.success {
-    --kirby-progress-circle-stroke-color: #{utils.get-color('success-shade')};
+    --kirby-progress-circle-stroke-color: var(--kirby-success-shade);
   }
 
   &.warning {
-    --kirby-progress-circle-stroke-color: #{utils.get-color('warning-shade')};
+    --kirby-progress-circle-stroke-color: var(--kirby-warning-shade);
   }
 
   &.danger {
-    --kirby-progress-circle-stroke-color: #{utils.get-color('danger')};
+    --kirby-progress-circle-stroke-color: var(--kirby-danger);
   }
 
   &.view-initialized {
     .progress {
       transition-property: stroke-dasharray, stroke;
-      transition-duration: utils.get-transition-duration('extra-long');
-      transition-timing-function: utils.get-transition-easing('enter-exit');
+      transition-duration: var(--kirby-transition-duration-extra-long);
+      transition-timing-function: var(--kirby-transition-easing-enter-exit);
       transform-origin: 50% 50%;
-      stroke: var(--kirby-progress-circle-stroke-color, #{utils.get-color('success')});
+      stroke: var(--kirby-progress-circle-stroke-color, var(--kirby-success));
     }
   }
 }

--- a/libs/designsystem/progress-circle/src/progress-circle.component.scss
+++ b/libs/designsystem/progress-circle/src/progress-circle.component.scss
@@ -13,6 +13,8 @@ kirby-progress-circle-ring {
 }
 
 kirby-progress-circle-ring {
+  // TODO(@kirby): migrate utils.z('default') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
+
   z-index: utils.z('default') + 1;
 }
 
@@ -22,7 +24,7 @@ kirby-progress-circle-ring {
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: utils.z('default');
-  border-radius: utils.border-radius('circle');
+  z-index: var(--kirby-z-index-default);
+  border-radius: var(--kirby-border-radius-circle);
   overflow: hidden;
 }

--- a/libs/designsystem/progress-circle/src/progress-circle.component.scss
+++ b/libs/designsystem/progress-circle/src/progress-circle.component.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 :host {
   display: inline-block;
   position: relative;
@@ -13,9 +11,7 @@ kirby-progress-circle-ring {
 }
 
 kirby-progress-circle-ring {
-  // TODO(@kirby): migrate utils.z('default') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
-
-  z-index: utils.z('default') + 1;
+  z-index: calc(var(--kirby-z-index-default) + 1);
 }
 
 .transcluded-content {

--- a/libs/designsystem/radio/src/radio.component.scss
+++ b/libs/designsystem/radio/src/radio.component.scss
@@ -1,4 +1,3 @@
-@use 'sass:color';
 @use 'sass:map';
 @use '@kirbydesign/core/src/scss/interaction-state';
 @use '@kirbydesign/core/src/scss/utils';

--- a/libs/designsystem/radio/src/radio.component.scss
+++ b/libs/designsystem/radio/src/radio.component.scss
@@ -4,14 +4,13 @@
 @use '@kirbydesign/core/src/scss/utils';
 
 $radio-size: 20px; // used to overwrite ionics default relative sizing, so radio size same across font sizes
-// TODO(@kirby): migrate utils.size('m') — $radio-icon-size feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
-$radio-icon-size: utils.size('m');
+$radio-icon-size: var(--kirby-spacing-m);
 $radio-icon-mark-size: var(--kirby-spacing-xs);
 $spacing-to-edge: map.get(utils.$checkbox-radio-spacing, 'to-edge');
 $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
 
 @function get-vertical-padding($target-height) {
-  @return ($target-height - $radio-icon-size) * 0.5;
+  @return calc((#{$target-height} - #{$radio-icon-size}) * 0.5);
 }
 
 :host {

--- a/libs/designsystem/radio/src/radio.component.scss
+++ b/libs/designsystem/radio/src/radio.component.scss
@@ -155,7 +155,7 @@ ion-radio {
      * We style the native wrapper to make sure it has the same height as the container
      * so the radio can be properly start-aligned with multiline labels
      */
-    height: var(--kirby-relative-spacing-m);
+    height: var(--kirby-relative-size-m);
   }
 
   // Overrides for kirby-radio inside kirby-item

--- a/libs/designsystem/radio/src/radio.component.scss
+++ b/libs/designsystem/radio/src/radio.component.scss
@@ -4,8 +4,9 @@
 @use '@kirbydesign/core/src/scss/utils';
 
 $radio-size: 20px; // used to overwrite ionics default relative sizing, so radio size same across font sizes
+// TODO(@kirby): migrate utils.size('m') — $radio-icon-size feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
 $radio-icon-size: utils.size('m');
-$radio-icon-mark-size: utils.size('xs');
+$radio-icon-mark-size: var(--kirby-spacing-xs);
 $spacing-to-edge: map.get(utils.$checkbox-radio-spacing, 'to-edge');
 $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
 
@@ -17,18 +18,18 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
   display: flex;
 
   &[disabled] {
-    color: #{utils.get-text-color('semi-dark')};
+    color: var(--kirby-text-color-semi-dark);
 
     ion-radio {
-      --color: #{utils.get-color('medium')};
-      --color-checked: #{utils.get-color('medium')};
+      --color: var(--kirby-medium);
+      --color-checked: var(--kirby-medium);
 
       &::part(container) {
-        background-color: utils.get-color('semi-light');
+        background-color: var(--kirby-semi-light);
       }
 
       &::part(mark) {
-        --color-checked: #{utils.get-color('semi-dark')};
+        --color-checked: var(--kirby-semi-dark);
       }
 
       &::part(label-text-wrapper) {
@@ -108,8 +109,8 @@ ion-radio {
     box-sizing: border-box; // Ensure padding is not added to radio width/height
 
     --border-width: 1px;
-    --color: #{utils.get-color('semi-dark')};
-    --color-checked: #{utils.get-color('success')};
+    --color: var(--kirby-semi-dark);
+    --color-checked: var(--kirby-success);
   }
   /* stylelint-enable no-duplicate-selectors */
 
@@ -129,8 +130,8 @@ ion-radio {
   &::part(container) {
     transition: interaction-state.transition();
     transition-property: background-color, box-shadow;
-    background-color: utils.get-color('white');
-    margin: utils.size('xxxxs');
+    background-color: var(--kirby-white);
+    margin: var(--kirby-spacing-xxxxs);
     width: $radio-size;
     height: $radio-size;
   }
@@ -143,7 +144,7 @@ ion-radio {
   &::part(label) {
     align-items: start;
     padding-inline: $spacing-to-edge;
-    line-height: utils.line-height('n');
+    line-height: var(--kirby-line-height-n);
   }
 
   &::part(label-text-wrapper) {
@@ -172,13 +173,13 @@ ion-radio {
 
     &.radio-label-placement-start {
       &::part(label-text-wrapper) {
-        margin-inline: 0 utils.size('xxs');
+        margin-inline: 0 var(--kirby-spacing-xxs);
       }
     }
 
     &.radio-label-placement-end {
       &::part(label-text-wrapper) {
-        margin-inline: utils.size('xxs') 0;
+        margin-inline: var(--kirby-spacing-xxs) 0;
       }
     }
   }
@@ -187,14 +188,14 @@ ion-radio {
   :host-context(kirby-radio-group.ng-touched.ng-invalid) {
     ion-radio,
     ion-radio:active {
-      --color: #{utils.get-color('danger')};
+      --color: var(--kirby-danger);
     }
   }
 
   &.radio-checked {
     &:not(:focus, .radio-disabled) {
       &::part(container) {
-        box-shadow: utils.get-elevation(4);
+        box-shadow: var(--kirby-elevation-4);
       }
     }
 
@@ -207,7 +208,7 @@ ion-radio {
 }
 
 :host-context(kirby-item) {
-  z-index: utils.z('default'); // Makes whole kirby-item clickable above item-inner.
+  z-index: var(--kirby-z-index-default); // Makes whole kirby-item clickable above item-inner.
 
   ion-radio {
     margin: 0; // Reset Ionic in-item margins

--- a/libs/designsystem/radio/src/radio.component.scss
+++ b/libs/designsystem/radio/src/radio.component.scss
@@ -156,7 +156,7 @@ ion-radio {
      * We style the native wrapper to make sure it has the same height as the container
      * so the radio can be properly start-aligned with multiline labels
      */
-    height: utils.relative-size('m');
+    height: var(--kirby-relative-spacing-m);
   }
 
   // Overrides for kirby-radio inside kirby-item

--- a/libs/designsystem/range/src/range.component.scss
+++ b/libs/designsystem/range/src/range.component.scss
@@ -1,5 +1,4 @@
 @use '@kirbydesign/core/src/scss/interaction-state';
-@use '@kirbydesign/core/src/scss/utils';
 
 $tick-height: 6px;
 $tick-width: 6px;

--- a/libs/designsystem/range/src/range.component.scss
+++ b/libs/designsystem/range/src/range.component.scss
@@ -29,15 +29,15 @@ ion-range {
   // See: https://sass-lang.com/documentation/breaking-changes/mixed-decls/
   /* stylelint-disable no-duplicate-selectors */
   & {
-    --knob-background: #{utils.get-color('white')};
+    --knob-background: var(--kirby-white);
     --knob-box-shadow: #{$knob-shadow};
     --knob-size: 24px;
-    --pin-color: #{utils.get-text-color('black')};
-    --pin-background: #{utils.get-color('semi-light')};
-    --bar-background: #{utils.get-color('medium')};
-    --bar-background-active: #{utils.get-color('dark')};
-    --bar-border-radius: #{utils.size('xxxs')};
-    --bar-height: #{utils.size('xxxxs')};
+    --pin-color: var(--kirby-text-color-black);
+    --pin-background: var(--kirby-semi-light);
+    --bar-background: var(--kirby-medium);
+    --bar-background-active: var(--kirby-dark);
+    --bar-border-radius: var(--kirby-spacing-xxxs);
+    --bar-height: var(--kirby-spacing-xxxxs);
 
     flex: 1 1 100%;
     padding: 0;
@@ -45,13 +45,13 @@ ion-range {
   /* stylelint-enable no-duplicate-selectors */
 
   &.range-disabled {
-    --knob-background: #{utils.get-color('medium')};
+    --knob-background: var(--kirby-medium);
     --knob-box-shadow: none;
-    --bar-background: #{utils.get-color('semi-light')};
-    --bar-background-active: #{utils.get-color('medium')};
+    --bar-background: var(--kirby-semi-light);
+    --bar-background-active: var(--kirby-medium);
 
     &::part(tick) {
-      background: utils.get-color('semi-light');
+      background: var(--kirby-semi-light);
     }
   }
 
@@ -65,13 +65,13 @@ ion-range {
   }
 
   &::part(pin) {
-    font-size: utils.font-size('xs');
+    font-size: var(--kirby-font-size-xs);
     color: var(--pin-color);
     background-color: var(--pin-background);
-    padding: utils.size('xxxxs') utils.size('xxs');
-    border-radius: utils.size('xxxs');
-    min-width: utils.size('m');
-    top: -#{utils.size('xs')};
+    padding: var(--kirby-spacing-xxxxs) var(--kirby-spacing-xxs);
+    border-radius: var(--kirby-spacing-xxxs);
+    min-width: var(--kirby-spacing-m);
+    top: -var(--kirby-spacing-xs);
 
     &::before {
       content: '';
@@ -87,7 +87,7 @@ ion-range {
 
   &::part(tick),
   &::part(tick-active) {
-    border-radius: utils.border-radius('circle');
+    border-radius: var(--kirby-border-radius-circle);
     width: $tick-width;
     height: $tick-height;
     margin-top: 1px; // compensate for different height of ionic tick (8px)
@@ -96,13 +96,13 @@ ion-range {
   }
 
   &::part(tick) {
-    background: utils.get-color('medium');
+    background: var(--kirby-medium);
   }
 }
 
 label {
-  font-size: utils.font-size('xs');
-  line-height: utils.line-height('xs');
-  color: utils.get-text-color('semi-dark');
-  margin-top: -#{utils.size('xxxs')};
+  font-size: var(--kirby-font-size-xs);
+  line-height: var(--kirby-line-height-xs);
+  color: var(--kirby-text-color-semi-dark);
+  margin-top: -var(--kirby-spacing-xxxs);
 }

--- a/libs/designsystem/range/src/range.component.scss
+++ b/libs/designsystem/range/src/range.component.scss
@@ -71,7 +71,7 @@ ion-range {
     padding: var(--kirby-spacing-xxxxs) var(--kirby-spacing-xxs);
     border-radius: var(--kirby-spacing-xxxs);
     min-width: var(--kirby-spacing-m);
-    top: -var(--kirby-spacing-xs);
+    top: calc(-1 * var(--kirby-spacing-xxs));
 
     &::before {
       content: '';

--- a/libs/designsystem/range/src/range.component.scss
+++ b/libs/designsystem/range/src/range.component.scss
@@ -104,5 +104,5 @@ label {
   font-size: var(--kirby-font-size-xs);
   line-height: var(--kirby-line-height-xs);
   color: var(--kirby-text-color-semi-dark);
-  margin-top: -var(--kirby-spacing-xxxs);
+  margin-top: calc(-1 * var(--kirby-spacing-xxxs));
 }

--- a/libs/designsystem/reorder-list/src/reorder-list.component.scss
+++ b/libs/designsystem/reorder-list/src/reorder-list.component.scss
@@ -22,7 +22,7 @@ ion-backdrop {
   @include utils.slotted('kirby-item') {
     box-shadow: 0 0 10px rgb(0 0 0 / 40%);
     transform: scale(1.05, 1.05);
-    border-radius: utils.border-radius('n');
+    border-radius: var(--kirby-border-radius-n);
     overflow: hidden;
   }
 }
@@ -42,8 +42,8 @@ ion-backdrop {
   }
 
   @include utils.slotted('div:last-child kirby-item') {
-    border-bottom-left-radius: utils.border-radius('n');
-    border-bottom-right-radius: utils.border-radius('n');
+    border-bottom-left-radius: var(--kirby-border-radius-n);
+    border-bottom-right-radius: var(--kirby-border-radius-n);
     overflow: hidden;
   }
 
@@ -51,7 +51,7 @@ ion-backdrop {
     @include utils.slotted('kirby-item') {
       box-shadow: 0 0 10px rgb(0 0 0 / 40%);
       transform: scale(1.05, 1.05);
-      border-radius: utils.border-radius('n');
+      border-radius: var(--kirby-border-radius-n);
       overflow: hidden;
     }
   }
@@ -70,8 +70,8 @@ kirby-card {
   z-index: auto;
 
   @include utils.slotted('div:last-child ion-reorder-group div:last-child kirby-item') {
-    border-bottom-left-radius: utils.border-radius('n');
-    border-bottom-right-radius: utils.border-radius('n');
+    border-bottom-left-radius: var(--kirby-border-radius-n);
+    border-bottom-right-radius: var(--kirby-border-radius-n);
     overflow: hidden;
   }
 
@@ -80,7 +80,7 @@ kirby-card {
   }
 
   @include utils.slotted('.content-layer > div:first-child kirby-item') {
-    border-radius: utils.border-radius('n');
+    border-radius: var(--kirby-border-radius-n);
     overflow: hidden;
   }
 

--- a/libs/designsystem/router-outlet/src/router-outlet.component.scss
+++ b/libs/designsystem/router-outlet/src/router-outlet.component.scss
@@ -6,5 +6,5 @@
   contain: size layout style;
   z-index: 0;
   overflow: hidden;
-  background-color: utils.get-color('background-color');
+  background-color: var(--kirby-background-color);
 }

--- a/libs/designsystem/router-outlet/src/router-outlet.component.scss
+++ b/libs/designsystem/router-outlet/src/router-outlet.component.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 :host {
   inset: 0;
   position: absolute;

--- a/libs/designsystem/section-header/src/_section-header.utils.scss
+++ b/libs/designsystem/section-header/src/_section-header.utils.scss
@@ -7,28 +7,28 @@
 */
 
 @mixin typography() {
-  --padding-end: #{utils.size('s')};
-  --padding-start: #{utils.size('s')};
+  --padding-end: var(--kirby-spacing-s);
+  --padding-start: var(--kirby-spacing-s);
 
   @include utils.slotted('[heading]') {
-    font-weight: utils.font-weight('bold');
-    font-size: utils.font-size('m');
-    line-height: utils.line-height('m');
+    font-weight: var(--kirby-font-weight-bold);
+    font-size: var(--kirby-font-size-m);
+    line-height: var(--kirby-line-height-m);
     color: var(--kirby-section-header-color);
-    margin: 0 0 utils.size('xxs');
+    margin: 0 0 var(--kirby-spacing-xxs);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }
 
   @include utils.slotted('h2[heading]', '.kirby-text-large[heading]') {
-    font-size: utils.font-size('l');
-    line-height: utils.line-height('l');
+    font-size: var(--kirby-font-size-l);
+    line-height: var(--kirby-line-height-l);
   }
 
   @include utils.slotted('.kirby-text-medium[heading]') {
-    font-size: utils.font-size('m');
-    line-height: utils.line-height('m');
+    font-size: var(--kirby-font-size-m);
+    line-height: var(--kirby-line-height-m);
   }
 
   @include utils.slotted(
@@ -37,16 +37,16 @@
     'h6[heading]',
     '.kirby-text-normal[heading]'
   ) {
-    font-size: utils.font-size('n');
-    line-height: utils.line-height('n');
+    font-size: var(--kirby-font-size-n);
+    line-height: var(--kirby-line-height-n);
   }
 
   @include utils.slotted('[detail]', '[label]') {
-    font-weight: utils.font-weight('light');
-    font-size: utils.font-size('s');
-    line-height: utils.line-height('s');
+    font-weight: var(--kirby-font-weight-light);
+    font-size: var(--kirby-font-size-s);
+    line-height: var(--kirby-line-height-s);
     color: var(--kirby-section-header-color);
-    margin: utils.size('xxxs') 0 utils.size('xxs');
+    margin: var(--kirby-spacing-xxxs) 0 var(--kirby-spacing-xxs);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/libs/designsystem/section-header/src/section-header.component.scss
+++ b/libs/designsystem/section-header/src/section-header.component.scss
@@ -1,4 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
 @use './section-header.utils';
 
 :host {

--- a/libs/designsystem/section-header/src/section-header.component.scss
+++ b/libs/designsystem/section-header/src/section-header.component.scss
@@ -2,7 +2,7 @@
 @use './section-header.utils';
 
 :host {
-  --kirby-section-header-color: #{utils.get-text-color('black')};
+  --kirby-section-header-color: var(--kirby-text-color-black);
 
   display: block;
 
@@ -14,8 +14,8 @@
     min-height: 0;
     z-index: initial;
     align-items: flex-end;
-    padding-left: utils.size(
-      's'
+    padding-left: var(
+      --kirby-spacing-s
     ); // Padding left is fixed here, so safe-area is not added. Handled in page instead.
 
     @include section-header.typography;

--- a/libs/designsystem/segmented-control/src/segmented-control.component.scss
+++ b/libs/designsystem/segmented-control/src/segmented-control.component.scss
@@ -23,7 +23,7 @@ $badge-offset: 0.8em;
 
       --padding-start: var(--kirby-spacing-s);
       --padding-end: var(--kirby-spacing-s);
-      --kirby-badge-right: -var(--kirby-spacing-xxs);
+      --kirby-badge-right: calc(-1 * var(--kirby-spacing-xxs));
 
       &:focus-visible {
         transition: interaction-state.transition();

--- a/libs/designsystem/segmented-control/src/segmented-control.component.scss
+++ b/libs/designsystem/segmented-control/src/segmented-control.component.scss
@@ -3,11 +3,8 @@
 
 // There is a limit to how large text can be on narrow viewports with text resized
 // before segment-button texts start to collide horizontally, so we cap it for narrow viewports
-// TODO(@kirby): migrate utils.size('xs') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
-$maximum-font-size-sm: utils.size('xs') * utils.$text-resize-threshold;
-
-// TODO(@kirby): migrate utils.size('s') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
-$maximum-font-size-md: utils.size('s') * utils.$text-resize-threshold;
+$maximum-font-size-sm: calc(var(--kirby-spacing-xs) * #{utils.$text-resize-threshold});
+$maximum-font-size-md: calc(var(--kirby-spacing-s) * #{utils.$text-resize-threshold});
 $badge-offset: 0.8em;
 
 :host {

--- a/libs/designsystem/segmented-control/src/segmented-control.component.scss
+++ b/libs/designsystem/segmented-control/src/segmented-control.component.scss
@@ -3,7 +3,10 @@
 
 // There is a limit to how large text can be on narrow viewports with text resized
 // before segment-button texts start to collide horizontally, so we cap it for narrow viewports
+// TODO(@kirby): migrate utils.size('xs') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
 $maximum-font-size-sm: utils.size('xs') * utils.$text-resize-threshold;
+
+// TODO(@kirby): migrate utils.size('s') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
 $maximum-font-size-md: utils.size('s') * utils.$text-resize-threshold;
 $badge-offset: 0.8em;
 
@@ -14,22 +17,22 @@ $badge-offset: 0.8em;
   --kirby-badge-position: absolute;
   --kirby-badge-top: #{-1 * $badge-offset};
   --kirby-badge-right: #{-2 * $badge-offset};
-  --kirby-badge-z-index: #{utils.z('segment-badge')};
+  --kirby-badge-z-index: var(--kirby-z-index-segment-badge);
 
   &.sm {
     ion-segment-button {
-      min-height: utils.size('l');
-      font-size: min(utils.font-size('xs'), $maximum-font-size-sm);
+      min-height: var(--kirby-spacing-l);
+      font-size: min(var(--kirby-font-size-xs), $maximum-font-size-sm);
 
-      --padding-start: #{utils.size('s')};
-      --padding-end: #{utils.size('s')};
-      --kirby-badge-right: -#{utils.size('xxs')};
+      --padding-start: var(--kirby-spacing-s);
+      --padding-end: var(--kirby-spacing-s);
+      --kirby-badge-right: -var(--kirby-spacing-xxs);
 
       &:focus-visible {
         transition: interaction-state.transition();
         box-shadow: var(--kirby-focus-ring-md-inset);
         outline: none;
-        border-radius: utils.border-radius('pill');
+        border-radius: var(--kirby-border-radius-pill);
       }
     }
   }
@@ -54,8 +57,8 @@ $badge-offset: 0.8em;
       --background: none;
 
       border-radius: 0;
-      padding: #{utils.size('xxxs')};
-      gap: #{utils.size('xxs')};
+      padding: var(--kirby-spacing-xxxs);
+      gap: var(--kirby-spacing-xxs);
 
       @include utils.touch {
         scrollbar-width: none; /* Firefox */
@@ -83,8 +86,8 @@ $badge-offset: 0.8em;
 
     ion-segment-button {
       --background: transparent;
-      --padding-start: #{utils.size('xs')};
-      --padding-end: #{utils.size('xs')};
+      --padding-start: var(--kirby-spacing-xs);
+      --padding-end: var(--kirby-spacing-xs);
     }
   }
 
@@ -103,7 +106,7 @@ $badge-offset: 0.8em;
 }
 
 ion-segment {
-  border-radius: utils.border-radius('pill');
+  border-radius: var(--kirby-border-radius-pill);
   grid-auto-columns: max-content;
   box-sizing: border-box;
 }
@@ -120,7 +123,7 @@ ion-segment-button {
   // See: https://sass-lang.com/documentation/breaking-changes/mixed-decls/
   /* stylelint-disable no-duplicate-selectors */
   & {
-    --border-radius: #{utils.border-radius('pill')};
+    --border-radius: var(--kirby-border-radius-pill);
     --border-style: none;
     --background: none;
     --color: var(--kirby-inputs-color);
@@ -128,17 +131,17 @@ ion-segment-button {
     --color-checked: var(--kirby-inputs-indicator-color);
     --indicator-box-shadow: none;
     --indicator-transform: none;
-    --padding-start: #{utils.size('m')};
-    --padding-end: #{utils.size('m')};
+    --padding-start: var(--kirby-spacing-m);
+    --padding-end: var(--kirby-spacing-m);
     --margin-bottom: 0;
     --margin-end: 0;
     --margin-start: 0;
     --margin-top: 0;
 
-    min-height: utils.size('xl');
+    min-height: var(--kirby-spacing-xl);
     min-width: fit-content;
-    font-weight: utils.font-weight('normal');
-    font-size: min(utils.font-size('s'), $maximum-font-size-md);
+    font-weight: var(--kirby-font-weight-normal);
+    font-size: min(var(--kirby-font-size-s), $maximum-font-size-md);
     text-transform: none;
     margin: 0;
   }

--- a/libs/designsystem/slide-button/src/slide-button.component.scss
+++ b/libs/designsystem/slide-button/src/slide-button.component.scss
@@ -5,9 +5,9 @@ $slide-button-container-width: 256px;
 $slide-button-spacing: 2px;
 $slide-button-width: 52px;
 $slide-button-container-height: $slide-button-width + 2 * $slide-button-spacing;
-$slide-button-container-bg-color: utils.get-color('primary');
-$slider-thumb-bg-color: utils.get-color('white');
-$slide-button-text-color: utils.get-color('primary-contrast');
+$slide-button-container-bg-color: var(--kirby-primary);
+$slider-thumb-bg-color: var(--kirby-white);
+$slide-button-text-color: var(--kirby-primary-contrast);
 $total-slider-thumb-width: $slide-button-width + $slide-button-spacing * 2;
 $slide-button-container-radius: $slide-button-width * 0.5;
 $slide-button-text-padding: 0 $slide-button-container-radius 0 $total-slider-thumb-width;
@@ -26,12 +26,12 @@ $slide-button-text-padding: 0 $slide-button-container-radius 0 $total-slider-thu
   & {
     transition: interaction-state.transition();
     appearance: none;
-    border-radius: utils.border-radius('circle');
+    border-radius: var(--kirby-border-radius-circle);
     background-color: $slider-thumb-bg-color;
     background-image: url('/assets/kirby/icons/svg/arrow-more.svg');
     background-repeat: no-repeat;
     background-position: center;
-    background-size: utils.size('m');
+    background-size: var(--kirby-spacing-m);
     width: $slide-button-width;
     height: $slide-button-width;
     border: none;
@@ -63,7 +63,7 @@ $slide-button-text-padding: 0 $slide-button-container-radius 0 $total-slider-thu
 
     &:has(:focus-visible) {
       transition: interaction-state.transition();
-      box-shadow: utils.get-elevation(2), var(--kirby-focus-ring-md-inset);
+      box-shadow: var(--kirby-elevation-2), var(--kirby-focus-ring-md-inset);
     }
   }
 
@@ -76,7 +76,7 @@ $slide-button-text-padding: 0 $slide-button-container-radius 0 $total-slider-thu
 
   .slide-button-text {
     position: absolute;
-    font-size: utils.font-size('n');
+    font-size: var(--kirby-font-size-n);
     margin: 0;
     line-height: 1;
     z-index: 1;

--- a/libs/designsystem/slide-button/src/slide-button.component.scss
+++ b/libs/designsystem/slide-button/src/slide-button.component.scss
@@ -1,5 +1,4 @@
 @use '@kirbydesign/core/src/scss/interaction-state';
-@use '@kirbydesign/core/src/scss/utils';
 
 $slide-button-container-width: 256px;
 $slide-button-spacing: 2px;

--- a/libs/designsystem/slide/src/slides.component.scss
+++ b/libs/designsystem/slide/src/slides.component.scss
@@ -10,17 +10,17 @@ $bullet-inactive-opacity: 0.2;
   --swiper-pagination-bullet-width: #{$bullet-width};
   --swiper-pagination-bullet-height: #{$bullet-height};
   --swiper-pagination-bullet-border-radius: #{$bullet-border-radius};
-  --swiper-pagination-bullet-horizontal-gap: #{utils.size('xxxs')};
-  --swiper-pagination-color: #{utils.get-color('black')};
-  --swiper-pagination-bullet-inactive-color: #{utils.get-color('black')};
+  --swiper-pagination-bullet-horizontal-gap: var(--kirby-spacing-xxxs);
+  --swiper-pagination-color: var(--kirby-black);
+  --swiper-pagination-bullet-inactive-color: var(--kirby-black);
   --swiper-pagination-bullet-inactive-opacity: #{$bullet-inactive-opacity};
 
   .navigation {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-block: 0 utils.size('s');
-    margin-inline: utils.size('s');
+    margin-block: 0 var(--kirby-spacing-s);
+    margin-inline: var(--kirby-spacing-s);
 
     &-inner {
       display: flex;
@@ -32,7 +32,7 @@ $bullet-inactive-opacity: 0.2;
     display: flex;
     align-items: center;
     width: auto;
-    margin-inline-end: utils.size('s');
+    margin-inline-end: var(--kirby-spacing-s);
 
     // we need to use ::ng-deep as the pagination bullet spans are added to the dom by swiperjs:
     /* stylelint-disable selector-pseudo-element-no-unknown */
@@ -45,6 +45,8 @@ $bullet-inactive-opacity: 0.2;
     display: none;
 
     // Adding one to default to make buttons clickable through box shadow.
+    // TODO(@kirby): migrate utils.z('default') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
+
     z-index: utils.z('default') + 1;
 
     @include utils.media('>=medium') {
@@ -62,7 +64,7 @@ $bullet-inactive-opacity: 0.2;
     }
 
     @include utils.slotted('button[kirby-button]') {
-      margin-inline: utils.size('xxs') 0;
+      margin-inline: var(--kirby-spacing-xxs) 0;
     }
   }
 
@@ -73,13 +75,13 @@ $bullet-inactive-opacity: 0.2;
   }
 
   swiper-container {
-    padding-block: utils.size('m');
-    margin-block: -(utils.size('m'));
+    padding-block: var(--kirby-spacing-m);
+    margin-block: -(var(--kirby-spacing-m));
   }
 
   @include utils.media('<medium') {
     swiper-container {
-      padding-inline: utils.size('s');
+      padding-inline: var(--kirby-spacing-s);
       margin-inline: calc(-1 * var(--padding-start)) calc(-1 * var(--padding-end));
     }
 
@@ -101,9 +103,9 @@ $bullet-inactive-opacity: 0.2;
   .title {
     @include utils.slotted(h1, h2, h3, h4, h5, h6) {
       margin: 0;
-      font-size: utils.font-size('m');
-      font-weight: utils.font-weight('bold');
-      line-height: utils.line-height('m');
+      font-size: var(--kirby-font-size-m);
+      font-weight: var(--kirby-font-weight-bold);
+      line-height: var(--kirby-line-height-m);
     }
   }
 }

--- a/libs/designsystem/slide/src/slides.component.scss
+++ b/libs/designsystem/slide/src/slides.component.scss
@@ -45,9 +45,7 @@ $bullet-inactive-opacity: 0.2;
     display: none;
 
     // Adding one to default to make buttons clickable through box shadow.
-    // TODO(@kirby): migrate utils.z('default') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
-
-    z-index: utils.z('default') + 1;
+    z-index: calc(var(--kirby-z-index-default) + 1);
 
     @include utils.media('>=medium') {
       display: block;

--- a/libs/designsystem/slide/src/slides.component.scss
+++ b/libs/designsystem/slide/src/slides.component.scss
@@ -74,7 +74,7 @@ $bullet-inactive-opacity: 0.2;
 
   swiper-container {
     padding-block: var(--kirby-spacing-m);
-    margin-block: -(var(--kirby-spacing-m));
+    margin-block: calc(-1 * var(--kirby-spacing-m));
   }
 
   @include utils.media('<medium') {

--- a/libs/designsystem/spinner/src/spinner.component.scss
+++ b/libs/designsystem/spinner/src/spinner.component.scss
@@ -2,8 +2,8 @@
 
 .spinner {
   overflow: hidden;
-  width: utils.size('l');
-  height: utils.size('l');
+  width: var(--kirby-spacing-l);
+  height: var(--kirby-spacing-l);
   position: relative;
   margin: 0 auto;
 }
@@ -12,8 +12,8 @@
 .outer-circle {
   width: 100%;
   height: 100%;
-  border-radius: utils.border-radius('circle');
-  background-color: utils.get-color('primary');
+  border-radius: var(--kirby-border-radius-circle);
+  background-color: var(--kirby-primary);
   opacity: 0.6;
   position: absolute;
   top: 0;

--- a/libs/designsystem/spinner/src/spinner.component.scss
+++ b/libs/designsystem/spinner/src/spinner.component.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 .spinner {
   overflow: hidden;
   width: var(--kirby-spacing-l);

--- a/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.scss
+++ b/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.scss
@@ -4,9 +4,7 @@
 $tab-item-text-max-width: 100px;
 $bottom-border-height: 1px;
 $border-color-selected: var(--kirby-dark);
-
-// TODO(@kirby): migrate utils.size('s') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
-$maximum-font-size: utils.size('s') * utils.$text-resize-threshold;
+$maximum-font-size: calc(var(--kirby-spacing-s) * #{utils.$text-resize-threshold});
 
 @mixin button-reset {
   background: transparent;

--- a/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.scss
+++ b/libs/designsystem/tab-navigation/src/tab-navigation-item/tab-navigation-item.component.scss
@@ -3,7 +3,9 @@
 
 $tab-item-text-max-width: 100px;
 $bottom-border-height: 1px;
-$border-color-selected: utils.get-color('dark');
+$border-color-selected: var(--kirby-dark);
+
+// TODO(@kirby): migrate utils.size('s') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
 $maximum-font-size: utils.size('s') * utils.$text-resize-threshold;
 
 @mixin button-reset {
@@ -33,27 +35,27 @@ $maximum-font-size: utils.size('s') * utils.$text-resize-threshold;
   button[role='tab'] {
     @include button-reset;
 
-    color: utils.get-color('black');
+    color: var(--kirby-black);
     box-sizing: border-box; // Ensure border is not added to button height
-    padding: utils.size('s');
-    font-size: min(utils.font-size('n'), $maximum-font-size);
-    line-height: utils.line-height('m');
-    gap: utils.size('xxxs');
+    padding: var(--kirby-spacing-s);
+    font-size: min(var(--kirby-font-size-n), $maximum-font-size);
+    line-height: var(--kirby-line-height-m);
+    gap: var(--kirby-spacing-xxxs);
 
     &:focus,
     &:hover {
-      font-weight: utils.font-weight('bold');
+      font-weight: var(--kirby-font-weight-bold);
     }
 
     &:focus-visible {
       outline: none;
-      border-radius: utils.size('xxxs');
+      border-radius: var(--kirby-spacing-xxxs);
       transition: box-shadow #{interaction-state.$default-transition-duration} linear;
       box-shadow: var(--kirby-focus-ring-sm-inset);
     }
 
     &[aria-selected='true'] {
-      font-weight: utils.font-weight('bold');
+      font-weight: var(--kirby-font-weight-bold);
 
       // Selected divider
       &::before {
@@ -82,7 +84,7 @@ span[data-text] {
   &::before {
     display: block;
     content: attr(data-text);
-    font-weight: utils.font-weight('bold');
+    font-weight: var(--kirby-font-weight-bold);
     height: 0;
     overflow: hidden;
     visibility: hidden;

--- a/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.scss
+++ b/libs/designsystem/tab-navigation/src/tab-navigation/tab-navigation.component.scss
@@ -1,7 +1,7 @@
 @use '@kirbydesign/core/src/scss/utils';
 
 $bottom-border-height: 1px;
-$border-color-standard: utils.get-color('medium');
+$border-color-standard: var(--kirby-medium);
 
 :host {
   display: block;
@@ -20,7 +20,7 @@ $border-color-standard: utils.get-color('medium');
     position: absolute;
     height: $bottom-border-height;
     bottom: 0;
-    z-index: utils.z('default');
+    z-index: var(--kirby-z-index-default);
     left: 0;
     width: 100%;
   }
@@ -34,7 +34,7 @@ div[role='tablist'] {
   justify-content: left;
   flex-wrap: nowrap;
   overflow-x: scroll;
-  column-gap: utils.size('xs');
+  column-gap: var(--kirby-spacing-xs);
 
   // Ensures that the .container divider pseudo-element does not overlap the .selected divider pseudo-element.
   // There seems be a weird bug with the iOS browser where z-index of scrollable elements are not respected with momentum scrolling active - so we disable it for now.

--- a/libs/designsystem/tabs/src/tab-button/tab-button.component.scss
+++ b/libs/designsystem/tabs/src/tab-button/tab-button.component.scss
@@ -1,12 +1,9 @@
-@use 'sass:math';
-
 @use '@kirbydesign/core/src/scss/interaction-state';
 @use '@kirbydesign/core/src/scss/utils';
 
 // There is a limit to how large text can be on narrow viewports with text resized
 // before tab button texts start to collide horizontally, so we cap it for narrow viewports
-// TODO(@kirby): migrate utils.size('xs') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
-$maximum-font-size: utils.size('xs') * utils.$text-resize-threshold;
+$maximum-font-size: calc(var(--kirby-spacing-xs) * #{utils.$text-resize-threshold});
 
 // badge size is fixed on narrow viewports to ensure it is properly sized accordion to the tab icon
 $fixed-badge-size: 10px;

--- a/libs/designsystem/tabs/src/tab-button/tab-button.component.scss
+++ b/libs/designsystem/tabs/src/tab-button/tab-button.component.scss
@@ -5,6 +5,7 @@
 
 // There is a limit to how large text can be on narrow viewports with text resized
 // before tab button texts start to collide horizontally, so we cap it for narrow viewports
+// TODO(@kirby): migrate utils.size('xs') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
 $maximum-font-size: utils.size('xs') * utils.$text-resize-threshold;
 
 // badge size is fixed on narrow viewports to ensure it is properly sized accordion to the tab icon
@@ -42,14 +43,14 @@ ion-tab-button {
     height: 100%;
     flex: 1 1 0%;
     max-width: 168px;
-    font-weight: utils.font-weight('medium');
-    font-size: min(utils.font-size('xs'), $maximum-font-size);
+    font-weight: var(--kirby-font-weight-medium);
+    font-size: min(var(--kirby-font-size-xs), $maximum-font-size);
 
-    --color: #{utils.get-text-color('semi-dark')};
-    --color-selected: #{utils.get-color('black')};
+    --color: var(--kirby-text-color-semi-dark);
+    --color-selected: var(--kirby-black);
     --padding-start: 0;
     --padding-end: 0;
-    --kirby-icon-font-size: #{utils.size('m')};
+    --kirby-icon-font-size: var(--kirby-spacing-m);
 
     // Magic values here as we have no tokens that gives
     // badge the correct position in relation to the tab icon
@@ -72,10 +73,10 @@ ion-tab-button {
   @include utils.media('>=medium') {
     flex: none;
     flex-direction: row;
-    font-size: min(utils.font-size('s'), $maximum-font-size);
+    font-size: min(var(--kirby-font-size-s), $maximum-font-size);
 
-    --padding-start: #{utils.size('m')};
-    --padding-end: #{utils.size('m')};
+    --padding-start: var(--kirby-spacing-m);
+    --padding-end: var(--kirby-spacing-m);
 
     // Magic values here as we have no tokens that gives
     // badge the correct position in relation to the tab icon
@@ -95,24 +96,24 @@ ion-tab-button {
         // Using / for division outside of calc() is deprecated
         // and will be removed in Dart Sass 2.0.0. Use math.div() instead.
         // See: https://sass-lang.com/documentation/breaking-changes/slash-div/
-        margin-bottom: math.div(utils.size('xxxxs'), 2);
+        margin-bottom: math.div(var(--kirby-spacing-xxxxs), 2);
       }
     }
 
     @include utils.slotted(kirby-icon) {
-      --kirby-icon-margin-right: #{utils.size('xxs')};
+      --kirby-icon-margin-right: var(--kirby-spacing-xxs);
     }
   }
 
   @include utils.media('>=large') {
-    font-size: utils.font-size('s');
-    line-height: utils.line-height('s');
+    font-size: var(--kirby-font-size-s);
+    line-height: var(--kirby-line-height-s);
 
     --kirby-badge-font-size: initial;
 
     @include utils.not-touch {
-      --padding-start: #{utils.size('xs')};
-      --padding-end: #{utils.size('xs')};
+      --padding-start: var(--kirby-spacing-xs);
+      --padding-end: var(--kirby-spacing-xs);
     }
   }
 }

--- a/libs/designsystem/tabs/src/tab-button/tab-button.component.scss
+++ b/libs/designsystem/tabs/src/tab-button/tab-button.component.scss
@@ -89,7 +89,7 @@ ion-tab-button {
         --kirby-badge-left: 0;
 
         margin-left: $wide-viewport-badge-margin;
-        margin-bottom: calc(var(--kirby-spacing-xxxxs / 2));
+        margin-bottom: calc(var(--kirby-spacing-xxxxs) / 2);
       }
     }
 

--- a/libs/designsystem/tabs/src/tab-button/tab-button.component.scss
+++ b/libs/designsystem/tabs/src/tab-button/tab-button.component.scss
@@ -92,11 +92,7 @@ ion-tab-button {
         --kirby-badge-left: 0;
 
         margin-left: $wide-viewport-badge-margin;
-
-        // Using / for division outside of calc() is deprecated
-        // and will be removed in Dart Sass 2.0.0. Use math.div() instead.
-        // See: https://sass-lang.com/documentation/breaking-changes/slash-div/
-        margin-bottom: math.div(var(--kirby-spacing-xxxxs), 2);
+        margin-bottom: calc(var(--kirby-spacing-xxxxs / 2));
       }
     }
 

--- a/libs/designsystem/tabs/src/tabs.component.scss
+++ b/libs/designsystem/tabs/src/tabs.component.scss
@@ -6,9 +6,9 @@
 
 ion-tabs {
   ion-tab-bar {
-    --background: rgba(#{utils.get-color('white-rgb')}, 0.94);
-    --border: 1px solid #{utils.get-color('light')};
-    --color: #{utils.get-color('black')};
+    --background: rgba(var(--kirby-white-rgb), 0.94);
+    --border: 1px solid var(--kirby-light);
+    --color: var(--kirby-black);
 
     display: flex;
     max-width: var(--kirby-tab-bar-max-width, none);
@@ -30,7 +30,7 @@ ion-tabs {
     --kirby-tab-bar-height: 70px;
 
     ion-tab-bar {
-      column-gap: utils.size('m');
+      column-gap: var(--kirby-spacing-m);
     }
   }
 

--- a/libs/designsystem/toggle/src/toggle.component.scss
+++ b/libs/designsystem/toggle/src/toggle.component.scss
@@ -108,12 +108,12 @@ ion-toggle {
   /* stylelint-disable no-duplicate-selectors */
   & {
     // Not checked
-    --track-background: #{utils.get-color($background)};
-    --handle-background: #{utils.get-color($handle-background)};
+    --track-background: var(--kirby-semi-dark);
+    --handle-background: var(--kirby-white);
 
     // Checked
-    --track-background-checked: #{utils.get-color($background-checked)};
-    --handle-background-checked: #{utils.get-color($handle-background)};
+    --track-background-checked: var(--kirby-success);
+    --handle-background-checked: var(--kirby-white);
     --handle-transition: var(--kirby-transition-duration-quick);
     --handle-box-shadow: var(--kirby-elevation-2);
 
@@ -167,8 +167,8 @@ ion-toggle {
 }
 
 /*
-* For now, Kirby defaults to the legacy ion-toggle to not force users into 
-* providing a label for each toggle. The legacy toggle has additional padding  
+* For now, Kirby defaults to the legacy ion-toggle to not force users into
+* providing a label for each toggle. The legacy toggle has additional padding
 * in Ionic v7 when inside an item that needs to be reset.
 */
 ion-toggle.in-item.legacy-toggle {

--- a/libs/designsystem/toggle/src/toggle.component.scss
+++ b/libs/designsystem/toggle/src/toggle.component.scss
@@ -1,4 +1,3 @@
-@use 'sass:math';
 @use 'sass:map';
 @use '@kirbydesign/core/src/scss/interaction-state';
 @use '@kirbydesign/core/src/scss/utils';
@@ -120,17 +119,13 @@ ion-toggle {
 
     // Ion v8 changed height on toggles to 31px. To make toggles still follow our 8,16,24,32 pixel-size pattern, we force the toggle back to 32px
 
-    // TODO(@kirby): migrate utils.size('l') — $toggle-size feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
-
-    $toggle-size: utils.size('l');
-
-    // TODO(@kirby): migrate utils.size('xxxxs') — $toggle-border-size feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
-    $toggle-border-size: utils.size('xxxxs');
-    $toggle-handle-size: $toggle-size - ($toggle-border-size * 2);
+    $toggle-size: var(--kirby-spacing-l);
+    $toggle-border-size: var(--kirby-spacing-xxxxs);
+    $toggle-handle-size: calc(#{$toggle-size} - (#{$toggle-border-size} * 2));
 
     --handle-height: #{$toggle-handle-size};
     --handle-width: #{$toggle-handle-size};
-    --border-radius: #{math.div($toggle-size, 2)};
+    --border-radius: calc(#{$toggle-size} / 2);
 
     &::part(track) {
       transition: interaction-state.transition();

--- a/libs/designsystem/toggle/src/toggle.component.scss
+++ b/libs/designsystem/toggle/src/toggle.component.scss
@@ -47,11 +47,11 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
   }
 
   &[disabled] {
-    color: #{utils.get-text-color('semi-dark')};
+    color: var(--kirby-text-color-semi-dark);
 
     ion-toggle {
-      --color: #{utils.get-color('medium')};
-      --color-checked: #{utils.get-color('medium')};
+      --color: var(--kirby-medium);
+      --color-checked: var(--kirby-medium);
 
       opacity: 1; // Reset Ionic disabled style for label
 
@@ -115,12 +115,16 @@ ion-toggle {
     // Checked
     --track-background-checked: #{utils.get-color($background-checked)};
     --handle-background-checked: #{utils.get-color($handle-background)};
-    --handle-transition: #{utils.get-transition-duration('quick')};
-    --handle-box-shadow: #{utils.get-elevation(2)};
+    --handle-transition: var(--kirby-transition-duration-quick);
+    --handle-box-shadow: var(--kirby-elevation-2);
 
     // Ion v8 changed height on toggles to 31px. To make toggles still follow our 8,16,24,32 pixel-size pattern, we force the toggle back to 32px
 
+    // TODO(@kirby): migrate utils.size('l') — $toggle-size feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
+
     $toggle-size: utils.size('l');
+
+    // TODO(@kirby): migrate utils.size('xxxxs') — $toggle-border-size feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
     $toggle-border-size: utils.size('xxxxs');
     $toggle-handle-size: $toggle-size - ($toggle-border-size * 2);
 
@@ -136,7 +140,7 @@ ion-toggle {
   }
 
   ::part(label-text-wrapper) {
-    line-height: utils.line-height('n');
+    line-height: var(--kirby-line-height-n);
     white-space: pre-line;
   }
 
@@ -177,7 +181,7 @@ ion-toggle.in-item.legacy-toggle {
 }
 
 :host-context(kirby-item) {
-  z-index: utils.z('default'); // Makes whole kirby-item clickable above item-inner.
+  z-index: var(--kirby-z-index-default); // Makes whole kirby-item clickable above item-inner.
 
   ion-toggle {
     margin: 0;

--- a/libs/extensions/angular/combobox/src/combobox.component.scss
+++ b/libs/extensions/angular/combobox/src/combobox.component.scss
@@ -3,6 +3,8 @@
 
 $dropdown-max-height: 8 * utils.$dropdown-item-height;
 $dropdown-min-height: utils.$dropdown-item-height;
+
+// TODO(@kirby): migrate utils.size('s') — $margin-horizontal-total feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
 $margin-horizontal-total: 2 * utils.size('s');
 $min-screen-width-small: 320px;
 $min-screen-width: 375px;
@@ -12,7 +14,7 @@ $min-screen-width: 375px;
     transition: interaction-state.transition();
     box-shadow: var(--kirby-focus-ring-md-inset);
     outline: none;
-    border-radius: utils.border-radius('pill');
+    border-radius: var(--kirby-border-radius-pill);
   }
 
   // Wrap declarations to avoid mixing with nested rules.
@@ -43,18 +45,18 @@ $min-screen-width: 375px;
     position: relative;
 
     > input[kirby-input] {
-      padding-right: utils.size('xl');
+      padding-right: var(--kirby-spacing-xl);
     }
 
     > input[kirby-input]:disabled ~ kirby-icon {
-      color: utils.get-color('semi-dark-shade');
+      color: var(--kirby-semi-dark-shade);
     }
 
     > kirby-icon {
       position: absolute;
       top: 0;
       bottom: 0;
-      right: utils.size('xs');
+      right: var(--kirby-spacing-xs);
     }
   }
 
@@ -74,7 +76,7 @@ kirby-card {
   flex-direction: column;
   max-height: $dropdown-max-height;
   overflow: hidden;
-  box-shadow: utils.get-elevation(4);
+  box-shadow: var(--kirby-elevation-4);
   max-width: calc(100vw - #{$margin-horizontal-total});
   min-width: $min-screen-width-small - $margin-horizontal-total;
   @include utils.media('>xsmall') {
@@ -88,5 +90,5 @@ kirby-card {
 }
 
 .no-results {
-  color: utils.get-text-color('semi-dark');
+  color: var(--kirby-text-color-semi-dark);
 }

--- a/libs/extensions/angular/combobox/src/combobox.component.scss
+++ b/libs/extensions/angular/combobox/src/combobox.component.scss
@@ -3,9 +3,7 @@
 
 $dropdown-max-height: 8 * utils.$dropdown-item-height;
 $dropdown-min-height: utils.$dropdown-item-height;
-
-// TODO(@kirby): migrate utils.size('s') — $margin-horizontal-total feeds a SCSS calculation — convert the calculation to CSS calc() using the design token(s)
-$margin-horizontal-total: 2 * utils.size('s');
+$margin-horizontal-total: calc(2 * var(--kirby-spacing-s));
 $min-screen-width-small: 320px;
 $min-screen-width: 375px;
 
@@ -78,9 +76,9 @@ kirby-card {
   overflow: hidden;
   box-shadow: var(--kirby-elevation-4);
   max-width: calc(100vw - #{$margin-horizontal-total});
-  min-width: $min-screen-width-small - $margin-horizontal-total;
+  min-width: calc(#{$min-screen-width-small} - #{$margin-horizontal-total});
   @include utils.media('>xsmall') {
-    min-width: $min-screen-width - $margin-horizontal-total;
+    min-width: calc(#{$min-screen-width} - #{$margin-horizontal-total});
   }
 }
 

--- a/libs/extensions/angular/image-banner/src/image-banner.component.scss
+++ b/libs/extensions/angular/image-banner/src/image-banner.component.scss
@@ -13,15 +13,9 @@ $min-text-content-height: calc(
 $main-image-height-small: 132px;
 $wide-image-banner-min-height: 180px;
 $text-box-trim-offset: 2px;
-
-// TODO(@kirby): migrate utils.size('s') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
-$main-content-top-padding: utils.size('s') - $text-box-trim-offset;
-
-// TODO(@kirby): migrate utils.size('xs') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
-$wide-main-content-top-padding: utils.size('xs') - $text-box-trim-offset;
-
-// TODO(@kirby): migrate utils.size('xxs') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
-$main-content-bottom-padding: utils.size('xxs') - $text-box-trim-offset;
+$main-content-top-padding: calc(var(--kirby-spacing-s) - #{$text-box-trim-offset});
+$wide-main-content-top-padding: calc(var(--kirby-spacing-xs) - #{$text-box-trim-offset});
+$main-content-bottom-padding: calc(var(--kirby-spacing-xxs) - #{$text-box-trim-offset});
 
 // The breakpoint where container should switch from "narrow" to "wide"
 $container-query-breakpoint: 600px;

--- a/libs/extensions/angular/image-banner/src/image-banner.component.scss
+++ b/libs/extensions/angular/image-banner/src/image-banner.component.scss
@@ -7,14 +7,20 @@ $max-content-width: 324px;
 // Minimum height for the text area: 1 line of normal-sized title + 2 lines of small-sized body.
 // Computed explicitly because the two text styles have different font-sizes, so a single `lh` unit cannot represent both.
 $min-text-content-height: calc(
-  #{utils.font-size('n')} * #{utils.line-height('n')} + 2 * #{utils.font-size('s')} *
-    #{utils.line-height('s')}
+  var(--kirby-font-size-n) * var(--kirby-line-height-n) + 2 * var(--kirby-font-size-s) *
+    var(--kirby-line-height-s)
 );
 $main-image-height-small: 132px;
 $wide-image-banner-min-height: 180px;
 $text-box-trim-offset: 2px;
+
+// TODO(@kirby): migrate utils.size('s') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
 $main-content-top-padding: utils.size('s') - $text-box-trim-offset;
+
+// TODO(@kirby): migrate utils.size('xs') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
 $wide-main-content-top-padding: utils.size('xs') - $text-box-trim-offset;
+
+// TODO(@kirby): migrate utils.size('xxs') — used in a SCSS arithmetic expression — convert the calculation to CSS calc() using the design token(s)
 $main-content-bottom-padding: utils.size('xxs') - $text-box-trim-offset;
 
 // The breakpoint where container should switch from "narrow" to "wide"
@@ -143,13 +149,13 @@ kirby-card {
 .main-content-wrapper {
   width: 100%;
   min-height: $wide-image-banner-min-height;
-  padding: utils.size('xxs');
+  padding: var(--kirby-spacing-xxs);
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
 
   @include if-wide-view {
-    gap: utils.size('s');
+    gap: var(--kirby-spacing-s);
     flex-direction: initial;
   }
 }
@@ -157,7 +163,7 @@ kirby-card {
 .main-content-image-wrapper {
   display: flex;
   overflow: hidden;
-  border-radius: utils.border-radius('s');
+  border-radius: var(--kirby-border-radius-s);
 
   @include if-wide-view {
     flex: 1;
@@ -170,7 +176,7 @@ kirby-card {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding: $main-content-top-padding 0 $main-content-bottom-padding utils.size('xxs');
+  padding: $main-content-top-padding 0 $main-content-bottom-padding var(--kirby-spacing-xxs);
   overflow: hidden;
 
   @include if-narrow-view {
@@ -179,21 +185,21 @@ kirby-card {
 
   @include if-wide-view {
     flex: 1;
-    gap: utils.size('xs');
-    padding: $wide-main-content-top-padding utils.size('xxs') utils.size('xxs') 0;
+    gap: var(--kirby-spacing-xs);
+    padding: $wide-main-content-top-padding var(--kirby-spacing-xxs) var(--kirby-spacing-xxs) 0;
   }
 
   .main-content-header {
-    padding-inline-end: utils.size('xxs');
+    padding-inline-end: var(--kirby-spacing-xxs);
 
     @include if-wide-view {
-      padding-inline-end: utils.size('xl');
+      padding-inline-end: var(--kirby-spacing-xl);
     }
   }
 
   &:has(.main-content-body-action-link) {
     .main-content-header {
-      padding-inline-end: utils.size('xl');
+      padding-inline-end: var(--kirby-spacing-xl);
     }
   }
 }
@@ -244,10 +250,10 @@ kirby-card {
   line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  padding-inline-end: utils.size('xxs');
+  padding-inline-end: var(--kirby-spacing-xxs);
 
   @include if-wide-view {
-    padding-inline-end: utils.size('xxl');
+    padding-inline-end: var(--kirby-spacing-xxl);
   }
 
   @include if-narrow-view {
@@ -259,7 +265,7 @@ kirby-card {
 
 .breakout {
   position: initial;
-  border-radius: utils.size('s');
+  border-radius: var(--kirby-spacing-s);
   align-self: center;
 
   &::before {
@@ -289,12 +295,12 @@ kirby-card {
   }
 
   &:is(a) {
-    width: utils.size('m');
-    min-width: utils.size('m');
-    margin-bottom: utils.size('xxxs');
+    width: var(--kirby-spacing-m);
+    min-width: var(--kirby-spacing-m);
+    margin-bottom: var(--kirby-spacing-xxxs);
 
     kirby-icon {
-      font-size: utils.size('m');
+      font-size: var(--kirby-spacing-m);
     }
   }
 
@@ -311,7 +317,7 @@ kirby-card {
 :host(.show-button-in-narrow-view) {
   .wide-view-action {
     display: inline-flex;
-    margin-bottom: utils.size('xxs');
+    margin-bottom: var(--kirby-spacing-xxs);
   }
 
   .narrow-view-action {
@@ -321,8 +327,8 @@ kirby-card {
 
 button.dismiss {
   position: absolute;
-  top: utils.size('s');
-  right: utils.size('s');
+  top: var(--kirby-spacing-s);
+  right: var(--kirby-spacing-s);
   margin: 0;
 }
 
@@ -336,7 +342,7 @@ button.dismiss {
   min-height: var(--kirby-x-image-banner-min-height, $min-text-content-height);
 
   @include if-wide-view {
-    gap: utils.size('xs');
+    gap: var(--kirby-spacing-xs);
     min-height: initial;
   }
 }
@@ -344,9 +350,9 @@ button.dismiss {
 .title {
   @include utils.slotted(h1, h2, h3, h4, h5, h6) {
     margin-bottom: 0;
-    font-size: utils.font-size('n');
-    font-weight: utils.font-weight('bold');
-    line-height: utils.line-height('n');
+    font-size: var(--kirby-font-size-n);
+    font-weight: var(--kirby-font-weight-bold);
+    line-height: var(--kirby-line-height-n);
   }
 }
 

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-anchor-item/menu-anchor-item.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-anchor-item/menu-anchor-item.component.scss
@@ -1,6 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-@use '@kirbydesign/core/src/scss/interaction-state';
-
 :host {
   display: flex;
   flex-direction: row;

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-anchor-item/menu-anchor-item.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-anchor-item/menu-anchor-item.component.scss
@@ -9,7 +9,7 @@
   overflow: visible;
 
   &.selected {
-    color: var(--menuitem-selected-color, utils.get-color('primary-contrast'));
+    color: var(--menuitem-selected-color, var(--kirby-primary-contrast));
   }
 
   &:not(.selected):hover a {
@@ -28,8 +28,8 @@
 .selected:hover,
 .selected:active,
 .selected:focus-visible {
-  background: var(--menuitem-selected-background-color, utils.get-color('primary'));
-  font-weight: utils.font-weight('bold');
+  background: var(--menuitem-selected-background-color, var(--kirby-primary));
+  font-weight: var(--kirby-font-weight-bold);
 }
 
 .item-badge {
@@ -37,7 +37,7 @@
 }
 
 .toggle-spacer {
-  width: utils.icon-font-size('sm');
+  width: var(--kirby-icon-font-size-sm);
   display: none;
 }
 
@@ -61,7 +61,7 @@
 .toggle-button-wrapper {
   display: inline-flex;
   position: absolute;
-  right: utils.size('xs');
+  right: var(--kirby-spacing-xs);
 }
 
 .toggle-button {

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-item-list/menu-item-list.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-item-list/menu-item-list.component.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 :host {
   display: flex;
   flex-direction: column;

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-item-list/menu-item-list.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-item-list/menu-item-list.component.scss
@@ -12,7 +12,7 @@
 kirby-divider {
   display: flex;
   background: var(--kirby-white-overlay-20);
-  margin: utils.size('xxs') 0;
+  margin: var(--kirby-spacing-xxs) 0;
 }
 
 li {
@@ -28,8 +28,8 @@ li {
 // When dragging, style non-dragged items
 :host.cdk-drop-list-dragging .cdk-drag:not(.cdk-drag-preview, .cdk-drag-placeholder) {
   transition-property: transform;
-  transition-duration: utils.get-transition-duration('short');
-  transition-timing-function: utils.get-transition-easing('static');
+  transition-duration: var(--kirby-transition-duration-short);
+  transition-timing-function: var(--kirby-transition-easing-static);
   pointer-events: none;
 }
 

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-item/menu-item.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-item/menu-item.component.scss
@@ -8,10 +8,10 @@
   align-items: center;
   align-self: stretch;
   box-sizing: border-box;
-  min-height: utils.size('l');
-  border-radius: utils.border-radius('s');
-  padding: utils.size('xxxs') utils.size('xs');
-  gap: utils.size('xxs');
+  min-height: var(--kirby-spacing-l);
+  border-radius: var(--kirby-border-radius-s);
+  padding: var(--kirby-spacing-xxxs) var(--kirby-spacing-xs);
+  gap: var(--kirby-spacing-xxs);
   border: none;
   background: inherit;
   font: inherit;
@@ -20,7 +20,7 @@
   cursor: pointer;
 
   &.lg {
-    min-height: utils.size('xl');
+    min-height: var(--kirby-spacing-xl);
   }
 
   &:hover {
@@ -75,22 +75,22 @@
 
   &.lg,
   &.md {
-    width: utils.icon-font-size('sm');
-    height: utils.icon-font-size('sm');
+    width: var(--kirby-icon-font-size-sm);
+    height: var(--kirby-icon-font-size-sm);
   }
 
   &.sm,
   &.xs {
-    width: utils.icon-font-size('xs');
-    height: utils.icon-font-size('xs');
+    width: var(--kirby-icon-font-size-xs);
+    height: var(--kirby-icon-font-size-xs);
   }
 
   &.sm {
-    padding-left: utils.size('l');
+    padding-left: var(--kirby-spacing-l);
   }
 
   &.xs {
-    padding-left: utils.size('xxxl');
+    padding-left: var(--kirby-spacing-xxxl);
   }
 }
 
@@ -102,16 +102,16 @@
   word-break: break-word;
   hyphens: auto;
   hyphenate-limit-chars: 10 4 4;
-  font-size: utils.font-size('n');
-  line-height: utils.line-height('m');
+  font-size: var(--kirby-font-size-n);
+  line-height: var(--kirby-line-height-m);
 }
 
 .menu-item-end {
   display: inline-flex;
-  min-width: utils.icon-font-size('sm');
+  min-width: var(--kirby-icon-font-size-sm);
   align-items: center;
   justify-content: center;
-  gap: utils.size('xxs');
+  gap: var(--kirby-spacing-xxs);
 
   &:empty {
     display: none;

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-item/menu-item.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-item/menu-item.component.scss
@@ -1,4 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
 @use '@kirbydesign/core/src/scss/interaction-state';
 
 :host {

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-submenu-item/menu-submenu-item.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-submenu-item/menu-submenu-item.component.scss
@@ -10,12 +10,12 @@
   width: 100%;
 
   &[aria-expanded='true'] {
-    font-weight: utils.font-weight('bold');
+    font-weight: var(--kirby-font-weight-bold);
   }
 }
 
 .disclosure {
-  transition: transform utils.get-transition-duration('quick');
+  transition: transform var(--kirby-transition-duration-quick);
 
   &.rotate {
     transform: rotate(90deg);

--- a/libs/extensions/angular/sidebar-menu/src/components/menu-submenu-item/menu-submenu-item.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/components/menu-submenu-item/menu-submenu-item.component.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 :host {
   display: flex;
   overflow: visible;

--- a/libs/extensions/angular/sidebar-menu/src/components/sidebar-container/sidebar-container.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/components/sidebar-container/sidebar-container.component.scss
@@ -28,6 +28,8 @@
 
   /* get kirby color with 50% opacity */
   *::-webkit-scrollbar-thumb {
+    // no color-mix or other Safari-15-safe CSS custom property equivalent, so kept as SCSS.
+    // stylelint-disable-next-line kirby/use-design-token
     // TODO(@kirby): migrate utils.get-color('semi-dark', $getValueOnly: true) — get-color() with $getValueOnly: true returns a raw value for SCSS color manipulation
 
     background-color: color.adjust(utils.get-color('semi-dark', $getValueOnly: true), $alpha: -0.5);

--- a/libs/extensions/angular/sidebar-menu/src/components/sidebar-container/sidebar-container.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/components/sidebar-container/sidebar-container.component.scss
@@ -29,9 +29,8 @@
   /* get kirby color with 50% opacity */
   *::-webkit-scrollbar-thumb {
     // no color-mix or other Safari-15-safe CSS custom property equivalent, so kept as SCSS.
-    // stylelint-disable-next-line kirby/use-design-token
-    // TODO(@kirby): migrate utils.get-color('semi-dark', $getValueOnly: true) — get-color() with $getValueOnly: true returns a raw value for SCSS color manipulation
 
+    // stylelint-disable-next-line kirby/use-design-tokens
     background-color: color.adjust(utils.get-color('semi-dark', $getValueOnly: true), $alpha: -0.5);
     border-radius: 20px;
     border: 4px solid transparent;

--- a/libs/extensions/angular/sidebar-menu/src/components/sidebar-container/sidebar-container.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/components/sidebar-container/sidebar-container.component.scss
@@ -7,14 +7,14 @@
 
   height: 100%; // Fallback for browsers that do not support dynamic viewport units
   height: 100dvh;
-  background-color: var(--sidebar-background-color, utils.get-color('tertiary'));
-  color: var(--sidebar-color, utils.get-color('tertiary-contrast'));
+  background-color: var(--sidebar-background-color, var(--kirby-tertiary));
+  color: var(--sidebar-color, var(--kirby-tertiary-contrast));
   display: flex;
   flex-direction: column;
 
   * {
     scrollbar-width: thin;
-    scrollbar-color: utils.get-color('semi-dark') utils.get-color('tertiary');
+    scrollbar-color: var(--kirby-semi-dark) var(--kirby-tertiary);
   }
 
   /* Works on Chrome, Edge, and Safari */
@@ -28,6 +28,8 @@
 
   /* get kirby color with 50% opacity */
   *::-webkit-scrollbar-thumb {
+    // TODO(@kirby): migrate utils.get-color('semi-dark', $getValueOnly: true) — get-color() with $getValueOnly: true returns a raw value for SCSS color manipulation
+
     background-color: color.adjust(utils.get-color('semi-dark', $getValueOnly: true), $alpha: -0.5);
     border-radius: 20px;
     border: 4px solid transparent;

--- a/libs/extensions/angular/skeleton-loader/src/skeleton-loader.component.scss
+++ b/libs/extensions/angular/skeleton-loader/src/skeleton-loader.component.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 $dark-theme-gradient: linear-gradient(
   to right,
   rgb(255 255 255 / 16%) 0%,

--- a/libs/extensions/angular/spot-illustration/src/spot-illustration.component.scss
+++ b/libs/extensions/angular/spot-illustration/src/spot-illustration.component.scss
@@ -1,5 +1,3 @@
-@use '@kirbydesign/core/src/scss/utils';
-
 .sm {
   font-size: 40px;
   display: block;

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,7 +151,6 @@
       "name": "@kirbydesign/core",
       "version": "0.0.92",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lit": "^3.1.4"
       },
@@ -557,7 +556,6 @@
       "integrity": "sha512-cj4tzUMiloLTg5rNf17E8MsvIxCWYoBiBsaj7ns6dgXqT9XCeG+J0TA2t1M+N9uuqfeLd22U/rYoCkADmcircQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/core": "21.2.19",
         "rxjs": "7.8.2"
@@ -577,7 +575,6 @@
       "integrity": "sha512-AlPZT9E7+1gp4TJ4CK8Kefsyo2dx8riREjDTyAYe4++BeWRIjxsaypgHgTZER3CtkugLXr0wknvsCw4i+A3qSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
         "@angular-devkit/architect": "0.2102.19",
@@ -1377,7 +1374,6 @@
       "integrity": "sha512-dtpJMQBz5nhkcIogPmXP/aT2Ak8m/wLRPOSTI/g4vSJSuGiI53PgtWq4/wfQga6E6wdM2XWsblAE89d8w5heQQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
@@ -1406,7 +1402,6 @@
       "integrity": "sha512-AG3Fzh9wJCmKBfxUQOUWaEHMj5Gq2O+Msf1z52aDSxbVhs5/iSQcXGPv/DLdAXu7d4xmQhLouNe9Glaq2omDyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/core": "21.2.19",
         "jsonc-parser": "3.3.1",
@@ -1469,7 +1464,6 @@
       "integrity": "sha512-pQiOg+se1AU/ncMlnJ9V6xYnMQ84qI1BGWuJpbU6A99VTXJg90scg0+T7DWmKssR1YjP5qmmBtrZfKsHEcLW/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "19.8.1",
         "eslint-scope": "^8.0.2"
@@ -1499,7 +1493,6 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.18.tgz",
       "integrity": "sha512-zN++Qb4Oz4x/5LYHuW9FItm7aHsV4HBz518GT25QusMvGymh+4io2TWhPYB0C9jx+g5q8GeQLd3c8r42yLrRxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1516,7 +1509,6 @@
       "integrity": "sha512-emy9mqrTXAwhZzcvx8MaHyz+cUR06PVGxnqy91+bpDxPP9S5x67sPoOkY9y/ETFFhRpB5ULlUxyq0eN/pi6QOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
         "@angular-devkit/architect": "0.2102.19",
@@ -2151,7 +2143,6 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.14.tgz",
       "integrity": "sha512-806REq/CLf37nEhmmd8Q+ILN8z/RVG2vk2n8YZ/4TdHpcBCi5ux4AxLbpMmduLwGPOzPagJ6ggRzE5fnX0rmcQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"
@@ -2169,7 +2160,6 @@
       "integrity": "sha512-i78NzvoNonAY17QgzSmqrYnXHmEfraLv4wZ/o/m3efxuz61ZJ+5X/PsCeAhbwBvQfRrPRQaJV2tK9vGjHa+U6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/architect": "0.2102.19",
         "@angular-devkit/core": "21.2.19",
@@ -2204,7 +2194,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.18.tgz",
       "integrity": "sha512-gZugZ8gX/KkACIZ3/ekoImLu5z8a0Iu9O5b84kh8e+++VUjmkmd19IygBsq/8/fF3vKf0UcIKcx3P6A/gb2DJw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2221,7 +2210,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.18.tgz",
       "integrity": "sha512-ccnDuKLuzIa0ayijR+alarsHNWIksuGV/lxGTZ0t6/0+B6J/RXupz6M2IO6ZHHEcg8r7pcrLCUBTyp3FoiRJrg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2235,7 +2223,6 @@
       "integrity": "sha512-L5zbIp7YfTTB4I4xT33FgEBanzhppNejzZX0HJOEqKDyDL2jXq+flt83lE0XVuRJ6/zrG+UKj0B+y/CK6Ro7Wg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.29.7",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -2268,7 +2255,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.18.tgz",
       "integrity": "sha512-AG4bb6GU0+qp+vVBjc/IhSPjgcRX8QsCb8jzN8dDyhnjsyuuG/LlIiU0l6n65BI9SGKE9m6TfsJ1ObkkAiE5KQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2294,7 +2280,6 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.18.tgz",
       "integrity": "sha512-TrRuiNjIzrrNtQgpJVH5gultQrvBlawa+tTzIpxBfIqLpkHrTPZLtYu118EUk6jhWzgRhKYUorInjJe+sSxC+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "tslib": "^2.3.0"
@@ -2324,7 +2309,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.18.tgz",
       "integrity": "sha512-zltF+3HrlgtZbYg8U98LhG0dyGm1aHT3Px8//9wjqi/TUY8UlHsYKByL197QtVWDBjf/dekzXdz5c+iyVtanLQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2347,7 +2331,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.18.tgz",
       "integrity": "sha512-doTDss6GhDTGjVuuANlzFrdYKBqHQVlWgy2tiTjy9EbrmMTOOHg0D6yUQXh1ZqmUWKDZ3owkUjUNGiXt92rQ6w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2366,7 +2349,6 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.2.18.tgz",
       "integrity": "sha512-Xix19uG1YthC8IslhWKSfPdhscVWREBGVJZW2OnRmLef8F7DvhF49S6vOywaBo+Uahe0egkmgWDNpEwxAzsgLw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2396,6 +2378,7 @@
       "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/generational-cache": "^1.0.1",
         "@csstools/css-calc": "^3.2.0",
@@ -2423,6 +2406,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -2447,6 +2431,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/color-helpers": "^6.1.0",
         "@csstools/css-calc": "^3.2.1"
@@ -2510,6 +2495,7 @@
       "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/generational-cache": "^1.0.1",
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -2527,6 +2513,7 @@
       "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
@@ -2536,7 +2523,8 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -2568,7 +2556,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -4541,6 +4528,7 @@
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-tree": "^3.0.0"
       },
@@ -4588,7 +4576,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -5439,6 +5426,7 @@
         }
       ],
       "license": "MIT-0",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -5530,7 +5518,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -5577,7 +5564,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5731,7 +5717,6 @@
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -5990,7 +5975,6 @@
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -6002,7 +5986,6 @@
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -6619,6 +6602,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
       "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/utils": "^0.2.12"
       }
@@ -6638,7 +6622,8 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
       "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@fontsource/roboto": {
       "version": "5.2.10",
@@ -6993,7 +6978,6 @@
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
         "@inquirer/confirm": "^5.1.21",
@@ -7133,6 +7117,7 @@
       "resolved": "https://registry.npmjs.org/@ionic/core/-/core-8.8.19.tgz",
       "integrity": "sha512-eAAKZi/qR0U44OxH3MXAyoyLxTl1AeQCoOWvGdzywKbpl/JTVlGnfZJCiJGTmXszQlRsNXsl7fMDOvpsOtf6sQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@stencil/core": "4.43.5",
         "ionicons": "^8.0.13",
@@ -7656,7 +7641,6 @@
       "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/types": "30.3.0",
@@ -7690,7 +7674,6 @@
       "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.0.1",
         "@jest/schemas": "30.0.5",
@@ -8699,7 +8682,6 @@
       "integrity": "sha512-3yOqjdSHXxX4HA3GhlXg3hghGAXW2RJUsnwXCcik2/lTxOHizKI8f3RM+GGCKPxDVqtw43IShe3tA12jNL5A/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "2.8.0",
         "@module-federation/webpack-bundler-runtime": "2.8.0"
@@ -9548,6 +9530,7 @@
       "integrity": "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "^1.1.0",
         "@emnapi/runtime": "^1.1.0",
@@ -9587,7 +9570,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-darwin-x64": {
       "version": "21.6.11",
@@ -9601,7 +9585,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-freebsd-x64": {
       "version": "21.6.11",
@@ -9615,7 +9600,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-arm-gnueabihf": {
       "version": "21.6.11",
@@ -9629,7 +9615,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-arm64-gnu": {
       "version": "21.6.11",
@@ -9643,7 +9630,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-arm64-musl": {
       "version": "21.6.11",
@@ -9657,7 +9645,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-x64-gnu": {
       "version": "21.6.11",
@@ -9671,7 +9660,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-x64-musl": {
       "version": "21.6.11",
@@ -9685,7 +9675,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-win32-arm64-msvc": {
       "version": "21.6.11",
@@ -9699,7 +9690,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-win32-x64-msvc": {
       "version": "21.6.11",
@@ -9713,7 +9705,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@nrwl/devkit/node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
@@ -9721,6 +9714,7 @@
       "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -9731,6 +9725,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9751,6 +9746,7 @@
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "restore-cursor": "^3.1.0"
       },
@@ -9764,6 +9760,7 @@
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9773,7 +9770,8 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@nrwl/devkit/node_modules/is-docker": {
       "version": "2.2.1",
@@ -9781,6 +9779,7 @@
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -9797,6 +9796,7 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9807,6 +9807,7 @@
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9817,6 +9818,7 @@
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9830,6 +9832,7 @@
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -9842,7 +9845,8 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@nrwl/devkit/node_modules/log-symbols": {
       "version": "4.1.0",
@@ -9850,6 +9854,7 @@
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -9957,6 +9962,7 @@
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -9973,6 +9979,7 @@
       "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -9991,6 +9998,7 @@
       "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "chalk": "^4.1.0",
@@ -10014,6 +10022,7 @@
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -10027,7 +10036,8 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@nrwl/devkit/node_modules/string-width": {
       "version": "4.2.3",
@@ -10035,6 +10045,7 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -10050,6 +10061,7 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -10063,6 +10075,7 @@
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -10073,6 +10086,7 @@
       "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "json5": "^2.2.2",
         "minimist": "^1.2.6",
@@ -10088,6 +10102,7 @@
       "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -10531,7 +10546,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -11657,7 +11671,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -12976,7 +12989,6 @@
       "integrity": "sha512-FolcIAH5FW4J2FET+qwjd1kNeFbCkd0VLuIHO0thyolEjaPSxw5qxG67DA7BZGm6PVcoiSgPLks1DL6eZ8c+fA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/runtime-tools": "0.21.6",
         "@rspack/binding": "1.6.8",
@@ -15986,6 +15998,7 @@
       "integrity": "sha512-f4HHuLbvuld8Ba4iB/4ibse5XrKxFrgmM3S4P2AOKnPlekAFlBjmltCuaTL/W2ggYvILaVY+YcFXrEH1rrKeQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "optionalDependencies": {
         "@rspack/binding-darwin-arm64": "1.7.12",
         "@rspack/binding-darwin-x64": "1.7.12",
@@ -16011,7 +16024,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/binding-darwin-x64": {
       "version": "1.7.12",
@@ -16025,7 +16039,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
       "version": "1.7.12",
@@ -16039,7 +16054,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
       "version": "1.7.12",
@@ -16053,7 +16069,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/binding-linux-x64-gnu": {
       "version": "1.7.12",
@@ -16067,7 +16084,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
       "version": "1.7.12",
@@ -16081,7 +16099,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/binding-wasm32-wasi": {
       "version": "1.7.12",
@@ -16093,6 +16112,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "1.0.7"
       }
@@ -16109,7 +16129,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
       "version": "1.7.12",
@@ -16123,7 +16144,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
       "version": "1.7.12",
@@ -16137,7 +16159,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rspack/core": {
       "version": "1.7.12",
@@ -16168,7 +16191,8 @@
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.22.0.tgz",
       "integrity": "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@rspack/core/node_modules/@module-federation/runtime": {
       "version": "0.22.0",
@@ -16176,6 +16200,7 @@
       "integrity": "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.22.0",
         "@module-federation/runtime-core": "0.22.0",
@@ -16188,6 +16213,7 @@
       "integrity": "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.22.0",
         "@module-federation/sdk": "0.22.0"
@@ -16199,6 +16225,7 @@
       "integrity": "sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.22.0",
         "@module-federation/webpack-bundler-runtime": "0.22.0"
@@ -16209,7 +16236,8 @@
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.22.0.tgz",
       "integrity": "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@rspack/core/node_modules/@module-federation/webpack-bundler-runtime": {
       "version": "0.22.0",
@@ -16217,6 +16245,7 @@
       "integrity": "sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.22.0",
         "@module-federation/sdk": "0.22.0"
@@ -16724,7 +16753,6 @@
       "integrity": "sha512-eL+UU9eizoadhDB4YEctRmmo0A5iwrSmGzeuEa6akrq8nLGVWM8zO91HTJutkPqGQjelF+UOiOShsQSZAU9SIQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/core": "21.2.19",
         "@angular-devkit/schematics": "21.2.19",
@@ -16885,6 +16913,7 @@
       "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.43.5.tgz",
       "integrity": "sha512-cgWD+GeuvJpTe1WQn40p02+BJ2j0j1YJ17GdkF2qKIQ23s2e3Zivq5yISXS3dcuV6oUJFN93jprdk+nk/sq99Q==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -16914,7 +16943,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@stencil/core/node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.44.0",
@@ -16927,7 +16957,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@stencil/core/node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.44.0",
@@ -16943,7 +16974,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@stencil/core/node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.44.0",
@@ -16959,7 +16991,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@stencil/core/node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.44.0",
@@ -16975,7 +17008,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@stencil/core/node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.44.0",
@@ -16991,7 +17025,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@stencil/core/node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.44.0",
@@ -17004,7 +17039,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@stencil/core/node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.44.0",
@@ -17017,7 +17053,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@storybook/addon-a11y": {
       "version": "10.2.13",
@@ -17322,7 +17359,6 @@
       "integrity": "sha512-VQ0hJ5jX31TVv/fhZx4xJRzd8pwn6VvzYd2tGOHHr2TfXGCBixZoqdPDXTiEoJLCTS2MmvBf6zyQZZ0M8aGQCQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@swc-node/core": "^1.14.1",
         "@swc-node/sourcemap-support": "^0.6.1",
@@ -17359,7 +17395,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.26"
@@ -17611,7 +17646,6 @@
       "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -17622,7 +17656,6 @@
       "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }
@@ -18060,7 +18093,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -18100,7 +18132,6 @@
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -18458,7 +18489,6 @@
       "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -18742,7 +18772,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -18850,7 +18879,6 @@
       "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -18932,7 +18960,6 @@
       "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.58.1",
@@ -19818,7 +19845,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -19926,7 +19952,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -20445,7 +20470,6 @@
       "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/transform": "30.3.0",
         "@types/babel__core": "^7.20.5",
@@ -20761,6 +20785,7 @@
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
@@ -20902,7 +20927,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -21509,7 +21533,6 @@
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -22742,7 +22765,8 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cuint": {
       "version": "0.2.2",
@@ -22771,6 +22795,7 @@
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
         "whatwg-url": "^16.0.0"
@@ -22785,6 +22810,7 @@
       "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
@@ -22803,6 +22829,7 @@
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -22816,6 +22843,7 @@
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -22826,6 +22854,7 @@
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -22836,6 +22865,7 @@
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.11.0",
         "tr46": "^6.0.0",
@@ -22904,7 +22934,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -22915,7 +22944,6 @@
       "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
       "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "date-fns": "^3.0.0 || ^4.0.0"
       }
@@ -24049,7 +24077,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -24675,7 +24702,6 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -25324,7 +25350,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -26159,7 +26184,6 @@
       "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -26333,7 +26357,6 @@
       "integrity": "sha512-bLjW01UTrvoWTJQL5LsMRo1SypHW80FTm12OJRSnr3v6YHNhfe+1r0MYUZJMACxnCHURVnBWRwAsWs2yPU9Ezw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/html-minifier-terser": "^6.0.0",
         "html-minifier-terser": "^6.0.2",
@@ -27068,6 +27091,7 @@
       "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-8.1.0.tgz",
       "integrity": "sha512-XSM2gYWTXxSYTwjmKWAoy4yR7AbAFDjpc5ZIivAiGXskM0fe5CdMPfs6InQRUcrYtVb2WZ/0HQ1/jeh3JW78SA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@stencil/core": "^4.43.5"
       }
@@ -27871,8 +27895,7 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.2.0.tgz",
       "integrity": "sha512-OcFpBrIhnbmb9wfI8cqPSJ50pv3Wg4/NSgoZIqHzIwO/2a9qivJWzv8hUvaREIMYYJBas6AvfXATFdVuzzCqVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jasmine-spec-reporter": {
       "version": "7.0.0",
@@ -27890,7 +27913,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -29051,6 +29073,7 @@
       "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
@@ -29069,6 +29092,7 @@
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
       },
@@ -29082,6 +29106,7 @@
       "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -29092,6 +29117,7 @@
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -29105,6 +29131,7 @@
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -29115,6 +29142,7 @@
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -29125,6 +29153,7 @@
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.11.0",
         "tr46": "^6.0.0",
@@ -29286,7 +29315,6 @@
       "integrity": "sha512-Cj57NKOskK7wtFWSlMvZf459iX+kpYIPXmkNUzP2WAFcA7nhr/ALn5R7sw3w+1udFDcpMx/tuB8d5amgm3ijaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -29419,7 +29447,6 @@
       "integrity": "sha512-i/zQLFrfEpRyQoJF9fsCdTMOF5c2dK7C7OmsuKg2D0YSsuZSfQDiLuaiktbuio6F2wiCsZSnSnieIQ0ant/uzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jasmine-core": "^4.1.0"
       },
@@ -29865,7 +29892,6 @@
       "integrity": "sha512-j1n1IuTX1VQjIy3tT7cyGbX7nvQOsFLoIqobZv4ttI5axP923gA44zUj6miiA6R5Aoms4sEGVIIcucXUbRI14g==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -30320,7 +30346,6 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -31488,7 +31513,6 @@
       "integrity": "sha512-WGF4DK6nOE3xKPj8miC3lw6I66n1wdBhnMl25zMExqFmzRk9jABwFj3eycellTiH4t4x+yHnuxS/im9DLTa9cg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@rollup/plugin-json": "^6.1.0",
@@ -31704,7 +31728,8 @@
       "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
       "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/node-releases": {
       "version": "2.0.37",
@@ -31910,7 +31935,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.4.5",
         "@emnapi/runtime": "1.4.5",
@@ -32085,6 +32109,7 @@
       "integrity": "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "^1.1.0",
         "@emnapi/runtime": "^1.1.0",
@@ -32124,7 +32149,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-darwin-x64": {
       "version": "21.6.11",
@@ -32138,7 +32164,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-freebsd-x64": {
       "version": "21.6.11",
@@ -32152,7 +32179,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-linux-arm-gnueabihf": {
       "version": "21.6.11",
@@ -32166,7 +32194,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-linux-arm64-gnu": {
       "version": "21.6.11",
@@ -32180,7 +32209,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-linux-arm64-musl": {
       "version": "21.6.11",
@@ -32194,7 +32224,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-linux-x64-gnu": {
       "version": "21.6.11",
@@ -32208,7 +32239,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-linux-x64-musl": {
       "version": "21.6.11",
@@ -32222,7 +32254,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-win32-arm64-msvc": {
       "version": "21.6.11",
@@ -32236,7 +32269,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-win32-x64-msvc": {
       "version": "21.6.11",
@@ -32250,7 +32284,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/nx-stylelint/node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
@@ -32258,6 +32293,7 @@
       "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -32268,6 +32304,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -32288,6 +32325,7 @@
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "restore-cursor": "^3.1.0"
       },
@@ -32301,6 +32339,7 @@
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -32310,7 +32349,8 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/nx-stylelint/node_modules/is-docker": {
       "version": "2.2.1",
@@ -32318,6 +32358,7 @@
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -32334,6 +32375,7 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -32344,6 +32386,7 @@
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -32354,6 +32397,7 @@
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -32367,6 +32411,7 @@
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -32379,7 +32424,8 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/nx-stylelint/node_modules/log-symbols": {
       "version": "4.1.0",
@@ -32387,6 +32433,7 @@
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -32494,6 +32541,7 @@
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -32510,6 +32558,7 @@
       "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -32528,6 +32577,7 @@
       "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "chalk": "^4.1.0",
@@ -32551,6 +32601,7 @@
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -32564,7 +32615,8 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/nx-stylelint/node_modules/string-width": {
       "version": "4.2.3",
@@ -32572,6 +32624,7 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -32587,6 +32640,7 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -32600,6 +32654,7 @@
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -32610,6 +32665,7 @@
       "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "json5": "^2.2.2",
         "minimist": "^1.2.6",
@@ -32625,6 +32681,7 @@
       "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -34197,7 +34254,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -35040,7 +35096,6 @@
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -35499,7 +35554,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -35647,7 +35701,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -35942,7 +35995,6 @@
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -35953,7 +36005,6 @@
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -36603,7 +36654,6 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -36776,7 +36826,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -38223,7 +38272,8 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
       "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ssri": {
       "version": "13.0.1",
@@ -38311,7 +38361,6 @@
       "integrity": "sha512-heMfJjOfbHvL+wlCAwFZlSxcakyJ5yQDam6e9k2RRArB1veJhRnsjO6lO1hOXjJYrqxfHA/ldIugbBVlCDqfvQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -38754,7 +38803,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -38883,7 +38931,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "stylelint-config-recommended": "^14.0.1"
       },
@@ -38900,7 +38947,6 @@
       "integrity": "sha512-Eo5w7/XvwGHWkeGLtdm2FZLOMYoZl1omP2/jgFCXyl2x5yNz7/8vv4Tj6slHvMSSUNTaGoam/GAZ0ZhukvalfA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "stylelint-config-recommended-scss": "^14.0.0",
         "stylelint-config-standard": "^36.0.0"
@@ -39694,6 +39740,7 @@
       "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tldts-core": "^7.4.8"
       },
@@ -39706,7 +39753,8 @@
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
       "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tmp": {
       "version": "0.2.7",
@@ -39763,6 +39811,7 @@
       "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "tldts": "^7.0.5"
       },
@@ -40060,7 +40109,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -40180,8 +40228,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -40189,7 +40236,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -40381,7 +40427,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -40698,7 +40743,6 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -40806,7 +40850,6 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -40984,7 +41027,6 @@
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -41094,7 +41136,6 @@
       "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -41587,7 +41628,6 @@
       "integrity": "sha512-khZGfAeJx6I8K9zKohEWWYN6KDlVw2DHownoe+6Vtwj1LP9WFgegXnVMSkZ/dBEBtXFwrkkydsaPFlB7f8wU2A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-html-community": "0.0.8",
         "html-entities": "^2.1.0",
@@ -42226,7 +42266,6 @@
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -42494,7 +42533,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,6 +151,7 @@
       "name": "@kirbydesign/core",
       "version": "0.0.92",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lit": "^3.1.4"
       },
@@ -556,6 +557,7 @@
       "integrity": "sha512-cj4tzUMiloLTg5rNf17E8MsvIxCWYoBiBsaj7ns6dgXqT9XCeG+J0TA2t1M+N9uuqfeLd22U/rYoCkADmcircQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-devkit/core": "21.2.19",
         "rxjs": "7.8.2"
@@ -575,6 +577,7 @@
       "integrity": "sha512-AlPZT9E7+1gp4TJ4CK8Kefsyo2dx8riREjDTyAYe4++BeWRIjxsaypgHgTZER3CtkugLXr0wknvsCw4i+A3qSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
         "@angular-devkit/architect": "0.2102.19",
@@ -1374,6 +1377,7 @@
       "integrity": "sha512-dtpJMQBz5nhkcIogPmXP/aT2Ak8m/wLRPOSTI/g4vSJSuGiI53PgtWq4/wfQga6E6wdM2XWsblAE89d8w5heQQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
@@ -1402,6 +1406,7 @@
       "integrity": "sha512-AG3Fzh9wJCmKBfxUQOUWaEHMj5Gq2O+Msf1z52aDSxbVhs5/iSQcXGPv/DLdAXu7d4xmQhLouNe9Glaq2omDyw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-devkit/core": "21.2.19",
         "jsonc-parser": "3.3.1",
@@ -1464,6 +1469,7 @@
       "integrity": "sha512-pQiOg+se1AU/ncMlnJ9V6xYnMQ84qI1BGWuJpbU6A99VTXJg90scg0+T7DWmKssR1YjP5qmmBtrZfKsHEcLW/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-eslint/bundled-angular-compiler": "19.8.1",
         "eslint-scope": "^8.0.2"
@@ -1493,6 +1499,7 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.18.tgz",
       "integrity": "sha512-zN++Qb4Oz4x/5LYHuW9FItm7aHsV4HBz518GT25QusMvGymh+4io2TWhPYB0C9jx+g5q8GeQLd3c8r42yLrRxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1509,6 +1516,7 @@
       "integrity": "sha512-emy9mqrTXAwhZzcvx8MaHyz+cUR06PVGxnqy91+bpDxPP9S5x67sPoOkY9y/ETFFhRpB5ULlUxyq0eN/pi6QOg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
         "@angular-devkit/architect": "0.2102.19",
@@ -2143,6 +2151,7 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.14.tgz",
       "integrity": "sha512-806REq/CLf37nEhmmd8Q+ILN8z/RVG2vk2n8YZ/4TdHpcBCi5ux4AxLbpMmduLwGPOzPagJ6ggRzE5fnX0rmcQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse5": "^8.0.0",
         "tslib": "^2.3.0"
@@ -2160,6 +2169,7 @@
       "integrity": "sha512-i78NzvoNonAY17QgzSmqrYnXHmEfraLv4wZ/o/m3efxuz61ZJ+5X/PsCeAhbwBvQfRrPRQaJV2tK9vGjHa+U6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-devkit/architect": "0.2102.19",
         "@angular-devkit/core": "21.2.19",
@@ -2194,6 +2204,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.18.tgz",
       "integrity": "sha512-gZugZ8gX/KkACIZ3/ekoImLu5z8a0Iu9O5b84kh8e+++VUjmkmd19IygBsq/8/fF3vKf0UcIKcx3P6A/gb2DJw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2210,6 +2221,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.18.tgz",
       "integrity": "sha512-ccnDuKLuzIa0ayijR+alarsHNWIksuGV/lxGTZ0t6/0+B6J/RXupz6M2IO6ZHHEcg8r7pcrLCUBTyp3FoiRJrg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2223,6 +2235,7 @@
       "integrity": "sha512-L5zbIp7YfTTB4I4xT33FgEBanzhppNejzZX0HJOEqKDyDL2jXq+flt83lE0XVuRJ6/zrG+UKj0B+y/CK6Ro7Wg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.29.7",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -2255,6 +2268,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.18.tgz",
       "integrity": "sha512-AG4bb6GU0+qp+vVBjc/IhSPjgcRX8QsCb8jzN8dDyhnjsyuuG/LlIiU0l6n65BI9SGKE9m6TfsJ1ObkkAiE5KQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2280,6 +2294,7 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.18.tgz",
       "integrity": "sha512-TrRuiNjIzrrNtQgpJVH5gultQrvBlawa+tTzIpxBfIqLpkHrTPZLtYu118EUk6jhWzgRhKYUorInjJe+sSxC+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "tslib": "^2.3.0"
@@ -2309,6 +2324,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.18.tgz",
       "integrity": "sha512-zltF+3HrlgtZbYg8U98LhG0dyGm1aHT3Px8//9wjqi/TUY8UlHsYKByL197QtVWDBjf/dekzXdz5c+iyVtanLQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2331,6 +2347,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-21.2.18.tgz",
       "integrity": "sha512-doTDss6GhDTGjVuuANlzFrdYKBqHQVlWgy2tiTjy9EbrmMTOOHg0D6yUQXh1ZqmUWKDZ3owkUjUNGiXt92rQ6w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2349,6 +2366,7 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.2.18.tgz",
       "integrity": "sha512-Xix19uG1YthC8IslhWKSfPdhscVWREBGVJZW2OnRmLef8F7DvhF49S6vOywaBo+Uahe0egkmgWDNpEwxAzsgLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -2378,7 +2396,6 @@
       "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/generational-cache": "^1.0.1",
         "@csstools/css-calc": "^3.2.0",
@@ -2406,7 +2423,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -2431,7 +2447,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/color-helpers": "^6.1.0",
         "@csstools/css-calc": "^3.2.1"
@@ -2495,7 +2510,6 @@
       "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/generational-cache": "^1.0.1",
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -2513,7 +2527,6 @@
       "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
@@ -2523,8 +2536,7 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -2556,6 +2568,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -4528,7 +4541,6 @@
       "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "css-tree": "^3.0.0"
       },
@@ -4576,6 +4588,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -5426,7 +5439,6 @@
         }
       ],
       "license": "MIT-0",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -5518,6 +5530,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -5564,6 +5577,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5717,6 +5731,7 @@
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -5975,6 +5990,7 @@
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -5986,6 +6002,7 @@
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -6602,7 +6619,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
       "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/utils": "^0.2.12"
       }
@@ -6622,8 +6638,7 @@
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
       "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@fontsource/roboto": {
       "version": "5.2.10",
@@ -6978,6 +6993,7 @@
       "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.3.2",
         "@inquirer/confirm": "^5.1.21",
@@ -7117,7 +7133,6 @@
       "resolved": "https://registry.npmjs.org/@ionic/core/-/core-8.8.19.tgz",
       "integrity": "sha512-eAAKZi/qR0U44OxH3MXAyoyLxTl1AeQCoOWvGdzywKbpl/JTVlGnfZJCiJGTmXszQlRsNXsl7fMDOvpsOtf6sQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@stencil/core": "4.43.5",
         "ionicons": "^8.0.13",
@@ -7641,6 +7656,7 @@
       "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/types": "30.3.0",
@@ -7674,6 +7690,7 @@
       "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.0.1",
         "@jest/schemas": "30.0.5",
@@ -8682,6 +8699,7 @@
       "integrity": "sha512-3yOqjdSHXxX4HA3GhlXg3hghGAXW2RJUsnwXCcik2/lTxOHizKI8f3RM+GGCKPxDVqtw43IShe3tA12jNL5A/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "2.8.0",
         "@module-federation/webpack-bundler-runtime": "2.8.0"
@@ -9530,7 +9548,6 @@
       "integrity": "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "^1.1.0",
         "@emnapi/runtime": "^1.1.0",
@@ -9570,8 +9587,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-darwin-x64": {
       "version": "21.6.11",
@@ -9585,8 +9601,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-freebsd-x64": {
       "version": "21.6.11",
@@ -9600,8 +9615,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-arm-gnueabihf": {
       "version": "21.6.11",
@@ -9615,8 +9629,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-arm64-gnu": {
       "version": "21.6.11",
@@ -9630,8 +9643,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-arm64-musl": {
       "version": "21.6.11",
@@ -9645,8 +9657,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-x64-gnu": {
       "version": "21.6.11",
@@ -9660,8 +9671,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-linux-x64-musl": {
       "version": "21.6.11",
@@ -9675,8 +9685,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-win32-arm64-msvc": {
       "version": "21.6.11",
@@ -9690,8 +9699,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@nrwl/devkit/node_modules/@nx/nx-win32-x64-msvc": {
       "version": "21.6.11",
@@ -9705,8 +9713,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@nrwl/devkit/node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
@@ -9714,7 +9721,6 @@
       "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -9725,7 +9731,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9746,7 +9751,6 @@
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "restore-cursor": "^3.1.0"
       },
@@ -9760,7 +9764,6 @@
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9770,8 +9773,7 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@nrwl/devkit/node_modules/is-docker": {
       "version": "2.2.1",
@@ -9779,7 +9781,6 @@
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -9796,7 +9797,6 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9807,7 +9807,6 @@
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9818,7 +9817,6 @@
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9832,7 +9830,6 @@
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -9845,8 +9842,7 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@nrwl/devkit/node_modules/log-symbols": {
       "version": "4.1.0",
@@ -9854,7 +9850,6 @@
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -9962,7 +9957,6 @@
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -9979,7 +9973,6 @@
       "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -9998,7 +9991,6 @@
       "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "chalk": "^4.1.0",
@@ -10022,7 +10014,6 @@
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -10036,8 +10027,7 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/@nrwl/devkit/node_modules/string-width": {
       "version": "4.2.3",
@@ -10045,7 +10035,6 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -10061,7 +10050,6 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -10075,7 +10063,6 @@
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -10086,7 +10073,6 @@
       "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "json5": "^2.2.2",
         "minimist": "^1.2.6",
@@ -10102,7 +10088,6 @@
       "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -10546,6 +10531,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -11671,6 +11657,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -12989,6 +12976,7 @@
       "integrity": "sha512-FolcIAH5FW4J2FET+qwjd1kNeFbCkd0VLuIHO0thyolEjaPSxw5qxG67DA7BZGm6PVcoiSgPLks1DL6eZ8c+fA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime-tools": "0.21.6",
         "@rspack/binding": "1.6.8",
@@ -15998,7 +15986,6 @@
       "integrity": "sha512-f4HHuLbvuld8Ba4iB/4ibse5XrKxFrgmM3S4P2AOKnPlekAFlBjmltCuaTL/W2ggYvILaVY+YcFXrEH1rrKeQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "optionalDependencies": {
         "@rspack/binding-darwin-arm64": "1.7.12",
         "@rspack/binding-darwin-x64": "1.7.12",
@@ -16024,8 +16011,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-darwin-x64": {
       "version": "1.7.12",
@@ -16039,8 +16025,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
       "version": "1.7.12",
@@ -16054,8 +16039,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
       "version": "1.7.12",
@@ -16069,8 +16053,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-x64-gnu": {
       "version": "1.7.12",
@@ -16084,8 +16067,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
       "version": "1.7.12",
@@ -16099,8 +16081,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-wasm32-wasi": {
       "version": "1.7.12",
@@ -16112,7 +16093,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "1.0.7"
       }
@@ -16129,8 +16109,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
       "version": "1.7.12",
@@ -16144,8 +16123,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
       "version": "1.7.12",
@@ -16159,8 +16137,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/core": {
       "version": "1.7.12",
@@ -16191,8 +16168,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.22.0.tgz",
       "integrity": "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@rspack/core/node_modules/@module-federation/runtime": {
       "version": "0.22.0",
@@ -16200,7 +16176,6 @@
       "integrity": "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.22.0",
         "@module-federation/runtime-core": "0.22.0",
@@ -16213,7 +16188,6 @@
       "integrity": "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.22.0",
         "@module-federation/sdk": "0.22.0"
@@ -16225,7 +16199,6 @@
       "integrity": "sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.22.0",
         "@module-federation/webpack-bundler-runtime": "0.22.0"
@@ -16236,8 +16209,7 @@
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.22.0.tgz",
       "integrity": "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@rspack/core/node_modules/@module-federation/webpack-bundler-runtime": {
       "version": "0.22.0",
@@ -16245,7 +16217,6 @@
       "integrity": "sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.22.0",
         "@module-federation/sdk": "0.22.0"
@@ -16753,6 +16724,7 @@
       "integrity": "sha512-eL+UU9eizoadhDB4YEctRmmo0A5iwrSmGzeuEa6akrq8nLGVWM8zO91HTJutkPqGQjelF+UOiOShsQSZAU9SIQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@angular-devkit/core": "21.2.19",
         "@angular-devkit/schematics": "21.2.19",
@@ -16913,7 +16885,6 @@
       "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.43.5.tgz",
       "integrity": "sha512-cgWD+GeuvJpTe1WQn40p02+BJ2j0j1YJ17GdkF2qKIQ23s2e3Zivq5yISXS3dcuV6oUJFN93jprdk+nk/sq99Q==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -16943,8 +16914,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@stencil/core/node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.44.0",
@@ -16957,8 +16927,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@stencil/core/node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.44.0",
@@ -16974,8 +16943,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@stencil/core/node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.44.0",
@@ -16991,8 +16959,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@stencil/core/node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.44.0",
@@ -17008,8 +16975,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@stencil/core/node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.44.0",
@@ -17025,8 +16991,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@stencil/core/node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.44.0",
@@ -17039,8 +17004,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@stencil/core/node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.44.0",
@@ -17053,8 +17017,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@storybook/addon-a11y": {
       "version": "10.2.13",
@@ -17359,6 +17322,7 @@
       "integrity": "sha512-VQ0hJ5jX31TVv/fhZx4xJRzd8pwn6VvzYd2tGOHHr2TfXGCBixZoqdPDXTiEoJLCTS2MmvBf6zyQZZ0M8aGQCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@swc-node/core": "^1.14.1",
         "@swc-node/sourcemap-support": "^0.6.1",
@@ -17395,6 +17359,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.26"
@@ -17646,6 +17611,7 @@
       "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -17656,6 +17622,7 @@
       "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }
@@ -18093,6 +18060,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -18132,6 +18100,7 @@
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -18489,6 +18458,7 @@
       "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -18772,6 +18742,7 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -18879,6 +18850,7 @@
       "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -18960,6 +18932,7 @@
       "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.58.1",
@@ -19845,6 +19818,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -19952,6 +19926,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -20470,6 +20445,7 @@
       "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/transform": "30.3.0",
         "@types/babel__core": "^7.20.5",
@@ -20785,7 +20761,6 @@
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
@@ -20927,6 +20902,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -21533,6 +21509,7 @@
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -22765,8 +22742,7 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cuint": {
       "version": "0.2.2",
@@ -22795,7 +22771,6 @@
       "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
         "whatwg-url": "^16.0.0"
@@ -22810,7 +22785,6 @@
       "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
@@ -22829,7 +22803,6 @@
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -22843,7 +22816,6 @@
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -22854,7 +22826,6 @@
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -22865,7 +22836,6 @@
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.11.0",
         "tr46": "^6.0.0",
@@ -22934,6 +22904,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -22944,6 +22915,7 @@
       "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
       "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "date-fns": "^3.0.0 || ^4.0.0"
       }
@@ -24077,6 +24049,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -24702,6 +24675,7 @@
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -24838,7 +24812,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
       "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -25351,6 +25324,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -26185,6 +26159,7 @@
       "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -26358,6 +26333,7 @@
       "integrity": "sha512-bLjW01UTrvoWTJQL5LsMRo1SypHW80FTm12OJRSnr3v6YHNhfe+1r0MYUZJMACxnCHURVnBWRwAsWs2yPU9Ezw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/html-minifier-terser": "^6.0.0",
         "html-minifier-terser": "^6.0.2",
@@ -27092,7 +27068,6 @@
       "resolved": "https://registry.npmjs.org/ionicons/-/ionicons-8.1.0.tgz",
       "integrity": "sha512-XSM2gYWTXxSYTwjmKWAoy4yR7AbAFDjpc5ZIivAiGXskM0fe5CdMPfs6InQRUcrYtVb2WZ/0HQ1/jeh3JW78SA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@stencil/core": "^4.43.5"
       }
@@ -27896,7 +27871,8 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.2.0.tgz",
       "integrity": "sha512-OcFpBrIhnbmb9wfI8cqPSJ50pv3Wg4/NSgoZIqHzIwO/2a9qivJWzv8hUvaREIMYYJBas6AvfXATFdVuzzCqVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jasmine-spec-reporter": {
       "version": "7.0.0",
@@ -27914,6 +27890,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -29074,7 +29051,6 @@
       "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
@@ -29093,7 +29069,6 @@
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
       },
@@ -29107,7 +29082,6 @@
       "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
-      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
@@ -29118,7 +29092,6 @@
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -29132,7 +29105,6 @@
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -29143,7 +29115,6 @@
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -29154,7 +29125,6 @@
       "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@exodus/bytes": "^1.11.0",
         "tr46": "^6.0.0",
@@ -29316,6 +29286,7 @@
       "integrity": "sha512-Cj57NKOskK7wtFWSlMvZf459iX+kpYIPXmkNUzP2WAFcA7nhr/ALn5R7sw3w+1udFDcpMx/tuB8d5amgm3ijaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -29448,6 +29419,7 @@
       "integrity": "sha512-i/zQLFrfEpRyQoJF9fsCdTMOF5c2dK7C7OmsuKg2D0YSsuZSfQDiLuaiktbuio6F2wiCsZSnSnieIQ0ant/uzQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jasmine-core": "^4.1.0"
       },
@@ -29893,6 +29865,7 @@
       "integrity": "sha512-j1n1IuTX1VQjIy3tT7cyGbX7nvQOsFLoIqobZv4ttI5axP923gA44zUj6miiA6R5Aoms4sEGVIIcucXUbRI14g==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -30347,6 +30320,7 @@
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -31514,6 +31488,7 @@
       "integrity": "sha512-WGF4DK6nOE3xKPj8miC3lw6I66n1wdBhnMl25zMExqFmzRk9jABwFj3eycellTiH4t4x+yHnuxS/im9DLTa9cg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "@rollup/plugin-json": "^6.1.0",
@@ -31729,8 +31704,7 @@
       "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
       "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.37",
@@ -31936,6 +31910,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.4.5",
         "@emnapi/runtime": "1.4.5",
@@ -32110,7 +32085,6 @@
       "integrity": "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "^1.1.0",
         "@emnapi/runtime": "^1.1.0",
@@ -32150,8 +32124,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-darwin-x64": {
       "version": "21.6.11",
@@ -32165,8 +32138,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-freebsd-x64": {
       "version": "21.6.11",
@@ -32180,8 +32152,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-linux-arm-gnueabihf": {
       "version": "21.6.11",
@@ -32195,8 +32166,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-linux-arm64-gnu": {
       "version": "21.6.11",
@@ -32210,8 +32180,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-linux-arm64-musl": {
       "version": "21.6.11",
@@ -32225,8 +32194,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-linux-x64-gnu": {
       "version": "21.6.11",
@@ -32240,8 +32208,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-linux-x64-musl": {
       "version": "21.6.11",
@@ -32255,8 +32222,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-win32-arm64-msvc": {
       "version": "21.6.11",
@@ -32270,8 +32236,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/nx-stylelint/node_modules/@nx/nx-win32-x64-msvc": {
       "version": "21.6.11",
@@ -32285,8 +32250,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/nx-stylelint/node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
@@ -32294,7 +32258,6 @@
       "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -32305,7 +32268,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -32326,7 +32288,6 @@
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "restore-cursor": "^3.1.0"
       },
@@ -32340,7 +32301,6 @@
       "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -32350,8 +32310,7 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/nx-stylelint/node_modules/is-docker": {
       "version": "2.2.1",
@@ -32359,7 +32318,6 @@
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -32376,7 +32334,6 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -32387,7 +32344,6 @@
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -32398,7 +32354,6 @@
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -32412,7 +32367,6 @@
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -32425,8 +32379,7 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/nx-stylelint/node_modules/log-symbols": {
       "version": "4.1.0",
@@ -32434,7 +32387,6 @@
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -32542,7 +32494,6 @@
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -32559,7 +32510,6 @@
       "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -32578,7 +32528,6 @@
       "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bl": "^4.0.3",
         "chalk": "^4.1.0",
@@ -32602,7 +32551,6 @@
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -32616,8 +32564,7 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/nx-stylelint/node_modules/string-width": {
       "version": "4.2.3",
@@ -32625,7 +32572,6 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -32641,7 +32587,6 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -32655,7 +32600,6 @@
       "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -32666,7 +32610,6 @@
       "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "json5": "^2.2.2",
         "minimist": "^1.2.6",
@@ -32682,7 +32625,6 @@
       "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -34255,6 +34197,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -35097,6 +35040,7 @@
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -35555,6 +35499,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -35702,6 +35647,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -35996,6 +35942,7 @@
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -36006,6 +35953,7 @@
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -36655,6 +36603,7 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -36827,6 +36776,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -38273,8 +38223,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
       "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ssri": {
       "version": "13.0.1",
@@ -38362,6 +38311,7 @@
       "integrity": "sha512-heMfJjOfbHvL+wlCAwFZlSxcakyJ5yQDam6e9k2RRArB1veJhRnsjO6lO1hOXjJYrqxfHA/ldIugbBVlCDqfvQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -38804,6 +38754,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -38932,6 +38883,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "stylelint-config-recommended": "^14.0.1"
       },
@@ -38948,6 +38900,7 @@
       "integrity": "sha512-Eo5w7/XvwGHWkeGLtdm2FZLOMYoZl1omP2/jgFCXyl2x5yNz7/8vv4Tj6slHvMSSUNTaGoam/GAZ0ZhukvalfA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "stylelint-config-recommended-scss": "^14.0.0",
         "stylelint-config-standard": "^36.0.0"
@@ -39741,7 +39694,6 @@
       "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tldts-core": "^7.4.8"
       },
@@ -39754,8 +39706,7 @@
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
       "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.2.7",
@@ -39812,7 +39763,6 @@
       "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "tldts": "^7.0.5"
       },
@@ -40110,6 +40060,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -40229,7 +40180,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -40237,6 +40189,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -40428,6 +40381,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -40744,6 +40698,7 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -40851,6 +40806,7 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -41028,6 +40984,7 @@
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -41137,6 +41094,7 @@
       "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -41629,6 +41587,7 @@
       "integrity": "sha512-khZGfAeJx6I8K9zKohEWWYN6KDlVw2DHownoe+6Vtwj1LP9WFgegXnVMSkZ/dBEBtXFwrkkydsaPFlB7f8wU2A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-html-community": "0.0.8",
         "html-entities": "^2.1.0",
@@ -42267,6 +42226,7 @@
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -42534,6 +42494,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24838,6 +24838,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
       "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4608 

## What is the new behavior?
We now use CSS custom props instead of scss accessors. 
I registered the plugin from #4604 in `.stylelintrc` and enabled the `kirby/use-design-tokens` rule for enforcement going forward. 

Then ran the autofixer to automatically migrate as much as possible.

Any remaining scss calculations with variables were manually (well, and agentically) converted to calcs afterwards

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [x] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

