### PR TITLE
Modal: Fix keyboard overlap calculation to properly set footer directly after the keyboard

### DIFF
--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.integration.spec.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.integration.spec.ts
@@ -115,6 +115,7 @@ describe('ModalWrapperComponent + ModalFooterComponent', () => {
     beforeEach(() => {
       spectator = modalWrapperTestBuilder.flavor('modal').withDynamicFooter().build();
       spectator.detectComponentChanges();
+      spectator.component['initialViewportHeight'] = window.innerHeight;
     });
 
     afterEach(() => {

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.integration.spec.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.integration.spec.ts
@@ -48,6 +48,7 @@ describe('ModalWrapperComponent + ModalFooterComponent', () => {
     beforeEach(() => {
       spectator = modalWrapperTestBuilder.withStaticFooter().build();
       spectator.detectChanges();
+      spectator.component['initialViewportHeight'] = window.innerHeight;
     });
 
     afterEach(() => {

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
@@ -540,6 +540,40 @@ describe('ModalWrapperComponent', () => {
     });
   });
 
+  describe(`getKeyboardOverlap`, () => {
+    const elementWithBottom = (bottom: number): Element =>
+      ({ getBoundingClientRect: () => ({ bottom }) as DOMRect }) as Element;
+
+    beforeEach(() => {
+      spectator = modalWrapperTestBuilder.build();
+      spectator.component['initialViewportHeight'] = 800;
+    });
+
+    afterEach(() => {
+      spectator.fixture.destroy();
+    });
+
+    it('should return 0 when the keyboard height is not positive', () => {
+      expect(spectator.component['getKeyboardOverlap'](0, elementWithBottom(800))).toBe(0);
+    });
+
+    it('should return the full keyboard height when the element sits at the bottom of the pre-keyboard viewport', () => {
+      // Overlay keyboard (no resize): element still at the true bottom, fully covered.
+      expect(spectator.component['getKeyboardOverlap'](300, elementWithBottom(800))).toBe(300);
+    });
+
+    it('should return the residual overlap when the element is only partially covered', () => {
+      // Element lifted 100px (bottom at 700 of 800) => 300 - 100 = 200 still covered.
+      expect(spectator.component['getKeyboardOverlap'](300, elementWithBottom(700))).toBe(200);
+    });
+
+    it('should return 0 when the element is already lifted above the keyboard by the viewport resize', () => {
+      // Android/Capacitor: webview shrank so the element bottom (500) is already a full
+      // keyboard height above the pre-keyboard bottom (800) => no additional overlap.
+      expect(spectator.component['getKeyboardOverlap'](300, elementWithBottom(500))).toBe(0);
+    });
+  });
+
   describe(`onHeaderTouchStart`, () => {
     let ionContent: HTMLIonContentElement;
     let input: HTMLInputElement;

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.spec.ts
@@ -541,36 +541,53 @@ describe('ModalWrapperComponent', () => {
   });
 
   describe(`getKeyboardOverlap`, () => {
-    const elementWithBottom = (bottom: number): Element =>
+    const elementWithDistanceFromTopOfViewport = (bottom: number): Element =>
       ({ getBoundingClientRect: () => ({ bottom }) as DOMRect }) as Element;
-
+    const viewportHeight = 800;
+    const keyboardHeight = 300;
     beforeEach(() => {
       spectator = modalWrapperTestBuilder.build();
-      spectator.component['initialViewportHeight'] = 800;
+      spectator.component['initialViewportHeight'] = viewportHeight;
     });
 
     afterEach(() => {
       spectator.fixture.destroy();
     });
 
-    it('should return 0 when the keyboard height is not positive', () => {
-      expect(spectator.component['getKeyboardOverlap'](0, elementWithBottom(800))).toBe(0);
+    it('should return 0 when the keyboard height is negative', () => {
+      expect(
+        spectator.component['getKeyboardOverlap'](
+          -1,
+          elementWithDistanceFromTopOfViewport(viewportHeight)
+        )
+      ).toBe(0);
     });
 
-    it('should return the full keyboard height when the element sits at the bottom of the pre-keyboard viewport', () => {
-      // Overlay keyboard (no resize): element still at the true bottom, fully covered.
-      expect(spectator.component['getKeyboardOverlap'](300, elementWithBottom(800))).toBe(300);
+    it('should return the height of the keyboard when the element sits at the bottom of the viewport', () => {
+      expect(
+        spectator.component['getKeyboardOverlap'](
+          keyboardHeight,
+          elementWithDistanceFromTopOfViewport(viewportHeight)
+        )
+      ).toBe(keyboardHeight);
     });
 
     it('should return the residual overlap when the element is only partially covered', () => {
-      // Element lifted 100px (bottom at 700 of 800) => 300 - 100 = 200 still covered.
-      expect(spectator.component['getKeyboardOverlap'](300, elementWithBottom(700))).toBe(200);
+      expect(
+        spectator.component['getKeyboardOverlap'](
+          keyboardHeight,
+          elementWithDistanceFromTopOfViewport(700)
+        )
+      ).toBe(200);
     });
 
     it('should return 0 when the element is already lifted above the keyboard by the viewport resize', () => {
-      // Android/Capacitor: webview shrank so the element bottom (500) is already a full
-      // keyboard height above the pre-keyboard bottom (800) => no additional overlap.
-      expect(spectator.component['getKeyboardOverlap'](300, elementWithBottom(500))).toBe(0);
+      expect(
+        spectator.component['getKeyboardOverlap'](
+          keyboardHeight,
+          elementWithDistanceFromTopOfViewport(viewportHeight - keyboardHeight - 100)
+        )
+      ).toBe(0);
     });
   });
 

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
@@ -131,7 +131,7 @@ export class ModalWrapperComponent
   private toolbarButtons: HTMLButtonElement[] = [];
   private delayedClose = () => {};
   private delayedCloseTimeoutId;
-  private initialViewportHeight: number;
+  private initialViewportHeight: number = 0;
   private viewportResized = false;
   private ionModalElement?: HTMLIonModalElement;
   private ionModalDialog?: HTMLElement;

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
@@ -534,10 +534,12 @@ export class ModalWrapperComponent
 
   private getKeyboardOverlap(keyboardHeight: number, element: Element) {
     if (keyboardHeight <= 0 || !element) return 0;
-    const distanceFromViewportBottomToElement = Math.floor(
-      this.windowRef.nativeWindow.innerHeight - element.getBoundingClientRect().bottom
+    const preKeyboardViewportHeight =
+      this.initialViewportHeight || this.windowRef.nativeWindow.innerHeight;
+    const elementDistanceAboveBottomOfScreen = Math.floor(
+      preKeyboardViewportHeight - element.getBoundingClientRect().bottom
     );
-    return Math.max(keyboardHeight - distanceFromViewportBottomToElement, 0);
+    return Math.max(keyboardHeight - elementDistanceAboveBottomOfScreen, 0);
   }
 
   private setCssVar(element: Element, property: string, value: string) {

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
@@ -131,7 +131,7 @@ export class ModalWrapperComponent
   private toolbarButtons: HTMLButtonElement[] = [];
   private delayedClose = () => {};
   private delayedCloseTimeoutId;
-  private initialViewportHeight: number = 0;
+  private initialViewportHeight: number;
   private viewportResized = false;
   private ionModalElement?: HTMLIonModalElement;
   private ionModalDialog?: HTMLElement;

--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.ts
@@ -533,11 +533,9 @@ export class ModalWrapperComponent
   }
 
   private getKeyboardOverlap(keyboardHeight: number, element: Element) {
-    if (keyboardHeight <= 0 || !element) return 0;
-    const preKeyboardViewportHeight =
-      this.initialViewportHeight || this.windowRef.nativeWindow.innerHeight;
+    if (keyboardHeight <= 0 || !element || !this.initialViewportHeight) return 0;
     const elementDistanceAboveBottomOfScreen = Math.floor(
-      preKeyboardViewportHeight - element.getBoundingClientRect().bottom
+      this.initialViewportHeight - element.getBoundingClientRect().bottom
     );
     return Math.max(keyboardHeight - elementDistanceAboveBottomOfScreen, 0);
   }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4611

## What is the new behavior?
Changed the keyboard-overlap calculation to measure against the pre-keyboard viewport height instead of the live innerHeight.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?
This fixes a problem where a modal footer would be pushed, the height of a keyboard, up above the content, if used in an app within a webview that is set to "resize" mode, which automatically resizes the viewport when the keyboard is shown. 

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

