### PR TITLE
Modal: Use ion-safe-area-bottom var directly in modal-wrapper stylesheet

### DIFF
--- a/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.scss
+++ b/libs/designsystem/modal/src/modal-wrapper/modal-wrapper.component.scss
@@ -76,6 +76,9 @@ ion-header {
   --header-height: 0px;
   --footer-height: 0px;
 
+  // Ionic changes the ion-safe-area-bottom var within ion-modal, so we can't use the global kirby-safe-area-bottom var here, since that won't see the changed value.
+  --kirby-modal-safe-area-bottom: var(--ion-safe-area-bottom);
+
   &.drawer ion-header ion-toolbar {
     @include utils.media('<medium') {
       --padding-top: #{utils.size('s')};
@@ -142,7 +145,7 @@ ion-content {
   --background: transparent;
   --color: var(--kirby-modal-color, #{utils.get-color('black')});
   --padding-top: #{utils.size('m')};
-  --padding-bottom: calc(var(--kirby-spacing-m) + var(--kirby-safe-area-bottom, 0px));
+  --padding-bottom: calc(var(--kirby-spacing-m) + var(--kirby-modal-safe-area-bottom));
   --padding-start: #{utils.size('s')};
   --padding-end: #{utils.size('s')};
 

--- a/libs/designsystem/modal/src/modal/footer/modal-footer.component.scss
+++ b/libs/designsystem/modal/src/modal/footer/modal-footer.component.scss
@@ -12,7 +12,7 @@ ion-footer {
   background-color: var(--kirby-modal-footer-background, utils.get-color('white'));
   color: var(--kirby-modal-footer-color, utils.get-color('white-contrast'));
   padding: utils.size('s');
-  padding-bottom: calc(#{utils.size('xs')} + var(--kirby-safe-area-bottom));
+  padding-bottom: calc(#{utils.size('xs')} + var(--kirby-modal-safe-area-bottom));
 
   @include utils.media('>=medium') {
     padding: utils.size('m');
@@ -52,7 +52,7 @@ ion-footer {
 
       /* clean-css ignore:start */
       transform: translateY(
-        calc((var(--keyboard-offset, 0px) - var(--kirby-safe-area-bottom)) * -1)
+        calc((var(--keyboard-offset, 0px) - var(--kirby-modal-safe-area-bottom)) * -1)
       );
 
       /* clean-css ignore:end */

--- a/libs/designsystem/modal/src/modal/footer/modal-footer.component.spec.ts
+++ b/libs/designsystem/modal/src/modal/footer/modal-footer.component.spec.ts
@@ -74,7 +74,8 @@ describe('ModalFooterComponent', () => {
       spectator = createHost(`<kirby-modal-footer></kirby-modal-footer>`);
       modalFooterElement = spectator.element;
       ionFooterElement = spectator.query('ion-footer');
-      // Provided by kirby-modal-wrapper in the app; seed it so the footer's calc() is valid in this isolated test.
+      // Provided by kirby-modal-wrapper in the app;
+      // seed it so the footer's calc() is valid in this isolated test.
       modalFooterElement.style.setProperty(
         '--kirby-modal-safe-area-bottom',
         'var(--ion-safe-area-bottom)'
@@ -127,7 +128,8 @@ describe('ModalFooterComponent', () => {
       );
       modalFooterElement = spectator.element;
       ionFooterElement = spectator.query('ion-footer');
-      // Provided by kirby-modal-wrapper in the app; seed it so the footer's calc() is valid in this isolated test.
+      // Provided by kirby-modal-wrapper in the app;
+      // seed it so the footer's calc() is valid in this isolated test.
       modalFooterElement.style.setProperty(
         '--kirby-modal-safe-area-bottom',
         'var(--ion-safe-area-bottom)'

--- a/libs/designsystem/modal/src/modal/footer/modal-footer.component.spec.ts
+++ b/libs/designsystem/modal/src/modal/footer/modal-footer.component.spec.ts
@@ -74,6 +74,8 @@ describe('ModalFooterComponent', () => {
       spectator = createHost(`<kirby-modal-footer></kirby-modal-footer>`);
       modalFooterElement = spectator.element;
       ionFooterElement = spectator.query('ion-footer');
+      // Provided by kirby-modal-wrapper in the app; seed it so the footer's calc() is valid in isolation.
+      modalFooterElement.style.setProperty('--kirby-modal-safe-area-bottom', '0px');
     });
 
     describe('on desktop', () => {
@@ -107,13 +109,13 @@ describe('ModalFooterComponent', () => {
         TestHelper.resetTestWindow();
       });
 
-      it('when --kirby-safe-area-bottom is not set', () => {
+      it('when --kirby-modal-safe-area-bottom is not set', () => {
         expect(ionFooterElement).toHaveComputedStyle({
           'padding-bottom': BASE_PADDING_SMALL_SCREEN_PX,
         });
       });
 
-      it('when --kirby-safe-area-bottom is set', () => {
+      it('when --kirby-modal-safe-area-bottom is set', () => {
         setSafeAreaBottom();
         const expected = BASE_PADDING_SMALL_SCREEN + SAFE_AREA_BOTTOM + 'px';
         expect(ionFooterElement).toHaveComputedStyle({ 'padding-bottom': expected });
@@ -128,6 +130,7 @@ describe('ModalFooterComponent', () => {
       );
       modalFooterElement = spectator.element;
       ionFooterElement = spectator.query('ion-footer');
+      modalFooterElement.style.setProperty('--kirby-modal-safe-area-bottom', '0px');
     });
 
     describe('when snapToKeyboard is true', () => {
@@ -227,7 +230,7 @@ describe('ModalFooterComponent', () => {
 
   // utility functions
   function setSafeAreaBottom() {
-    modalFooterElement.style.setProperty('--kirby-safe-area-bottom', SAFE_AREA_BOTTOM_PX);
+    modalFooterElement.style.setProperty('--kirby-modal-safe-area-bottom', SAFE_AREA_BOTTOM_PX);
   }
 
   function keyboardSlideIn() {

--- a/libs/designsystem/modal/src/modal/footer/modal-footer.component.spec.ts
+++ b/libs/designsystem/modal/src/modal/footer/modal-footer.component.spec.ts
@@ -74,8 +74,11 @@ describe('ModalFooterComponent', () => {
       spectator = createHost(`<kirby-modal-footer></kirby-modal-footer>`);
       modalFooterElement = spectator.element;
       ionFooterElement = spectator.query('ion-footer');
-      // Provided by kirby-modal-wrapper in the app; seed it so the footer's calc() is valid in isolation.
-      modalFooterElement.style.setProperty('--kirby-modal-safe-area-bottom', '0px');
+      // Provided by kirby-modal-wrapper in the app; seed it so the footer's calc() is valid in this isolated test.
+      modalFooterElement.style.setProperty(
+        '--kirby-modal-safe-area-bottom',
+        'var(--ion-safe-area-bottom)'
+      );
     });
 
     describe('on desktop', () => {
@@ -109,12 +112,6 @@ describe('ModalFooterComponent', () => {
         TestHelper.resetTestWindow();
       });
 
-      it('when --kirby-modal-safe-area-bottom is not set', () => {
-        expect(ionFooterElement).toHaveComputedStyle({
-          'padding-bottom': BASE_PADDING_SMALL_SCREEN_PX,
-        });
-      });
-
       it('when --kirby-modal-safe-area-bottom is set', () => {
         setSafeAreaBottom();
         const expected = BASE_PADDING_SMALL_SCREEN + SAFE_AREA_BOTTOM + 'px';
@@ -130,7 +127,11 @@ describe('ModalFooterComponent', () => {
       );
       modalFooterElement = spectator.element;
       ionFooterElement = spectator.query('ion-footer');
-      modalFooterElement.style.setProperty('--kirby-modal-safe-area-bottom', '0px');
+      // Provided by kirby-modal-wrapper in the app; seed it so the footer's calc() is valid in this isolated test.
+      modalFooterElement.style.setProperty(
+        '--kirby-modal-safe-area-bottom',
+        'var(--ion-safe-area-bottom)'
+      );
     });
 
     describe('when snapToKeyboard is true', () => {


### PR DESCRIPTION
## Which issue does this PR close?

This PR is a second regression of #4579 

## What is the new behavior?
The PR #4609 accidentally introduced an extra bottom padding in the footer of modals on a tablet (or larger) screen. By using Ionics `ion-safe-area-bottom` directly in the modal (and not using the global `kirby-safe-area-bottom` which points at the same var but at root level) we get value changes when Ionic changes the value of the var, which Ionic does in certain modal scenarios. 
 
## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?
Before fix:
<img width="1234" height="1722" alt="image" src="https://github.com/user-attachments/assets/276e414c-d7cc-4155-b5b2-2fa1fcdfd5d8" />
After fix:
<img width="614" height="868" alt="image" src="https://github.com/user-attachments/assets/f328f6c9-d3c1-4598-a056-3cf3eda020c2" />


## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [ ] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [ ] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [ ] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

