### PR TITLE
Sidebar: make sidebar host non-scrollable and force header and footer to never shrink

### DIFF
--- a/libs/extensions/angular/sidebar-menu/src/components/sidebar-container/sidebar-container.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/components/sidebar-container/sidebar-container.component.scss
@@ -11,7 +11,7 @@
   color: var(--sidebar-color, utils.get-color('tertiary-contrast'));
   display: flex;
   flex-direction: column;
-  overflow: auto;
+  overflow: hidden; // Only the .sidebar-content should be scrollable.
 
   * {
     scrollbar-width: thin;
@@ -38,6 +38,7 @@
 
 .sidebar-content {
   flex-grow: 1;
+  min-height: 0; // Allow the content to shrink and scroll internally instead of pushing the footer out of view (iOS Safari)
   display: flex;
   flex-direction: column;
   overflow-y: auto;
@@ -51,10 +52,11 @@
 .sidebar-header,
 .sidebar-footer {
   z-index: 1;
+  flex-shrink: 0; // Keep header/footer at full size so they are never squeezed out by overflowing content
   display: flex;
   align-items: center;
   justify-content: center;
-  position: sticky;
+  position: relative; // Pinned by flex layout; relative keeps z-index active so the border shadow draws over content
 }
 
 .sidebar-header.bottom-border {

--- a/libs/extensions/angular/sidebar-menu/src/components/sidebar-container/sidebar-container.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/components/sidebar-container/sidebar-container.component.scss
@@ -52,7 +52,7 @@
 .sidebar-header,
 .sidebar-footer {
   z-index: 1;
-  flex-shrink: 0; // never shrink header/footer
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/libs/extensions/angular/sidebar-menu/src/components/sidebar-container/sidebar-container.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/components/sidebar-container/sidebar-container.component.scss
@@ -38,7 +38,7 @@
 
 .sidebar-content {
   flex-grow: 1;
-  min-height: 0; // Allow the content to shrink and scroll internally instead of pushing the footer out of view (iOS Safari)
+  min-height: 0; // Allow the content container to shrink and scroll internally.
   display: flex;
   flex-direction: column;
   overflow-y: auto;
@@ -52,11 +52,11 @@
 .sidebar-header,
 .sidebar-footer {
   z-index: 1;
-  flex-shrink: 0; // Keep header/footer at full size so they are never squeezed out by overflowing content
+  flex-shrink: 0; // never shrink header/footer
   display: flex;
   align-items: center;
   justify-content: center;
-  position: relative; // Pinned by flex layout; relative keeps z-index active so the border shadow draws over content
+  position: relative;
 }
 
 .sidebar-header.bottom-border {

--- a/libs/extensions/angular/sidebar-menu/src/components/sidebar-container/sidebar-container.component.scss
+++ b/libs/extensions/angular/sidebar-menu/src/components/sidebar-container/sidebar-container.component.scss
@@ -11,7 +11,6 @@
   color: var(--sidebar-color, utils.get-color('tertiary-contrast'));
   display: flex;
   flex-direction: column;
-  overflow: hidden; // Only the .sidebar-content should be scrollable.
 
   * {
     scrollbar-width: thin;
@@ -38,7 +37,7 @@
 
 .sidebar-content {
   flex-grow: 1;
-  min-height: 0; // Allow the content container to shrink and scroll internally.
+  min-height: 0; // Webkit fix: allow the content container to shrink and scroll internally.
   display: flex;
   flex-direction: column;
   overflow-y: auto;


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4629 

## What is the new behavior?
Three style-tweaks to the sidebar component: 
1. The sidebar :host had `overflow: auto` which probably made sense when the sidebar-content used to live within the sidebar itself and should allow scrolling. With the recent split into a container and menu component in #4508 the host (=container) no longer should be scrollable, thus removed.
2. The sidebar content now has `min-height: 0;` which is a webkit (safari) fix since chrome, firefox and edge already  does this for a scrollable container in a flex context.
3. header and footer gets `flex-shrink: 0;` which in a flex context makes sure those parts of the sidebar now have a static size. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

