### PR TITLE
SkeletonLoader: set border-radius on ion-skeleton-text to be 'inherit'

### DIFF
--- a/libs/extensions/angular/skeleton-loader/src/skeleton-loader.component.scss
+++ b/libs/extensions/angular/skeleton-loader/src/skeleton-loader.component.scss
@@ -59,4 +59,5 @@ ion-skeleton-text {
   margin: 0;
   animation-duration: 1.5s;
   background-clip: border-box;
+  border-radius: inherit;
 }


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4635 

## What is the new behavior?
Ionic sets border-radius on `ion-skeleton-text` component to be `var(--border-radius, inherit)` [here](https://github.com/ionic-team/ionic-framework/blob/625f9c38ad8c5db8a6c12df5c1622a36da90f9e3/core/src/components/skeleton-text/skeleton-text.scss#L15).  An accidental addition of `--border-radius`-var somewhere in a project, might override the border radius set by the shape parameter on the `kirby-x-skeleton-loader`.
The solution is to directly set `border-radius: inherit` on the `ion-skeleton-text` element in the stylesheet of `kirby-x-skeleton-loader`to force the border-radius on `the ion-skeleton-loader` to match the defined one on the `kirby-x-skeleton-loader`
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

