### PR TITLE
Checkbox: focus ring added on focus-visible instead of focus-within

### DIFF
--- a/libs/designsystem/checkbox/src/checkbox.component.scss
+++ b/libs/designsystem/checkbox/src/checkbox.component.scss
@@ -136,7 +136,6 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
     }
 
     &:focus-visible::part(container) {
-      outline: none;
       padding: calc(
         var(--kirby-checkbox-container-padding) + 1px
       ); // Compensate for removed 1px border to prevent checkmark from growing in ion-checkbox

--- a/libs/designsystem/checkbox/src/checkbox.component.scss
+++ b/libs/designsystem/checkbox/src/checkbox.component.scss
@@ -127,7 +127,9 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
   }
 
   ion-checkbox {
-    &:focus-within {
+    &:focus-visible {
+      outline: none;
+
       --border-width: 0;
       --border-color: transparent;
       --border-color-checked: transparent;
@@ -148,11 +150,6 @@ $spacing-to-label: map.get(utils.$checkbox-radio-spacing, 'to-label');
     }
     @include interaction-state.apply-active {
       --checkbox-background: #{interaction-state.get-state-color('white', 'xs')};
-    }
-
-    &:focus-visible {
-      // Remove default browser focus visible
-      outline: none;
     }
 
     // Wrap declarations to avoid mixing with nested rules.


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4597 

## What is the new behavior?
ion-checkbox receives focus directly on the host element, so the focus ring has to be added on `focus-visible` instead of `:focus-within`. `:focus-within` matches on any focus — including mouse clicks — whereas `:focus-visible` only matches keyboard (non-pointer) focus, which is when we actually want the ring. Both the border removal and the replacement focus ring are now targeting `:focus-visible`, so they always apply together. (before the removal of the border would happen on mouse click, which is why the border would dissappear)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any additional context?
Caused by #4467 

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [ ] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [ ] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

