### PR TITLE
Header: fix non-responsive font size for title max lines

### DIFF
--- a/libs/designsystem/header/src/header.component.spec.ts
+++ b/libs/designsystem/header/src/header.component.spec.ts
@@ -236,6 +236,40 @@ describe('HeaderComponent', () => {
     });
   });
 
+  describe('with browser text resize', () => {
+    const originalRootFontSize = document.documentElement.style.fontSize;
+
+    afterEach(() => {
+      document.documentElement.style.fontSize = originalRootFontSize;
+    });
+
+    it('should not scale a long title below body text size', async () => {
+      document.documentElement.style.fontSize = '32px';
+      spectator = createHost(`
+        <div style="width: 200px">
+          <kirby-header
+            title="A long article title that cannot fit within two lines at its original size"
+            [titleMaxLines]="2"
+          >
+            <p class="body-text" *kirbyHeaderCustomSection>Body text</p>
+          </kirby-header>
+        </div>
+      `);
+
+      await TestHelper.waitForResizeObserver();
+      await TestHelper.waitForTimeout();
+
+      const titleFontSize = parseFloat(
+        getComputedStyle(spectator.query<HTMLElement>('.title')).fontSize
+      );
+      const bodyFontSize = parseFloat(
+        getComputedStyle(spectator.query<HTMLElement>('.body-text')).fontSize
+      );
+
+      expect(titleFontSize).toBeGreaterThanOrEqual(bodyFontSize);
+    });
+  });
+
   describe('with avatar', () => {
     beforeEach(() => {
       spectator = createHost(`

--- a/libs/designsystem/shared/src/fit-heading/fit-heading.directive.ts
+++ b/libs/designsystem/shared/src/fit-heading/fit-heading.directive.ts
@@ -1,11 +1,7 @@
 import { Directive, ElementRef, Input, OnDestroy, OnInit, Renderer2 } from '@angular/core';
 
-import { DesignTokenHelper } from '@kirbydesign/designsystem/helpers';
 import { LineClampHelper } from '@kirbydesign/designsystem/helpers';
 import { ResizeObserverService } from '../resize-observer/resize-observer.service';
-
-const fontSize = DesignTokenHelper.fontSize;
-const lineHeight = DesignTokenHelper.lineHeight;
 
 interface HeadingSize {
   name: string;
@@ -34,18 +30,18 @@ export class FitHeadingDirective implements OnInit, OnDestroy {
   private headingSizes: HeadingSize[] = [
     {
       name: 'h1',
-      fontSize: fontSize('xl'),
-      lineHeight: lineHeight('xl'),
+      fontSize: 'var(--kirby-font-size-xl)',
+      lineHeight: 'var(--kirby-line-height-xl)',
     },
     {
       name: 'h2',
-      fontSize: fontSize('l'),
-      lineHeight: lineHeight('l'),
+      fontSize: 'var(--kirby-font-size-l)',
+      lineHeight: 'var(--kirby-line-height-l)',
     },
     {
       name: 'h3',
-      fontSize: fontSize('m'),
-      lineHeight: lineHeight('m'),
+      fontSize: 'var(--kirby-font-size-m)',
+      lineHeight: 'var(--kirby-line-height-m)',
     },
   ];
 


### PR DESCRIPTION
## Which issue does this PR close?

This PR closes #4670

## What is the new behavior?
We use custom css properties for the fit-heading directive as well, so it follows the same typography steps as the rest of the text elements.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, replace this paragraph with a description of the impact and migration path for existing applications  -->

## Are there any additional context?

<!-- Replace this paragraph with any additional context e.g, explanations, links or screenshots (if any) -->

## Checklist:

The following tasks should be carried out in sequence in order to follow [the process of contributing](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#the-process-of-contributing) correctly.

### Reminders
- [x] Make sure you have implemented tests following the guidelines in: "[The good: Test](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Test)".
- [x] Make sure you have updated the cookbook with examples and showcases (for bug fixes, enhancements & new components).

### Review  
- [x] Determine if your changes are a fix, feature or breaking-change, and add the matching label to your PR. If it is tooling, dependency updates or similar, add ignore-for-release.
- [x] Do a [self-review](https://github.com/kirbydesign/designsystem/wiki/The-Good%3A-Self-review).
- [x] Request that the changes are code-reviewed 
- [ ] Request that the changes are [UX reviewed](https://github.com/kirbydesign/designsystem/blob/develop/.github/CONTRIBUTING.md#ux-review) (only necessary if your PR introduces visual changes)

When the pull request has been approved it will be merged to `develop` by Team Kirby.

