### PR TITLE
Tooling: add registry info to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+registry=https://registry.npmjs.org/
 engine-strict = true


### PR DESCRIPTION
This PR adds registry information to shared .npmrc for better local development experience, so other local registry configurations do not leak into this repo.  